### PR TITLE
feat: redesign settings pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ docs/memory/
 .svn/
 .swiftpm/
 migrate_working_dir/
+.devtools/
+tool/install_devtools.ps1
 
 # IntelliJ related
 *.iml

--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -207,6 +207,7 @@ class _AppShellState extends State<AppShell> {
   Widget build(BuildContext context) {
     final controller = _planController;
     AppColors.palette = _settings.themePalette;
+    AppColors.customAccentValue = _settings.customThemeColorValue;
 
     if (controller == null) {
       return _PlanLoadState(error: _loadError, onRetry: _loadActivePlan);
@@ -218,89 +219,99 @@ class _AppShellState extends State<AppShell> {
         return MediaQuery(
           data: MediaQuery.of(
             context,
-          ).copyWith(textScaler: TextScaler.linear(_settings.uiScale)),
-          child: Theme(
-            data: AppTheme.light(palette: _settings.themePalette),
-            child: Scaffold(
-              body: IndexedStack(
-                index: _selectedIndex,
-                children: [
-                  PlanScreen(
-                    controller: controller,
-                    settings: _settings,
-                    repository: widget.repository,
-                    onOpenMap: _openMap,
-                    onOpenPlanManager: _openPlanManager,
-                    onOpenAddPoints: _openAddPoints,
-                    onOpenPointManager: _openPointManager,
-                    onOpenImportExport: _openImportExport,
-                  ),
-                  PilgrimageMapScreen(
-                    controller: controller,
-                    settings: _settings,
-                  ),
-                  RecordsScreen(controller: controller),
-                  SettingsScreen(settings: _settings, onChanged: _saveSettings),
-                ],
+          ).copyWith(textScaler: appTextScaler(_settings.fontScale)),
+          child: AppUiScaleView(
+            scale: _settings.uiScale,
+            child: Theme(
+              data: AppTheme.light(
+                palette: _settings.themePalette,
+                customAccentValue: _settings.customThemeColorValue,
               ),
-              bottomNavigationBar: NavigationBarTheme(
-                data: NavigationBarThemeData(
-                  indicatorColor: AppColors.accent,
-                  iconTheme: WidgetStateProperty.resolveWith((states) {
-                    if (states.contains(WidgetState.selected)) {
-                      return IconThemeData(color: AppColors.onAccent);
-                    }
+              child: Scaffold(
+                body: IndexedStack(
+                  index: _selectedIndex,
+                  children: [
+                    PlanScreen(
+                      controller: controller,
+                      settings: _settings,
+                      repository: widget.repository,
+                      onOpenMap: _openMap,
+                      onOpenPlanManager: _openPlanManager,
+                      onOpenAddPoints: _openAddPoints,
+                      onOpenPointManager: _openPointManager,
+                      onOpenImportExport: _openImportExport,
+                    ),
+                    PilgrimageMapScreen(
+                      controller: controller,
+                      settings: _settings,
+                    ),
+                    RecordsScreen(controller: controller),
+                    SettingsScreen(
+                      settings: _settings,
+                      repository: widget.repository,
+                      onChanged: _saveSettings,
+                    ),
+                  ],
+                ),
+                bottomNavigationBar: NavigationBarTheme(
+                  data: NavigationBarThemeData(
+                    indicatorColor: AppColors.accent,
+                    iconTheme: WidgetStateProperty.resolveWith((states) {
+                      if (states.contains(WidgetState.selected)) {
+                        return IconThemeData(color: AppColors.onAccent);
+                      }
 
-                    return const IconThemeData(color: AppColors.textPrimary);
-                  }),
-                  labelTextStyle: WidgetStateProperty.resolveWith((states) {
-                    if (states.contains(WidgetState.selected)) {
+                      return const IconThemeData(color: AppColors.textPrimary);
+                    }),
+                    labelTextStyle: WidgetStateProperty.resolveWith((states) {
+                      if (states.contains(WidgetState.selected)) {
+                        return const TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        );
+                      }
+
                       return const TextStyle(
                         color: AppColors.textPrimary,
                         fontSize: 12,
-                        fontWeight: FontWeight.w800,
+                        fontWeight: FontWeight.w500,
                         letterSpacing: 0,
                       );
-                    }
-
-                    return const TextStyle(
-                      color: AppColors.textPrimary,
-                      fontSize: 12,
-                      fontWeight: FontWeight.w500,
-                      letterSpacing: 0,
-                    );
-                  }),
-                ),
-                child: NavigationBar(
-                  selectedIndex: _selectedIndex,
-                  backgroundColor: AppColors.surface,
-                  onDestinationSelected: (index) {
-                    setState(() {
-                      _selectedIndex = index;
-                    });
-                  },
-                  destinations: const [
-                    NavigationDestination(
-                      icon: Icon(Icons.checklist_outlined),
-                      selectedIcon: Icon(Icons.checklist),
-                      label: '计划',
-                    ),
-                    NavigationDestination(
-                      icon: Icon(Icons.map_outlined),
-                      selectedIcon: Icon(Icons.map),
-                      label: '地图',
-                    ),
-                    NavigationDestination(
-                      icon: Icon(Icons.collections_bookmark_outlined),
-                      selectedIcon: Icon(Icons.collections_bookmark),
-                      label: '记录',
-                    ),
-                    NavigationDestination(
-                      icon: Icon(Icons.settings_outlined),
-                      selectedIcon: Icon(Icons.settings),
-                      label: '设置',
-                    ),
-                  ],
+                    }),
+                  ),
+                  child: NavigationBar(
+                    selectedIndex: _selectedIndex,
+                    backgroundColor: AppColors.surface,
+                    onDestinationSelected: (index) {
+                      setState(() {
+                        _selectedIndex = index;
+                      });
+                    },
+                    destinations: const [
+                      NavigationDestination(
+                        icon: Icon(Icons.checklist_outlined),
+                        selectedIcon: Icon(Icons.checklist),
+                        label: '计划',
+                      ),
+                      NavigationDestination(
+                        icon: Icon(Icons.map_outlined),
+                        selectedIcon: Icon(Icons.map),
+                        label: '地图',
+                      ),
+                      NavigationDestination(
+                        icon: Icon(Icons.collections_bookmark_outlined),
+                        selectedIcon: Icon(Icons.collections_bookmark),
+                        label: '记录',
+                      ),
+                      NavigationDestination(
+                        icon: Icon(Icons.settings_outlined),
+                        selectedIcon: Icon(Icons.settings),
+                        label: '设置',
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -6,6 +6,7 @@ class AppColors {
   const AppColors._();
 
   static AppThemePalette palette = AppThemePalette.classicGreen;
+  static int customAccentValue = 0xFF16C6A8;
 
   static const background = Color(0xFFF7F8FA);
   static const surface = Color(0xFFFFFFFF);
@@ -17,6 +18,16 @@ class AppColors {
   static const miriaYellowDark = Color(0xFFB77C00);
   static const classicGreen = Color(0xFF0F8B8D);
   static const classicGreenDark = Color(0xFF0B6F72);
+  static const deepBlue = Color(0xFF1C2B78);
+  static const deepBlueDark = Color(0xFF111B52);
+  static const cherryPink = Color(0xFFF45B9A);
+  static const cherryPinkDark = Color(0xFFB72665);
+  static const twilightPurple = Color(0xFF8753C7);
+  static const twilightPurpleDark = Color(0xFF5D3495);
+  static const graphite = Color(0xFF0C0D10);
+  static const graphiteDark = Color(0xFF000000);
+  static const aurora = Color(0xFF16C6A8);
+  static const auroraDark = Color(0xFF0A7E83);
   static const warning = Color(0xFFC87900);
   static const error = Color(0xFFC2413A);
   static const cameraDarkSurface = Color(0xFF101418);
@@ -24,23 +35,47 @@ class AppColors {
 
   static Color get accent {
     return switch (palette) {
-      AppThemePalette.miriaYellow => miriaYellow,
       AppThemePalette.classicGreen => classicGreen,
+      AppThemePalette.deepBlue => deepBlue,
+      AppThemePalette.cherryPink => cherryPink,
+      AppThemePalette.twilightPurple => twilightPurple,
+      AppThemePalette.miriaYellow => miriaYellow,
+      AppThemePalette.graphite => graphite,
+      AppThemePalette.aurora => Color(customAccentValue),
     };
   }
 
   static Color get accentDark {
     return switch (palette) {
-      AppThemePalette.miriaYellow => miriaYellowDark,
       AppThemePalette.classicGreen => classicGreenDark,
+      AppThemePalette.deepBlue => deepBlueDark,
+      AppThemePalette.cherryPink => cherryPinkDark,
+      AppThemePalette.twilightPurple => twilightPurpleDark,
+      AppThemePalette.miriaYellow => miriaYellowDark,
+      AppThemePalette.graphite => graphiteDark,
+      AppThemePalette.aurora => _darken(Color(customAccentValue)),
     };
   }
 
   static Color get onAccent {
     return switch (palette) {
-      AppThemePalette.miriaYellow => textPrimary,
       AppThemePalette.classicGreen => Colors.white,
+      AppThemePalette.deepBlue => Colors.white,
+      AppThemePalette.cherryPink => Colors.white,
+      AppThemePalette.twilightPurple => Colors.white,
+      AppThemePalette.miriaYellow => textPrimary,
+      AppThemePalette.graphite => Colors.white,
+      AppThemePalette.aurora => _foregroundFor(Color(customAccentValue)),
     };
+  }
+
+  static Color _darken(Color color) {
+    final hsl = HSLColor.fromColor(color);
+    return hsl.withLightness((hsl.lightness * 0.72).clamp(0.0, 1.0)).toColor();
+  }
+
+  static Color _foregroundFor(Color color) {
+    return color.computeLuminance() > 0.55 ? textPrimary : Colors.white;
   }
 }
 
@@ -49,8 +84,10 @@ class AppTheme {
 
   static ThemeData light({
     AppThemePalette palette = AppThemePalette.classicGreen,
+    int customAccentValue = 0xFF16C6A8,
   }) {
     AppColors.palette = palette;
+    AppColors.customAccentValue = customAccentValue;
     final colorScheme = ColorScheme(
       brightness: Brightness.light,
       primary: AppColors.accent,
@@ -137,6 +174,53 @@ class AppTheme {
           letterSpacing: 0,
         ),
         behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+}
+
+TextScaler appTextScaler(double fontScale) {
+  final clampedScale = fontScale.clamp(0.7, 1.4);
+  final easedScale = 1 + (clampedScale - 1) * 0.58;
+  return TextScaler.linear(easedScale.clamp(0.7, 1.6));
+}
+
+double appUiScaler(double uiScale) {
+  final clampedScale = uiScale.clamp(0.8, 1.2);
+  return 1 + (clampedScale - 1) * 0.72;
+}
+
+class AppUiScaleView extends StatelessWidget {
+  const AppUiScaleView({required this.scale, required this.child, super.key});
+
+  final double scale;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveScale = appUiScaler(scale);
+    if ((effectiveScale - 1).abs() < 0.001) {
+      return child;
+    }
+
+    final size = MediaQuery.sizeOf(context);
+    final scaledWidth = size.width / effectiveScale;
+    final scaledHeight = size.height / effectiveScale;
+
+    return ClipRect(
+      child: OverflowBox(
+        alignment: Alignment.topCenter,
+        maxWidth: scaledWidth,
+        maxHeight: scaledHeight,
+        child: Transform.scale(
+          scale: effectiveScale,
+          alignment: Alignment.topCenter,
+          child: SizedBox(
+            width: scaledWidth,
+            height: scaledHeight,
+            child: child,
+          ),
+        ),
       ),
     );
   }

--- a/lib/camera_reference/camerawesome_reference_screen.dart
+++ b/lib/camera_reference/camerawesome_reference_screen.dart
@@ -410,7 +410,24 @@ double _aspectRatioValue(CameraPhotoAspectRatio ratio) {
     CameraPhotoAspectRatio.portrait3x4 => 3 / 4,
     CameraPhotoAspectRatio.portrait2x3 => 2 / 3,
     CameraPhotoAspectRatio.square1x1 => 1,
+    CameraPhotoAspectRatio.custom => 1,
   };
+}
+
+double _settingsAspectRatioValue(
+  CameraPhotoAspectRatio ratio,
+  AppSettings settings,
+) {
+  if (ratio != CameraPhotoAspectRatio.custom) {
+    return _aspectRatioValue(ratio);
+  }
+
+  final width = settings.customCameraAspectRatioWidth;
+  final height = settings.customCameraAspectRatioHeight;
+  if (width <= 0 || height <= 0) {
+    return 1;
+  }
+  return width / height;
 }
 
 @visibleForTesting
@@ -424,9 +441,10 @@ double resolveCameraCaptureAspectRatio({
       ? referenceAspectRatio ??
             _fallbackAspectRatioValue(
               settings.cameraFallbackAspectRatio,
+              settings,
               orientation,
             )
-      : _aspectRatioValue(configuredRatio);
+      : _settingsAspectRatioValue(configuredRatio, settings);
   if (baseRatio <= 0) {
     return 1;
   }
@@ -435,12 +453,13 @@ double resolveCameraCaptureAspectRatio({
 
 double _fallbackAspectRatioValue(
   CameraPhotoAspectRatio ratio,
+  AppSettings settings,
   Orientation orientation,
 ) {
   if (ratio == CameraPhotoAspectRatio.native) {
     return orientation == Orientation.landscape ? 4 / 3 : 3 / 4;
   }
-  return _aspectRatioValue(ratio);
+  return _settingsAspectRatioValue(ratio, settings);
 }
 
 bool _shouldCropNativeCapture({

--- a/lib/data/anitabi_client.dart
+++ b/lib/data/anitabi_client.dart
@@ -29,6 +29,14 @@ class AnitabiClient {
     return AnitabiBangumiLite.fromJson(decoded);
   }
 
+  Future<AnitabiBangumiLite?> fetchBangumiLiteFromStatic(int bangumiId) async {
+    final staticIndex = await _fetchStaticIndex();
+    final work = staticIndex.works
+        .where((work) => work.bangumiId == bangumiId)
+        .firstOrNull;
+    return work?.toBangumiLite();
+  }
+
   Future<List<AnitabiPoint>> fetchPoints(
     int bangumiId, {
     AnitabiBangumiLite? lite,
@@ -171,7 +179,6 @@ class AnitabiClient {
       headers: const {'content-type': 'application/json; charset=utf-8'},
     );
   }
-
 }
 
 class AnitabiStaticIndex {

--- a/lib/data/anitabi_static_data_reader.dart
+++ b/lib/data/anitabi_static_data_reader.dart
@@ -17,22 +17,22 @@ class AnitabiStaticDataReader {
       return fetchDesktopAnitabiStaticJson(fileName: fileName);
     }
 
+    if (kIsWeb) {
+      final proxyUri = Uri.base.resolve('/__anitabi_static__/$fileName');
+      try {
+        return (await _checkedGet(proxyUri)).body;
+      } catch (error) {
+        throw AnitabiStaticDataUnavailableException(error);
+      }
+    }
+
     final primaryUri = Uri.parse('https://www.anitabi.cn/d/$fileName');
     try {
       return (await _checkedGet(primaryUri)).body;
     } catch (error) {
-      if (!kIsWeb) {
-        final fallbackUri = Uri.parse('https://anitabi.cn/d/$fileName');
-        try {
-          return (await _checkedGet(fallbackUri)).body;
-        } catch (_) {
-          rethrow;
-        }
-      }
-
-      final proxyUri = Uri.base.resolve('/__anitabi_static__/$fileName');
+      final fallbackUri = Uri.parse('https://anitabi.cn/d/$fileName');
       try {
-        return (await _checkedGet(proxyUri)).body;
+        return (await _checkedGet(fallbackUri)).body;
       } catch (_) {
         throw AnitabiStaticDataUnavailableException(error);
       }

--- a/lib/data/local/app_database.dart
+++ b/lib/data/local/app_database.dart
@@ -99,6 +99,8 @@ class VisitRecords extends Table {
 class AppSettingsEntries extends Table {
   TextColumn get id => text()();
   RealColumn get uiScale => real().withDefault(const Constant(1.0))();
+  RealColumn get fontScale => real().withDefault(const Constant(1.0))();
+  TextColumn get themeMode => text().withDefault(const Constant('light'))();
   TextColumn get cameraAspectRatio =>
       text().withDefault(const Constant('auto'))();
   TextColumn get cameraCaptureAspectRatio =>
@@ -113,6 +115,8 @@ class AppSettingsEntries extends Table {
       text().withDefault(const Constant('classicGreen'))();
   TextColumn get mapTileProvider =>
       text().withDefault(const Constant('openFreeMap'))();
+  TextColumn get navigationApp =>
+      text().withDefault(const Constant('googleMaps'))();
   TextColumn get customXyzTileUrl => text().withDefault(const Constant(''))();
   TextColumn get customMapLibreStyleUrl =>
       text().withDefault(const Constant(''))();
@@ -122,6 +126,16 @@ class AppSettingsEntries extends Table {
       boolean().withDefault(const Constant(false))();
   TextColumn get comparisonPilgrimName =>
       text().withDefault(const Constant(''))();
+  TextColumn get customThemeColorName =>
+      text().withDefault(const Constant('自定义'))();
+  IntColumn get customThemeColorValue =>
+      integer().withDefault(const Constant(0xFF16C6A8))();
+  TextColumn get customThemeColorsJson =>
+      text().withDefault(const Constant('[]'))();
+  RealColumn get customCameraAspectRatioWidth =>
+      real().withDefault(const Constant(1.0))();
+  RealColumn get customCameraAspectRatioHeight =>
+      real().withDefault(const Constant(1.0))();
 
   @override
   Set<Column<Object>> get primaryKey => {id};
@@ -134,7 +148,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 17;
+  int get schemaVersion => 21;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -288,6 +302,70 @@ class AppDatabase extends _$AppDatabase {
           'comparison_pilgrim_name',
           appSettingsEntries,
           appSettingsEntries.comparisonPilgrimName,
+        );
+      }
+      if (from < 18) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'font_scale',
+          appSettingsEntries,
+          appSettingsEntries.fontScale,
+        );
+      }
+      if (from < 19) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'theme_mode',
+          appSettingsEntries,
+          appSettingsEntries.themeMode,
+        );
+      }
+      if (from < 20) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'custom_theme_color_name',
+          appSettingsEntries,
+          appSettingsEntries.customThemeColorName,
+        );
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'custom_theme_color_value',
+          appSettingsEntries,
+          appSettingsEntries.customThemeColorValue,
+        );
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'custom_theme_colors_json',
+          appSettingsEntries,
+          appSettingsEntries.customThemeColorsJson,
+        );
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'custom_camera_aspect_ratio_width',
+          appSettingsEntries,
+          appSettingsEntries.customCameraAspectRatioWidth,
+        );
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'custom_camera_aspect_ratio_height',
+          appSettingsEntries,
+          appSettingsEntries.customCameraAspectRatioHeight,
+        );
+      }
+      if (from < 21) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'navigation_app',
+          appSettingsEntries,
+          appSettingsEntries.navigationApp,
         );
       }
     },

--- a/lib/data/local/app_database.g.dart
+++ b/lib/data/local/app_database.g.dart
@@ -3918,6 +3918,30 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
     requiredDuringInsert: false,
     defaultValue: const Constant(1.0),
   );
+  static const VerificationMeta _fontScaleMeta = const VerificationMeta(
+    'fontScale',
+  );
+  @override
+  late final GeneratedColumn<double> fontScale = GeneratedColumn<double>(
+    'font_scale',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(1.0),
+  );
+  static const VerificationMeta _themeModeMeta = const VerificationMeta(
+    'themeMode',
+  );
+  @override
+  late final GeneratedColumn<String> themeMode = GeneratedColumn<String>(
+    'theme_mode',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('light'),
+  );
   static const VerificationMeta _cameraAspectRatioMeta = const VerificationMeta(
     'cameraAspectRatio',
   );
@@ -4015,6 +4039,18 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
     requiredDuringInsert: false,
     defaultValue: const Constant('openFreeMap'),
   );
+  static const VerificationMeta _navigationAppMeta = const VerificationMeta(
+    'navigationApp',
+  );
+  @override
+  late final GeneratedColumn<String> navigationApp = GeneratedColumn<String>(
+    'navigation_app',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+    defaultValue: const Constant('googleMaps'),
+  );
   static const VerificationMeta _customXyzTileUrlMeta = const VerificationMeta(
     'customXyzTileUrl',
   );
@@ -4081,10 +4117,71 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         requiredDuringInsert: false,
         defaultValue: const Constant(''),
       );
+  static const VerificationMeta _customThemeColorNameMeta =
+      const VerificationMeta('customThemeColorName');
+  @override
+  late final GeneratedColumn<String> customThemeColorName =
+      GeneratedColumn<String>(
+        'custom_theme_color_name',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('自定义'),
+      );
+  static const VerificationMeta _customThemeColorValueMeta =
+      const VerificationMeta('customThemeColorValue');
+  @override
+  late final GeneratedColumn<int> customThemeColorValue = GeneratedColumn<int>(
+    'custom_theme_color_value',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0xFF16C6A8),
+  );
+  static const VerificationMeta _customThemeColorsJsonMeta =
+      const VerificationMeta('customThemeColorsJson');
+  @override
+  late final GeneratedColumn<String> customThemeColorsJson =
+      GeneratedColumn<String>(
+        'custom_theme_colors_json',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+        defaultValue: const Constant('[]'),
+      );
+  static const VerificationMeta _customCameraAspectRatioWidthMeta =
+      const VerificationMeta('customCameraAspectRatioWidth');
+  @override
+  late final GeneratedColumn<double> customCameraAspectRatioWidth =
+      GeneratedColumn<double>(
+        'custom_camera_aspect_ratio_width',
+        aliasedName,
+        false,
+        type: DriftSqlType.double,
+        requiredDuringInsert: false,
+        defaultValue: const Constant(1.0),
+      );
+  static const VerificationMeta _customCameraAspectRatioHeightMeta =
+      const VerificationMeta('customCameraAspectRatioHeight');
+  @override
+  late final GeneratedColumn<double> customCameraAspectRatioHeight =
+      GeneratedColumn<double>(
+        'custom_camera_aspect_ratio_height',
+        aliasedName,
+        false,
+        type: DriftSqlType.double,
+        requiredDuringInsert: false,
+        defaultValue: const Constant(1.0),
+      );
   @override
   List<GeneratedColumn> get $columns => [
     id,
     uiScale,
+    fontScale,
+    themeMode,
     cameraAspectRatio,
     cameraCaptureAspectRatio,
     cameraMinZoom,
@@ -4093,11 +4190,17 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
     nearestAssignDistanceMeters,
     themePalette,
     mapTileProvider,
+    navigationApp,
     customXyzTileUrl,
     customMapLibreStyleUrl,
     saveVisitPhotoToGallery,
     comparisonShowPilgrimName,
     comparisonPilgrimName,
+    customThemeColorName,
+    customThemeColorValue,
+    customThemeColorsJson,
+    customCameraAspectRatioWidth,
+    customCameraAspectRatioHeight,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -4120,6 +4223,18 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
       context.handle(
         _uiScaleMeta,
         uiScale.isAcceptableOrUnknown(data['ui_scale']!, _uiScaleMeta),
+      );
+    }
+    if (data.containsKey('font_scale')) {
+      context.handle(
+        _fontScaleMeta,
+        fontScale.isAcceptableOrUnknown(data['font_scale']!, _fontScaleMeta),
+      );
+    }
+    if (data.containsKey('theme_mode')) {
+      context.handle(
+        _themeModeMeta,
+        themeMode.isAcceptableOrUnknown(data['theme_mode']!, _themeModeMeta),
       );
     }
     if (data.containsKey('camera_aspect_ratio')) {
@@ -4194,6 +4309,15 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
       );
     }
+    if (data.containsKey('navigation_app')) {
+      context.handle(
+        _navigationAppMeta,
+        navigationApp.isAcceptableOrUnknown(
+          data['navigation_app']!,
+          _navigationAppMeta,
+        ),
+      );
+    }
     if (data.containsKey('custom_xyz_tile_url')) {
       context.handle(
         _customXyzTileUrlMeta,
@@ -4239,6 +4363,51 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
       );
     }
+    if (data.containsKey('custom_theme_color_name')) {
+      context.handle(
+        _customThemeColorNameMeta,
+        customThemeColorName.isAcceptableOrUnknown(
+          data['custom_theme_color_name']!,
+          _customThemeColorNameMeta,
+        ),
+      );
+    }
+    if (data.containsKey('custom_theme_color_value')) {
+      context.handle(
+        _customThemeColorValueMeta,
+        customThemeColorValue.isAcceptableOrUnknown(
+          data['custom_theme_color_value']!,
+          _customThemeColorValueMeta,
+        ),
+      );
+    }
+    if (data.containsKey('custom_theme_colors_json')) {
+      context.handle(
+        _customThemeColorsJsonMeta,
+        customThemeColorsJson.isAcceptableOrUnknown(
+          data['custom_theme_colors_json']!,
+          _customThemeColorsJsonMeta,
+        ),
+      );
+    }
+    if (data.containsKey('custom_camera_aspect_ratio_width')) {
+      context.handle(
+        _customCameraAspectRatioWidthMeta,
+        customCameraAspectRatioWidth.isAcceptableOrUnknown(
+          data['custom_camera_aspect_ratio_width']!,
+          _customCameraAspectRatioWidthMeta,
+        ),
+      );
+    }
+    if (data.containsKey('custom_camera_aspect_ratio_height')) {
+      context.handle(
+        _customCameraAspectRatioHeightMeta,
+        customCameraAspectRatioHeight.isAcceptableOrUnknown(
+          data['custom_camera_aspect_ratio_height']!,
+          _customCameraAspectRatioHeightMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -4255,6 +4424,14 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
       uiScale: attachedDatabase.typeMapping.read(
         DriftSqlType.double,
         data['${effectivePrefix}ui_scale'],
+      )!,
+      fontScale: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}font_scale'],
+      )!,
+      themeMode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}theme_mode'],
       )!,
       cameraAspectRatio: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
@@ -4288,6 +4465,10 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         DriftSqlType.string,
         data['${effectivePrefix}map_tile_provider'],
       )!,
+      navigationApp: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}navigation_app'],
+      )!,
       customXyzTileUrl: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}custom_xyz_tile_url'],
@@ -4308,6 +4489,26 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         DriftSqlType.string,
         data['${effectivePrefix}comparison_pilgrim_name'],
       )!,
+      customThemeColorName: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}custom_theme_color_name'],
+      )!,
+      customThemeColorValue: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}custom_theme_color_value'],
+      )!,
+      customThemeColorsJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}custom_theme_colors_json'],
+      )!,
+      customCameraAspectRatioWidth: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}custom_camera_aspect_ratio_width'],
+      )!,
+      customCameraAspectRatioHeight: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}custom_camera_aspect_ratio_height'],
+      )!,
     );
   }
 
@@ -4321,6 +4522,8 @@ class AppSettingsEntry extends DataClass
     implements Insertable<AppSettingsEntry> {
   final String id;
   final double uiScale;
+  final double fontScale;
+  final String themeMode;
   final String cameraAspectRatio;
   final String cameraCaptureAspectRatio;
   final double cameraMinZoom;
@@ -4329,14 +4532,22 @@ class AppSettingsEntry extends DataClass
   final double nearestAssignDistanceMeters;
   final String themePalette;
   final String mapTileProvider;
+  final String navigationApp;
   final String customXyzTileUrl;
   final String customMapLibreStyleUrl;
   final bool saveVisitPhotoToGallery;
   final bool comparisonShowPilgrimName;
   final String comparisonPilgrimName;
+  final String customThemeColorName;
+  final int customThemeColorValue;
+  final String customThemeColorsJson;
+  final double customCameraAspectRatioWidth;
+  final double customCameraAspectRatioHeight;
   const AppSettingsEntry({
     required this.id,
     required this.uiScale,
+    required this.fontScale,
+    required this.themeMode,
     required this.cameraAspectRatio,
     required this.cameraCaptureAspectRatio,
     required this.cameraMinZoom,
@@ -4345,17 +4556,25 @@ class AppSettingsEntry extends DataClass
     required this.nearestAssignDistanceMeters,
     required this.themePalette,
     required this.mapTileProvider,
+    required this.navigationApp,
     required this.customXyzTileUrl,
     required this.customMapLibreStyleUrl,
     required this.saveVisitPhotoToGallery,
     required this.comparisonShowPilgrimName,
     required this.comparisonPilgrimName,
+    required this.customThemeColorName,
+    required this.customThemeColorValue,
+    required this.customThemeColorsJson,
+    required this.customCameraAspectRatioWidth,
+    required this.customCameraAspectRatioHeight,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<String>(id);
     map['ui_scale'] = Variable<double>(uiScale);
+    map['font_scale'] = Variable<double>(fontScale);
+    map['theme_mode'] = Variable<String>(themeMode);
     map['camera_aspect_ratio'] = Variable<String>(cameraAspectRatio);
     map['camera_capture_aspect_ratio'] = Variable<String>(
       cameraCaptureAspectRatio,
@@ -4368,6 +4587,7 @@ class AppSettingsEntry extends DataClass
     );
     map['theme_palette'] = Variable<String>(themePalette);
     map['map_tile_provider'] = Variable<String>(mapTileProvider);
+    map['navigation_app'] = Variable<String>(navigationApp);
     map['custom_xyz_tile_url'] = Variable<String>(customXyzTileUrl);
     map['custom_map_libre_style_url'] = Variable<String>(
       customMapLibreStyleUrl,
@@ -4379,6 +4599,15 @@ class AppSettingsEntry extends DataClass
       comparisonShowPilgrimName,
     );
     map['comparison_pilgrim_name'] = Variable<String>(comparisonPilgrimName);
+    map['custom_theme_color_name'] = Variable<String>(customThemeColorName);
+    map['custom_theme_color_value'] = Variable<int>(customThemeColorValue);
+    map['custom_theme_colors_json'] = Variable<String>(customThemeColorsJson);
+    map['custom_camera_aspect_ratio_width'] = Variable<double>(
+      customCameraAspectRatioWidth,
+    );
+    map['custom_camera_aspect_ratio_height'] = Variable<double>(
+      customCameraAspectRatioHeight,
+    );
     return map;
   }
 
@@ -4386,6 +4615,8 @@ class AppSettingsEntry extends DataClass
     return AppSettingsEntriesCompanion(
       id: Value(id),
       uiScale: Value(uiScale),
+      fontScale: Value(fontScale),
+      themeMode: Value(themeMode),
       cameraAspectRatio: Value(cameraAspectRatio),
       cameraCaptureAspectRatio: Value(cameraCaptureAspectRatio),
       cameraMinZoom: Value(cameraMinZoom),
@@ -4394,11 +4625,17 @@ class AppSettingsEntry extends DataClass
       nearestAssignDistanceMeters: Value(nearestAssignDistanceMeters),
       themePalette: Value(themePalette),
       mapTileProvider: Value(mapTileProvider),
+      navigationApp: Value(navigationApp),
       customXyzTileUrl: Value(customXyzTileUrl),
       customMapLibreStyleUrl: Value(customMapLibreStyleUrl),
       saveVisitPhotoToGallery: Value(saveVisitPhotoToGallery),
       comparisonShowPilgrimName: Value(comparisonShowPilgrimName),
       comparisonPilgrimName: Value(comparisonPilgrimName),
+      customThemeColorName: Value(customThemeColorName),
+      customThemeColorValue: Value(customThemeColorValue),
+      customThemeColorsJson: Value(customThemeColorsJson),
+      customCameraAspectRatioWidth: Value(customCameraAspectRatioWidth),
+      customCameraAspectRatioHeight: Value(customCameraAspectRatioHeight),
     );
   }
 
@@ -4410,6 +4647,8 @@ class AppSettingsEntry extends DataClass
     return AppSettingsEntry(
       id: serializer.fromJson<String>(json['id']),
       uiScale: serializer.fromJson<double>(json['uiScale']),
+      fontScale: serializer.fromJson<double>(json['fontScale']),
+      themeMode: serializer.fromJson<String>(json['themeMode']),
       cameraAspectRatio: serializer.fromJson<String>(json['cameraAspectRatio']),
       cameraCaptureAspectRatio: serializer.fromJson<String>(
         json['cameraCaptureAspectRatio'],
@@ -4424,6 +4663,7 @@ class AppSettingsEntry extends DataClass
       ),
       themePalette: serializer.fromJson<String>(json['themePalette']),
       mapTileProvider: serializer.fromJson<String>(json['mapTileProvider']),
+      navigationApp: serializer.fromJson<String>(json['navigationApp']),
       customXyzTileUrl: serializer.fromJson<String>(json['customXyzTileUrl']),
       customMapLibreStyleUrl: serializer.fromJson<String>(
         json['customMapLibreStyleUrl'],
@@ -4437,6 +4677,21 @@ class AppSettingsEntry extends DataClass
       comparisonPilgrimName: serializer.fromJson<String>(
         json['comparisonPilgrimName'],
       ),
+      customThemeColorName: serializer.fromJson<String>(
+        json['customThemeColorName'],
+      ),
+      customThemeColorValue: serializer.fromJson<int>(
+        json['customThemeColorValue'],
+      ),
+      customThemeColorsJson: serializer.fromJson<String>(
+        json['customThemeColorsJson'],
+      ),
+      customCameraAspectRatioWidth: serializer.fromJson<double>(
+        json['customCameraAspectRatioWidth'],
+      ),
+      customCameraAspectRatioHeight: serializer.fromJson<double>(
+        json['customCameraAspectRatioHeight'],
+      ),
     );
   }
   @override
@@ -4445,6 +4700,8 @@ class AppSettingsEntry extends DataClass
     return <String, dynamic>{
       'id': serializer.toJson<String>(id),
       'uiScale': serializer.toJson<double>(uiScale),
+      'fontScale': serializer.toJson<double>(fontScale),
+      'themeMode': serializer.toJson<String>(themeMode),
       'cameraAspectRatio': serializer.toJson<String>(cameraAspectRatio),
       'cameraCaptureAspectRatio': serializer.toJson<String>(
         cameraCaptureAspectRatio,
@@ -4457,6 +4714,7 @@ class AppSettingsEntry extends DataClass
       ),
       'themePalette': serializer.toJson<String>(themePalette),
       'mapTileProvider': serializer.toJson<String>(mapTileProvider),
+      'navigationApp': serializer.toJson<String>(navigationApp),
       'customXyzTileUrl': serializer.toJson<String>(customXyzTileUrl),
       'customMapLibreStyleUrl': serializer.toJson<String>(
         customMapLibreStyleUrl,
@@ -4468,12 +4726,23 @@ class AppSettingsEntry extends DataClass
         comparisonShowPilgrimName,
       ),
       'comparisonPilgrimName': serializer.toJson<String>(comparisonPilgrimName),
+      'customThemeColorName': serializer.toJson<String>(customThemeColorName),
+      'customThemeColorValue': serializer.toJson<int>(customThemeColorValue),
+      'customThemeColorsJson': serializer.toJson<String>(customThemeColorsJson),
+      'customCameraAspectRatioWidth': serializer.toJson<double>(
+        customCameraAspectRatioWidth,
+      ),
+      'customCameraAspectRatioHeight': serializer.toJson<double>(
+        customCameraAspectRatioHeight,
+      ),
     };
   }
 
   AppSettingsEntry copyWith({
     String? id,
     double? uiScale,
+    double? fontScale,
+    String? themeMode,
     String? cameraAspectRatio,
     String? cameraCaptureAspectRatio,
     double? cameraMinZoom,
@@ -4482,14 +4751,22 @@ class AppSettingsEntry extends DataClass
     double? nearestAssignDistanceMeters,
     String? themePalette,
     String? mapTileProvider,
+    String? navigationApp,
     String? customXyzTileUrl,
     String? customMapLibreStyleUrl,
     bool? saveVisitPhotoToGallery,
     bool? comparisonShowPilgrimName,
     String? comparisonPilgrimName,
+    String? customThemeColorName,
+    int? customThemeColorValue,
+    String? customThemeColorsJson,
+    double? customCameraAspectRatioWidth,
+    double? customCameraAspectRatioHeight,
   }) => AppSettingsEntry(
     id: id ?? this.id,
     uiScale: uiScale ?? this.uiScale,
+    fontScale: fontScale ?? this.fontScale,
+    themeMode: themeMode ?? this.themeMode,
     cameraAspectRatio: cameraAspectRatio ?? this.cameraAspectRatio,
     cameraCaptureAspectRatio:
         cameraCaptureAspectRatio ?? this.cameraCaptureAspectRatio,
@@ -4500,6 +4777,7 @@ class AppSettingsEntry extends DataClass
         nearestAssignDistanceMeters ?? this.nearestAssignDistanceMeters,
     themePalette: themePalette ?? this.themePalette,
     mapTileProvider: mapTileProvider ?? this.mapTileProvider,
+    navigationApp: navigationApp ?? this.navigationApp,
     customXyzTileUrl: customXyzTileUrl ?? this.customXyzTileUrl,
     customMapLibreStyleUrl:
         customMapLibreStyleUrl ?? this.customMapLibreStyleUrl,
@@ -4508,11 +4786,20 @@ class AppSettingsEntry extends DataClass
     comparisonShowPilgrimName:
         comparisonShowPilgrimName ?? this.comparisonShowPilgrimName,
     comparisonPilgrimName: comparisonPilgrimName ?? this.comparisonPilgrimName,
+    customThemeColorName: customThemeColorName ?? this.customThemeColorName,
+    customThemeColorValue: customThemeColorValue ?? this.customThemeColorValue,
+    customThemeColorsJson: customThemeColorsJson ?? this.customThemeColorsJson,
+    customCameraAspectRatioWidth:
+        customCameraAspectRatioWidth ?? this.customCameraAspectRatioWidth,
+    customCameraAspectRatioHeight:
+        customCameraAspectRatioHeight ?? this.customCameraAspectRatioHeight,
   );
   AppSettingsEntry copyWithCompanion(AppSettingsEntriesCompanion data) {
     return AppSettingsEntry(
       id: data.id.present ? data.id.value : this.id,
       uiScale: data.uiScale.present ? data.uiScale.value : this.uiScale,
+      fontScale: data.fontScale.present ? data.fontScale.value : this.fontScale,
+      themeMode: data.themeMode.present ? data.themeMode.value : this.themeMode,
       cameraAspectRatio: data.cameraAspectRatio.present
           ? data.cameraAspectRatio.value
           : this.cameraAspectRatio,
@@ -4537,6 +4824,9 @@ class AppSettingsEntry extends DataClass
       mapTileProvider: data.mapTileProvider.present
           ? data.mapTileProvider.value
           : this.mapTileProvider,
+      navigationApp: data.navigationApp.present
+          ? data.navigationApp.value
+          : this.navigationApp,
       customXyzTileUrl: data.customXyzTileUrl.present
           ? data.customXyzTileUrl.value
           : this.customXyzTileUrl,
@@ -4552,6 +4842,21 @@ class AppSettingsEntry extends DataClass
       comparisonPilgrimName: data.comparisonPilgrimName.present
           ? data.comparisonPilgrimName.value
           : this.comparisonPilgrimName,
+      customThemeColorName: data.customThemeColorName.present
+          ? data.customThemeColorName.value
+          : this.customThemeColorName,
+      customThemeColorValue: data.customThemeColorValue.present
+          ? data.customThemeColorValue.value
+          : this.customThemeColorValue,
+      customThemeColorsJson: data.customThemeColorsJson.present
+          ? data.customThemeColorsJson.value
+          : this.customThemeColorsJson,
+      customCameraAspectRatioWidth: data.customCameraAspectRatioWidth.present
+          ? data.customCameraAspectRatioWidth.value
+          : this.customCameraAspectRatioWidth,
+      customCameraAspectRatioHeight: data.customCameraAspectRatioHeight.present
+          ? data.customCameraAspectRatioHeight.value
+          : this.customCameraAspectRatioHeight,
     );
   }
 
@@ -4560,6 +4865,8 @@ class AppSettingsEntry extends DataClass
     return (StringBuffer('AppSettingsEntry(')
           ..write('id: $id, ')
           ..write('uiScale: $uiScale, ')
+          ..write('fontScale: $fontScale, ')
+          ..write('themeMode: $themeMode, ')
           ..write('cameraAspectRatio: $cameraAspectRatio, ')
           ..write('cameraCaptureAspectRatio: $cameraCaptureAspectRatio, ')
           ..write('cameraMinZoom: $cameraMinZoom, ')
@@ -4568,19 +4875,31 @@ class AppSettingsEntry extends DataClass
           ..write('nearestAssignDistanceMeters: $nearestAssignDistanceMeters, ')
           ..write('themePalette: $themePalette, ')
           ..write('mapTileProvider: $mapTileProvider, ')
+          ..write('navigationApp: $navigationApp, ')
           ..write('customXyzTileUrl: $customXyzTileUrl, ')
           ..write('customMapLibreStyleUrl: $customMapLibreStyleUrl, ')
           ..write('saveVisitPhotoToGallery: $saveVisitPhotoToGallery, ')
           ..write('comparisonShowPilgrimName: $comparisonShowPilgrimName, ')
-          ..write('comparisonPilgrimName: $comparisonPilgrimName')
+          ..write('comparisonPilgrimName: $comparisonPilgrimName, ')
+          ..write('customThemeColorName: $customThemeColorName, ')
+          ..write('customThemeColorValue: $customThemeColorValue, ')
+          ..write('customThemeColorsJson: $customThemeColorsJson, ')
+          ..write(
+            'customCameraAspectRatioWidth: $customCameraAspectRatioWidth, ',
+          )
+          ..write(
+            'customCameraAspectRatioHeight: $customCameraAspectRatioHeight',
+          )
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     id,
     uiScale,
+    fontScale,
+    themeMode,
     cameraAspectRatio,
     cameraCaptureAspectRatio,
     cameraMinZoom,
@@ -4589,18 +4908,26 @@ class AppSettingsEntry extends DataClass
     nearestAssignDistanceMeters,
     themePalette,
     mapTileProvider,
+    navigationApp,
     customXyzTileUrl,
     customMapLibreStyleUrl,
     saveVisitPhotoToGallery,
     comparisonShowPilgrimName,
     comparisonPilgrimName,
-  );
+    customThemeColorName,
+    customThemeColorValue,
+    customThemeColorsJson,
+    customCameraAspectRatioWidth,
+    customCameraAspectRatioHeight,
+  ]);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is AppSettingsEntry &&
           other.id == this.id &&
           other.uiScale == this.uiScale &&
+          other.fontScale == this.fontScale &&
+          other.themeMode == this.themeMode &&
           other.cameraAspectRatio == this.cameraAspectRatio &&
           other.cameraCaptureAspectRatio == this.cameraCaptureAspectRatio &&
           other.cameraMinZoom == this.cameraMinZoom &&
@@ -4610,16 +4937,26 @@ class AppSettingsEntry extends DataClass
               this.nearestAssignDistanceMeters &&
           other.themePalette == this.themePalette &&
           other.mapTileProvider == this.mapTileProvider &&
+          other.navigationApp == this.navigationApp &&
           other.customXyzTileUrl == this.customXyzTileUrl &&
           other.customMapLibreStyleUrl == this.customMapLibreStyleUrl &&
           other.saveVisitPhotoToGallery == this.saveVisitPhotoToGallery &&
           other.comparisonShowPilgrimName == this.comparisonShowPilgrimName &&
-          other.comparisonPilgrimName == this.comparisonPilgrimName);
+          other.comparisonPilgrimName == this.comparisonPilgrimName &&
+          other.customThemeColorName == this.customThemeColorName &&
+          other.customThemeColorValue == this.customThemeColorValue &&
+          other.customThemeColorsJson == this.customThemeColorsJson &&
+          other.customCameraAspectRatioWidth ==
+              this.customCameraAspectRatioWidth &&
+          other.customCameraAspectRatioHeight ==
+              this.customCameraAspectRatioHeight);
 }
 
 class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
   final Value<String> id;
   final Value<double> uiScale;
+  final Value<double> fontScale;
+  final Value<String> themeMode;
   final Value<String> cameraAspectRatio;
   final Value<String> cameraCaptureAspectRatio;
   final Value<double> cameraMinZoom;
@@ -4628,15 +4965,23 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
   final Value<double> nearestAssignDistanceMeters;
   final Value<String> themePalette;
   final Value<String> mapTileProvider;
+  final Value<String> navigationApp;
   final Value<String> customXyzTileUrl;
   final Value<String> customMapLibreStyleUrl;
   final Value<bool> saveVisitPhotoToGallery;
   final Value<bool> comparisonShowPilgrimName;
   final Value<String> comparisonPilgrimName;
+  final Value<String> customThemeColorName;
+  final Value<int> customThemeColorValue;
+  final Value<String> customThemeColorsJson;
+  final Value<double> customCameraAspectRatioWidth;
+  final Value<double> customCameraAspectRatioHeight;
   final Value<int> rowid;
   const AppSettingsEntriesCompanion({
     this.id = const Value.absent(),
     this.uiScale = const Value.absent(),
+    this.fontScale = const Value.absent(),
+    this.themeMode = const Value.absent(),
     this.cameraAspectRatio = const Value.absent(),
     this.cameraCaptureAspectRatio = const Value.absent(),
     this.cameraMinZoom = const Value.absent(),
@@ -4645,16 +4990,24 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.nearestAssignDistanceMeters = const Value.absent(),
     this.themePalette = const Value.absent(),
     this.mapTileProvider = const Value.absent(),
+    this.navigationApp = const Value.absent(),
     this.customXyzTileUrl = const Value.absent(),
     this.customMapLibreStyleUrl = const Value.absent(),
     this.saveVisitPhotoToGallery = const Value.absent(),
     this.comparisonShowPilgrimName = const Value.absent(),
     this.comparisonPilgrimName = const Value.absent(),
+    this.customThemeColorName = const Value.absent(),
+    this.customThemeColorValue = const Value.absent(),
+    this.customThemeColorsJson = const Value.absent(),
+    this.customCameraAspectRatioWidth = const Value.absent(),
+    this.customCameraAspectRatioHeight = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   AppSettingsEntriesCompanion.insert({
     required String id,
     this.uiScale = const Value.absent(),
+    this.fontScale = const Value.absent(),
+    this.themeMode = const Value.absent(),
     this.cameraAspectRatio = const Value.absent(),
     this.cameraCaptureAspectRatio = const Value.absent(),
     this.cameraMinZoom = const Value.absent(),
@@ -4663,16 +5016,24 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.nearestAssignDistanceMeters = const Value.absent(),
     this.themePalette = const Value.absent(),
     this.mapTileProvider = const Value.absent(),
+    this.navigationApp = const Value.absent(),
     this.customXyzTileUrl = const Value.absent(),
     this.customMapLibreStyleUrl = const Value.absent(),
     this.saveVisitPhotoToGallery = const Value.absent(),
     this.comparisonShowPilgrimName = const Value.absent(),
     this.comparisonPilgrimName = const Value.absent(),
+    this.customThemeColorName = const Value.absent(),
+    this.customThemeColorValue = const Value.absent(),
+    this.customThemeColorsJson = const Value.absent(),
+    this.customCameraAspectRatioWidth = const Value.absent(),
+    this.customCameraAspectRatioHeight = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id);
   static Insertable<AppSettingsEntry> custom({
     Expression<String>? id,
     Expression<double>? uiScale,
+    Expression<double>? fontScale,
+    Expression<String>? themeMode,
     Expression<String>? cameraAspectRatio,
     Expression<String>? cameraCaptureAspectRatio,
     Expression<double>? cameraMinZoom,
@@ -4681,16 +5042,24 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Expression<double>? nearestAssignDistanceMeters,
     Expression<String>? themePalette,
     Expression<String>? mapTileProvider,
+    Expression<String>? navigationApp,
     Expression<String>? customXyzTileUrl,
     Expression<String>? customMapLibreStyleUrl,
     Expression<bool>? saveVisitPhotoToGallery,
     Expression<bool>? comparisonShowPilgrimName,
     Expression<String>? comparisonPilgrimName,
+    Expression<String>? customThemeColorName,
+    Expression<int>? customThemeColorValue,
+    Expression<String>? customThemeColorsJson,
+    Expression<double>? customCameraAspectRatioWidth,
+    Expression<double>? customCameraAspectRatioHeight,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (uiScale != null) 'ui_scale': uiScale,
+      if (fontScale != null) 'font_scale': fontScale,
+      if (themeMode != null) 'theme_mode': themeMode,
       if (cameraAspectRatio != null) 'camera_aspect_ratio': cameraAspectRatio,
       if (cameraCaptureAspectRatio != null)
         'camera_capture_aspect_ratio': cameraCaptureAspectRatio,
@@ -4702,6 +5071,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         'nearest_assign_distance_meters': nearestAssignDistanceMeters,
       if (themePalette != null) 'theme_palette': themePalette,
       if (mapTileProvider != null) 'map_tile_provider': mapTileProvider,
+      if (navigationApp != null) 'navigation_app': navigationApp,
       if (customXyzTileUrl != null) 'custom_xyz_tile_url': customXyzTileUrl,
       if (customMapLibreStyleUrl != null)
         'custom_map_libre_style_url': customMapLibreStyleUrl,
@@ -4711,6 +5081,16 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         'comparison_show_pilgrim_name': comparisonShowPilgrimName,
       if (comparisonPilgrimName != null)
         'comparison_pilgrim_name': comparisonPilgrimName,
+      if (customThemeColorName != null)
+        'custom_theme_color_name': customThemeColorName,
+      if (customThemeColorValue != null)
+        'custom_theme_color_value': customThemeColorValue,
+      if (customThemeColorsJson != null)
+        'custom_theme_colors_json': customThemeColorsJson,
+      if (customCameraAspectRatioWidth != null)
+        'custom_camera_aspect_ratio_width': customCameraAspectRatioWidth,
+      if (customCameraAspectRatioHeight != null)
+        'custom_camera_aspect_ratio_height': customCameraAspectRatioHeight,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -4718,6 +5098,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
   AppSettingsEntriesCompanion copyWith({
     Value<String>? id,
     Value<double>? uiScale,
+    Value<double>? fontScale,
+    Value<String>? themeMode,
     Value<String>? cameraAspectRatio,
     Value<String>? cameraCaptureAspectRatio,
     Value<double>? cameraMinZoom,
@@ -4726,16 +5108,24 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Value<double>? nearestAssignDistanceMeters,
     Value<String>? themePalette,
     Value<String>? mapTileProvider,
+    Value<String>? navigationApp,
     Value<String>? customXyzTileUrl,
     Value<String>? customMapLibreStyleUrl,
     Value<bool>? saveVisitPhotoToGallery,
     Value<bool>? comparisonShowPilgrimName,
     Value<String>? comparisonPilgrimName,
+    Value<String>? customThemeColorName,
+    Value<int>? customThemeColorValue,
+    Value<String>? customThemeColorsJson,
+    Value<double>? customCameraAspectRatioWidth,
+    Value<double>? customCameraAspectRatioHeight,
     Value<int>? rowid,
   }) {
     return AppSettingsEntriesCompanion(
       id: id ?? this.id,
       uiScale: uiScale ?? this.uiScale,
+      fontScale: fontScale ?? this.fontScale,
+      themeMode: themeMode ?? this.themeMode,
       cameraAspectRatio: cameraAspectRatio ?? this.cameraAspectRatio,
       cameraCaptureAspectRatio:
           cameraCaptureAspectRatio ?? this.cameraCaptureAspectRatio,
@@ -4746,6 +5136,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           nearestAssignDistanceMeters ?? this.nearestAssignDistanceMeters,
       themePalette: themePalette ?? this.themePalette,
       mapTileProvider: mapTileProvider ?? this.mapTileProvider,
+      navigationApp: navigationApp ?? this.navigationApp,
       customXyzTileUrl: customXyzTileUrl ?? this.customXyzTileUrl,
       customMapLibreStyleUrl:
           customMapLibreStyleUrl ?? this.customMapLibreStyleUrl,
@@ -4755,6 +5146,15 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           comparisonShowPilgrimName ?? this.comparisonShowPilgrimName,
       comparisonPilgrimName:
           comparisonPilgrimName ?? this.comparisonPilgrimName,
+      customThemeColorName: customThemeColorName ?? this.customThemeColorName,
+      customThemeColorValue:
+          customThemeColorValue ?? this.customThemeColorValue,
+      customThemeColorsJson:
+          customThemeColorsJson ?? this.customThemeColorsJson,
+      customCameraAspectRatioWidth:
+          customCameraAspectRatioWidth ?? this.customCameraAspectRatioWidth,
+      customCameraAspectRatioHeight:
+          customCameraAspectRatioHeight ?? this.customCameraAspectRatioHeight,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -4767,6 +5167,12 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     }
     if (uiScale.present) {
       map['ui_scale'] = Variable<double>(uiScale.value);
+    }
+    if (fontScale.present) {
+      map['font_scale'] = Variable<double>(fontScale.value);
+    }
+    if (themeMode.present) {
+      map['theme_mode'] = Variable<String>(themeMode.value);
     }
     if (cameraAspectRatio.present) {
       map['camera_aspect_ratio'] = Variable<String>(cameraAspectRatio.value);
@@ -4798,6 +5204,9 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     if (mapTileProvider.present) {
       map['map_tile_provider'] = Variable<String>(mapTileProvider.value);
     }
+    if (navigationApp.present) {
+      map['navigation_app'] = Variable<String>(navigationApp.value);
+    }
     if (customXyzTileUrl.present) {
       map['custom_xyz_tile_url'] = Variable<String>(customXyzTileUrl.value);
     }
@@ -4821,6 +5230,31 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         comparisonPilgrimName.value,
       );
     }
+    if (customThemeColorName.present) {
+      map['custom_theme_color_name'] = Variable<String>(
+        customThemeColorName.value,
+      );
+    }
+    if (customThemeColorValue.present) {
+      map['custom_theme_color_value'] = Variable<int>(
+        customThemeColorValue.value,
+      );
+    }
+    if (customThemeColorsJson.present) {
+      map['custom_theme_colors_json'] = Variable<String>(
+        customThemeColorsJson.value,
+      );
+    }
+    if (customCameraAspectRatioWidth.present) {
+      map['custom_camera_aspect_ratio_width'] = Variable<double>(
+        customCameraAspectRatioWidth.value,
+      );
+    }
+    if (customCameraAspectRatioHeight.present) {
+      map['custom_camera_aspect_ratio_height'] = Variable<double>(
+        customCameraAspectRatioHeight.value,
+      );
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -4832,6 +5266,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     return (StringBuffer('AppSettingsEntriesCompanion(')
           ..write('id: $id, ')
           ..write('uiScale: $uiScale, ')
+          ..write('fontScale: $fontScale, ')
+          ..write('themeMode: $themeMode, ')
           ..write('cameraAspectRatio: $cameraAspectRatio, ')
           ..write('cameraCaptureAspectRatio: $cameraCaptureAspectRatio, ')
           ..write('cameraMinZoom: $cameraMinZoom, ')
@@ -4840,11 +5276,21 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           ..write('nearestAssignDistanceMeters: $nearestAssignDistanceMeters, ')
           ..write('themePalette: $themePalette, ')
           ..write('mapTileProvider: $mapTileProvider, ')
+          ..write('navigationApp: $navigationApp, ')
           ..write('customXyzTileUrl: $customXyzTileUrl, ')
           ..write('customMapLibreStyleUrl: $customMapLibreStyleUrl, ')
           ..write('saveVisitPhotoToGallery: $saveVisitPhotoToGallery, ')
           ..write('comparisonShowPilgrimName: $comparisonShowPilgrimName, ')
           ..write('comparisonPilgrimName: $comparisonPilgrimName, ')
+          ..write('customThemeColorName: $customThemeColorName, ')
+          ..write('customThemeColorValue: $customThemeColorValue, ')
+          ..write('customThemeColorsJson: $customThemeColorsJson, ')
+          ..write(
+            'customCameraAspectRatioWidth: $customCameraAspectRatioWidth, ',
+          )
+          ..write(
+            'customCameraAspectRatioHeight: $customCameraAspectRatioHeight, ',
+          )
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -7632,6 +8078,8 @@ typedef $$AppSettingsEntriesTableCreateCompanionBuilder =
     AppSettingsEntriesCompanion Function({
       required String id,
       Value<double> uiScale,
+      Value<double> fontScale,
+      Value<String> themeMode,
       Value<String> cameraAspectRatio,
       Value<String> cameraCaptureAspectRatio,
       Value<double> cameraMinZoom,
@@ -7640,17 +8088,25 @@ typedef $$AppSettingsEntriesTableCreateCompanionBuilder =
       Value<double> nearestAssignDistanceMeters,
       Value<String> themePalette,
       Value<String> mapTileProvider,
+      Value<String> navigationApp,
       Value<String> customXyzTileUrl,
       Value<String> customMapLibreStyleUrl,
       Value<bool> saveVisitPhotoToGallery,
       Value<bool> comparisonShowPilgrimName,
       Value<String> comparisonPilgrimName,
+      Value<String> customThemeColorName,
+      Value<int> customThemeColorValue,
+      Value<String> customThemeColorsJson,
+      Value<double> customCameraAspectRatioWidth,
+      Value<double> customCameraAspectRatioHeight,
       Value<int> rowid,
     });
 typedef $$AppSettingsEntriesTableUpdateCompanionBuilder =
     AppSettingsEntriesCompanion Function({
       Value<String> id,
       Value<double> uiScale,
+      Value<double> fontScale,
+      Value<String> themeMode,
       Value<String> cameraAspectRatio,
       Value<String> cameraCaptureAspectRatio,
       Value<double> cameraMinZoom,
@@ -7659,11 +8115,17 @@ typedef $$AppSettingsEntriesTableUpdateCompanionBuilder =
       Value<double> nearestAssignDistanceMeters,
       Value<String> themePalette,
       Value<String> mapTileProvider,
+      Value<String> navigationApp,
       Value<String> customXyzTileUrl,
       Value<String> customMapLibreStyleUrl,
       Value<bool> saveVisitPhotoToGallery,
       Value<bool> comparisonShowPilgrimName,
       Value<String> comparisonPilgrimName,
+      Value<String> customThemeColorName,
+      Value<int> customThemeColorValue,
+      Value<String> customThemeColorsJson,
+      Value<double> customCameraAspectRatioWidth,
+      Value<double> customCameraAspectRatioHeight,
       Value<int> rowid,
     });
 
@@ -7683,6 +8145,16 @@ class $$AppSettingsEntriesTableFilterComposer
 
   ColumnFilters<double> get uiScale => $composableBuilder(
     column: $table.uiScale,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get fontScale => $composableBuilder(
+    column: $table.fontScale,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get themeMode => $composableBuilder(
+    column: $table.themeMode,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -7726,6 +8198,11 @@ class $$AppSettingsEntriesTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get navigationApp => $composableBuilder(
+    column: $table.navigationApp,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get customXyzTileUrl => $composableBuilder(
     column: $table.customXyzTileUrl,
     builder: (column) => ColumnFilters(column),
@@ -7750,6 +8227,31 @@ class $$AppSettingsEntriesTableFilterComposer
     column: $table.comparisonPilgrimName,
     builder: (column) => ColumnFilters(column),
   );
+
+  ColumnFilters<String> get customThemeColorName => $composableBuilder(
+    column: $table.customThemeColorName,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get customThemeColorValue => $composableBuilder(
+    column: $table.customThemeColorValue,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get customThemeColorsJson => $composableBuilder(
+    column: $table.customThemeColorsJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get customCameraAspectRatioWidth => $composableBuilder(
+    column: $table.customCameraAspectRatioWidth,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get customCameraAspectRatioHeight => $composableBuilder(
+    column: $table.customCameraAspectRatioHeight,
+    builder: (column) => ColumnFilters(column),
+  );
 }
 
 class $$AppSettingsEntriesTableOrderingComposer
@@ -7768,6 +8270,16 @@ class $$AppSettingsEntriesTableOrderingComposer
 
   ColumnOrderings<double> get uiScale => $composableBuilder(
     column: $table.uiScale,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get fontScale => $composableBuilder(
+    column: $table.fontScale,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get themeMode => $composableBuilder(
+    column: $table.themeMode,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -7811,6 +8323,11 @@ class $$AppSettingsEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get navigationApp => $composableBuilder(
+    column: $table.navigationApp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get customXyzTileUrl => $composableBuilder(
     column: $table.customXyzTileUrl,
     builder: (column) => ColumnOrderings(column),
@@ -7835,6 +8352,33 @@ class $$AppSettingsEntriesTableOrderingComposer
     column: $table.comparisonPilgrimName,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get customThemeColorName => $composableBuilder(
+    column: $table.customThemeColorName,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get customThemeColorValue => $composableBuilder(
+    column: $table.customThemeColorValue,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get customThemeColorsJson => $composableBuilder(
+    column: $table.customThemeColorsJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get customCameraAspectRatioWidth =>
+      $composableBuilder(
+        column: $table.customCameraAspectRatioWidth,
+        builder: (column) => ColumnOrderings(column),
+      );
+
+  ColumnOrderings<double> get customCameraAspectRatioHeight =>
+      $composableBuilder(
+        column: $table.customCameraAspectRatioHeight,
+        builder: (column) => ColumnOrderings(column),
+      );
 }
 
 class $$AppSettingsEntriesTableAnnotationComposer
@@ -7851,6 +8395,12 @@ class $$AppSettingsEntriesTableAnnotationComposer
 
   GeneratedColumn<double> get uiScale =>
       $composableBuilder(column: $table.uiScale, builder: (column) => column);
+
+  GeneratedColumn<double> get fontScale =>
+      $composableBuilder(column: $table.fontScale, builder: (column) => column);
+
+  GeneratedColumn<String> get themeMode =>
+      $composableBuilder(column: $table.themeMode, builder: (column) => column);
 
   GeneratedColumn<String> get cameraAspectRatio => $composableBuilder(
     column: $table.cameraAspectRatio,
@@ -7892,6 +8442,11 @@ class $$AppSettingsEntriesTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<String> get navigationApp => $composableBuilder(
+    column: $table.navigationApp,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get customXyzTileUrl => $composableBuilder(
     column: $table.customXyzTileUrl,
     builder: (column) => column,
@@ -7916,6 +8471,33 @@ class $$AppSettingsEntriesTableAnnotationComposer
     column: $table.comparisonPilgrimName,
     builder: (column) => column,
   );
+
+  GeneratedColumn<String> get customThemeColorName => $composableBuilder(
+    column: $table.customThemeColorName,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get customThemeColorValue => $composableBuilder(
+    column: $table.customThemeColorValue,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get customThemeColorsJson => $composableBuilder(
+    column: $table.customThemeColorsJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<double> get customCameraAspectRatioWidth =>
+      $composableBuilder(
+        column: $table.customCameraAspectRatioWidth,
+        builder: (column) => column,
+      );
+
+  GeneratedColumn<double> get customCameraAspectRatioHeight =>
+      $composableBuilder(
+        column: $table.customCameraAspectRatioHeight,
+        builder: (column) => column,
+      );
 }
 
 class $$AppSettingsEntriesTableTableManager
@@ -7960,6 +8542,8 @@ class $$AppSettingsEntriesTableTableManager
               ({
                 Value<String> id = const Value.absent(),
                 Value<double> uiScale = const Value.absent(),
+                Value<double> fontScale = const Value.absent(),
+                Value<String> themeMode = const Value.absent(),
                 Value<String> cameraAspectRatio = const Value.absent(),
                 Value<String> cameraCaptureAspectRatio = const Value.absent(),
                 Value<double> cameraMinZoom = const Value.absent(),
@@ -7969,15 +8553,25 @@ class $$AppSettingsEntriesTableTableManager
                     const Value.absent(),
                 Value<String> themePalette = const Value.absent(),
                 Value<String> mapTileProvider = const Value.absent(),
+                Value<String> navigationApp = const Value.absent(),
                 Value<String> customXyzTileUrl = const Value.absent(),
                 Value<String> customMapLibreStyleUrl = const Value.absent(),
                 Value<bool> saveVisitPhotoToGallery = const Value.absent(),
                 Value<bool> comparisonShowPilgrimName = const Value.absent(),
                 Value<String> comparisonPilgrimName = const Value.absent(),
+                Value<String> customThemeColorName = const Value.absent(),
+                Value<int> customThemeColorValue = const Value.absent(),
+                Value<String> customThemeColorsJson = const Value.absent(),
+                Value<double> customCameraAspectRatioWidth =
+                    const Value.absent(),
+                Value<double> customCameraAspectRatioHeight =
+                    const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => AppSettingsEntriesCompanion(
                 id: id,
                 uiScale: uiScale,
+                fontScale: fontScale,
+                themeMode: themeMode,
                 cameraAspectRatio: cameraAspectRatio,
                 cameraCaptureAspectRatio: cameraCaptureAspectRatio,
                 cameraMinZoom: cameraMinZoom,
@@ -7986,17 +8580,25 @@ class $$AppSettingsEntriesTableTableManager
                 nearestAssignDistanceMeters: nearestAssignDistanceMeters,
                 themePalette: themePalette,
                 mapTileProvider: mapTileProvider,
+                navigationApp: navigationApp,
                 customXyzTileUrl: customXyzTileUrl,
                 customMapLibreStyleUrl: customMapLibreStyleUrl,
                 saveVisitPhotoToGallery: saveVisitPhotoToGallery,
                 comparisonShowPilgrimName: comparisonShowPilgrimName,
                 comparisonPilgrimName: comparisonPilgrimName,
+                customThemeColorName: customThemeColorName,
+                customThemeColorValue: customThemeColorValue,
+                customThemeColorsJson: customThemeColorsJson,
+                customCameraAspectRatioWidth: customCameraAspectRatioWidth,
+                customCameraAspectRatioHeight: customCameraAspectRatioHeight,
                 rowid: rowid,
               ),
           createCompanionCallback:
               ({
                 required String id,
                 Value<double> uiScale = const Value.absent(),
+                Value<double> fontScale = const Value.absent(),
+                Value<String> themeMode = const Value.absent(),
                 Value<String> cameraAspectRatio = const Value.absent(),
                 Value<String> cameraCaptureAspectRatio = const Value.absent(),
                 Value<double> cameraMinZoom = const Value.absent(),
@@ -8006,15 +8608,25 @@ class $$AppSettingsEntriesTableTableManager
                     const Value.absent(),
                 Value<String> themePalette = const Value.absent(),
                 Value<String> mapTileProvider = const Value.absent(),
+                Value<String> navigationApp = const Value.absent(),
                 Value<String> customXyzTileUrl = const Value.absent(),
                 Value<String> customMapLibreStyleUrl = const Value.absent(),
                 Value<bool> saveVisitPhotoToGallery = const Value.absent(),
                 Value<bool> comparisonShowPilgrimName = const Value.absent(),
                 Value<String> comparisonPilgrimName = const Value.absent(),
+                Value<String> customThemeColorName = const Value.absent(),
+                Value<int> customThemeColorValue = const Value.absent(),
+                Value<String> customThemeColorsJson = const Value.absent(),
+                Value<double> customCameraAspectRatioWidth =
+                    const Value.absent(),
+                Value<double> customCameraAspectRatioHeight =
+                    const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => AppSettingsEntriesCompanion.insert(
                 id: id,
                 uiScale: uiScale,
+                fontScale: fontScale,
+                themeMode: themeMode,
                 cameraAspectRatio: cameraAspectRatio,
                 cameraCaptureAspectRatio: cameraCaptureAspectRatio,
                 cameraMinZoom: cameraMinZoom,
@@ -8023,11 +8635,17 @@ class $$AppSettingsEntriesTableTableManager
                 nearestAssignDistanceMeters: nearestAssignDistanceMeters,
                 themePalette: themePalette,
                 mapTileProvider: mapTileProvider,
+                navigationApp: navigationApp,
                 customXyzTileUrl: customXyzTileUrl,
                 customMapLibreStyleUrl: customMapLibreStyleUrl,
                 saveVisitPhotoToGallery: saveVisitPhotoToGallery,
                 comparisonShowPilgrimName: comparisonShowPilgrimName,
                 comparisonPilgrimName: comparisonPilgrimName,
+                customThemeColorName: customThemeColorName,
+                customThemeColorValue: customThemeColorValue,
+                customThemeColorsJson: customThemeColorsJson,
+                customCameraAspectRatioWidth: customCameraAspectRatioWidth,
+                customCameraAspectRatioHeight: customCameraAspectRatioHeight,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/lib/data/local/sqlite_pilgrimage_repository.dart
+++ b/lib/data/local/sqlite_pilgrimage_repository.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'dart:convert';
 import 'package:latlong2/latlong.dart';
 
 import '../../plan/pilgrimage_models.dart';
@@ -50,6 +51,8 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
 
     return AppSettings(
       uiScale: row.uiScale.clamp(0.5, 2.0),
+      fontScale: row.fontScale.clamp(0.7, 1.4),
+      themeMode: _themeModeFromName(row.themeMode),
       cameraCaptureAspectRatio: _cameraAspectRatioFromName(
         row.cameraCaptureAspectRatio,
       ),
@@ -65,11 +68,23 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
       ),
       themePalette: _themePaletteFromName(row.themePalette),
       mapTileProvider: _mapTileProviderFromName(row.mapTileProvider),
+      navigationApp: _navigationAppFromName(row.navigationApp),
       customXyzTileUrl: row.customXyzTileUrl,
       customMapLibreStyleUrl: row.customMapLibreStyleUrl,
       saveVisitPhotoToGallery: row.saveVisitPhotoToGallery,
       comparisonShowPilgrimName: row.comparisonShowPilgrimName,
       comparisonPilgrimName: row.comparisonPilgrimName,
+      customThemeColorName: row.customThemeColorName,
+      customThemeColorValue: row.customThemeColorValue,
+      customThemeColors: _customThemeColorsFromJson(row.customThemeColorsJson),
+      customCameraAspectRatioWidth: row.customCameraAspectRatioWidth.clamp(
+        0.1,
+        99.0,
+      ),
+      customCameraAspectRatioHeight: row.customCameraAspectRatioHeight.clamp(
+        0.1,
+        99.0,
+      ),
     );
   }
 
@@ -818,6 +833,8 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
           AppSettingsEntriesCompanion.insert(
             id: 'default',
             uiScale: Value(settings.uiScale.clamp(0.5, 2.0)),
+            fontScale: Value(settings.fontScale.clamp(0.7, 1.4)),
+            themeMode: Value(settings.themeMode.name),
             cameraAspectRatio: Value(settings.cameraFallbackAspectRatio.name),
             cameraCaptureAspectRatio: Value(
               settings.cameraCaptureAspectRatio.name,
@@ -832,6 +849,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
             ),
             themePalette: Value(settings.themePalette.name),
             mapTileProvider: Value(settings.mapTileProvider.name),
+            navigationApp: Value(settings.navigationApp.name),
             customXyzTileUrl: Value(settings.customXyzTileUrl.trim()),
             customMapLibreStyleUrl: Value(
               settings.customMapLibreStyleUrl.trim(),
@@ -841,6 +859,21 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
               settings.comparisonShowPilgrimName,
             ),
             comparisonPilgrimName: Value(settings.comparisonPilgrimName.trim()),
+            customThemeColorName: Value(settings.customThemeColorName.trim()),
+            customThemeColorValue: Value(settings.customThemeColorValue),
+            customThemeColorsJson: Value(
+              jsonEncode(
+                settings.customThemeColors
+                    .map((color) => color.toJson())
+                    .toList(growable: false),
+              ),
+            ),
+            customCameraAspectRatioWidth: Value(
+              settings.customCameraAspectRatioWidth.clamp(0.1, 99.0),
+            ),
+            customCameraAspectRatioHeight: Value(
+              settings.customCameraAspectRatioHeight.clamp(0.1, 99.0),
+            ),
           ),
         );
   }
@@ -1344,10 +1377,39 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
     );
   }
 
+  AppThemeMode _themeModeFromName(String name) {
+    return AppThemeMode.values.firstWhere(
+      (mode) => mode.name == name,
+      orElse: () => AppThemeMode.light,
+    );
+  }
+
+  List<CustomThemeColor> _customThemeColorsFromJson(String source) {
+    try {
+      final decoded = jsonDecode(source);
+      if (decoded is! List) {
+        return const [];
+      }
+      return decoded
+          .map(CustomThemeColor.fromJson)
+          .whereType<CustomThemeColor>()
+          .toList(growable: false);
+    } catch (_) {
+      return const [];
+    }
+  }
+
   MapTileProvider _mapTileProviderFromName(String name) {
     return MapTileProvider.values.firstWhere(
       (provider) => provider.name == name,
       orElse: () => MapTileProvider.openFreeMap,
+    );
+  }
+
+  NavigationApp _navigationAppFromName(String name) {
+    return NavigationApp.values.firstWhere(
+      (app) => app.name == name,
+      orElse: () => NavigationApp.googleMaps,
     );
   }
 

--- a/lib/data/sample_pilgrimage_repository.dart
+++ b/lib/data/sample_pilgrimage_repository.dart
@@ -703,6 +703,8 @@ class SamplePilgrimageRepository implements PilgrimageRepository {
   Future<void> saveAppSettings(AppSettings settings) async {
     _settings = settings.copyWith(
       uiScale: settings.uiScale.clamp(0.5, 2.0),
+      fontScale: settings.fontScale.clamp(0.7, 1.4),
+      themeMode: settings.themeMode,
       cameraMinZoom: settings.cameraMinZoom.clamp(0.1, 20.0),
       cameraMaxZoom: settings.cameraMaxZoom.clamp(1.0, 20.0),
       referenceImageScale: settings.referenceImageScale.clamp(0.8, 1.0),
@@ -714,8 +716,20 @@ class SamplePilgrimageRepository implements PilgrimageRepository {
           settings.cameraFallbackAspectRatio == CameraPhotoAspectRatio.auto
           ? CameraPhotoAspectRatio.native
           : settings.cameraFallbackAspectRatio,
+      navigationApp: settings.navigationApp,
       customXyzTileUrl: settings.customXyzTileUrl.trim(),
       customMapLibreStyleUrl: settings.customMapLibreStyleUrl.trim(),
+      customThemeColorName: settings.customThemeColorName.trim().isEmpty
+          ? '\u81ea\u5b9a\u4e49'
+          : settings.customThemeColorName.trim(),
+      customThemeColorValue: settings.customThemeColorValue,
+      customThemeColors: settings.customThemeColors,
+      customCameraAspectRatioWidth: settings.customCameraAspectRatioWidth.clamp(
+        0.1,
+        99.0,
+      ),
+      customCameraAspectRatioHeight: settings.customCameraAspectRatioHeight
+          .clamp(0.1, 99.0),
     );
   }
 

--- a/lib/desktop/desktop_repository_state.dart
+++ b/lib/desktop/desktop_repository_state.dart
@@ -65,6 +65,8 @@ SamplePilgrimageRepositorySnapshot? decodeDesktopRepositoryState(
 Map<String, Object?> _settingsJson(AppSettings settings) {
   return {
     'uiScale': settings.uiScale,
+    'fontScale': settings.fontScale,
+    'themeMode': settings.themeMode.name,
     'cameraCaptureAspectRatio': settings.cameraCaptureAspectRatio.name,
     'cameraFallbackAspectRatio': settings.cameraFallbackAspectRatio.name,
     'cameraMinZoom': settings.cameraMinZoom,
@@ -73,17 +75,29 @@ Map<String, Object?> _settingsJson(AppSettings settings) {
     'nearestAssignDistanceMeters': settings.nearestAssignDistanceMeters,
     'themePalette': settings.themePalette.name,
     'mapTileProvider': settings.mapTileProvider.name,
+    'navigationApp': settings.navigationApp.name,
     'customXyzTileUrl': settings.customXyzTileUrl,
     'customMapLibreStyleUrl': settings.customMapLibreStyleUrl,
     'saveVisitPhotoToGallery': settings.saveVisitPhotoToGallery,
     'comparisonShowPilgrimName': settings.comparisonShowPilgrimName,
     'comparisonPilgrimName': settings.comparisonPilgrimName,
+    'customThemeColorName': settings.customThemeColorName,
+    'customThemeColorValue': settings.customThemeColorValue,
+    'customThemeColors': settings.customThemeColors
+        .map((color) => color.toJson())
+        .toList(growable: false),
+    'customCameraAspectRatioWidth': settings.customCameraAspectRatioWidth,
+    'customCameraAspectRatioHeight': settings.customCameraAspectRatioHeight,
   };
 }
 
 AppSettings _settingsFromJson(Map<String, Object?> json) {
   return AppSettings(
     uiScale: _doubleValue(json['uiScale']) ?? 1,
+    fontScale: _doubleValue(json['fontScale']) ?? 1,
+    themeMode:
+        _enumByName(AppThemeMode.values, json['themeMode']) ??
+        AppThemeMode.light,
     cameraCaptureAspectRatio:
         _enumByName(
           CameraPhotoAspectRatio.values,
@@ -107,6 +121,9 @@ AppSettings _settingsFromJson(Map<String, Object?> json) {
     mapTileProvider:
         _enumByName(MapTileProvider.values, json['mapTileProvider']) ??
         MapTileProvider.openFreeMap,
+    navigationApp:
+        _enumByName(NavigationApp.values, json['navigationApp']) ??
+        NavigationApp.googleMaps,
     customXyzTileUrl: _stringValue(json['customXyzTileUrl'], fallback: ''),
     customMapLibreStyleUrl: _stringValue(
       json['customMapLibreStyleUrl'],
@@ -120,6 +137,17 @@ AppSettings _settingsFromJson(Map<String, Object?> json) {
       json['comparisonPilgrimName'],
       fallback: '',
     ),
+    customThemeColorName: _stringValue(
+      json['customThemeColorName'],
+      fallback: '\u81ea\u5b9a\u4e49',
+    ),
+    customThemeColorValue:
+        _intValue(json['customThemeColorValue']) ?? 0xFF16C6A8,
+    customThemeColors: _customThemeColorsValue(json['customThemeColors']),
+    customCameraAspectRatioWidth:
+        _doubleValue(json['customCameraAspectRatioWidth']) ?? 1,
+    customCameraAspectRatioHeight:
+        _doubleValue(json['customCameraAspectRatioHeight']) ?? 1,
   );
 }
 
@@ -357,6 +385,16 @@ Set<String> _stringSet(Object? value) {
   return value.whereType<String>().toSet();
 }
 
+List<CustomThemeColor> _customThemeColorsValue(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value
+      .map(CustomThemeColor.fromJson)
+      .whereType<CustomThemeColor>()
+      .toList(growable: false);
+}
+
 String _stringValue(Object? value, {required String fallback}) {
   return value is String ? value : fallback;
 }
@@ -365,6 +403,14 @@ double? _doubleValue(Object? value) {
   return switch (value) {
     num number => number.toDouble(),
     String text => double.tryParse(text),
+    _ => null,
+  };
+}
+
+int? _intValue(Object? value) {
+  return switch (value) {
+    num number => number.toInt(),
+    String text => int.tryParse(text),
     _ => null,
   };
 }

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -138,7 +138,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     });
 
     try {
-      final lite = await widget.anitabiClient.fetchBangumiLite(bangumiId);
+      final lite = await _fetchBangumiLite(work);
       if (!_isActiveLoad(generation)) {
         return;
       }
@@ -189,7 +189,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     });
 
     try {
-      final lite = await widget.anitabiClient.fetchBangumiLite(bangumiId);
+      final lite = await _fetchBangumiLiteForBangumiId(bangumiId);
       if (!_isActiveLoad(generation)) {
         return;
       }
@@ -298,6 +298,51 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
         });
       }
     }
+  }
+
+  Future<AnitabiBangumiLite> _fetchBangumiLite(PilgrimageWork work) async {
+    final bangumiId = work.bangumiId;
+    if (bangumiId == null) {
+      throw const AnitabiStaticDataUnavailableException('Missing Bangumi ID');
+    }
+
+    final staticLite = await _fetchStaticBangumiLiteIfSupported(bangumiId);
+    if (staticLite != null) {
+      return staticLite;
+    }
+
+    try {
+      return await widget.anitabiClient.fetchBangumiLite(bangumiId);
+    } catch (_) {
+      return AnitabiBangumiLite(
+        bangumiId: bangumiId,
+        title: work.title,
+        subtitle: work.subtitle,
+        city: work.city,
+        center: const LatLng(35.0, 135.0),
+        zoom: 12,
+        pointsLength: 0,
+      );
+    }
+  }
+
+  Future<AnitabiBangumiLite> _fetchBangumiLiteForBangumiId(
+    int bangumiId,
+  ) async {
+    final staticLite = await _fetchStaticBangumiLiteIfSupported(bangumiId);
+    if (staticLite != null) {
+      return staticLite;
+    }
+    return widget.anitabiClient.fetchBangumiLite(bangumiId);
+  }
+
+  Future<AnitabiBangumiLite?> _fetchStaticBangumiLiteIfSupported(
+    int bangumiId,
+  ) {
+    if (widget.anitabiClient.runtimeType != AnitabiClient) {
+      return Future.value();
+    }
+    return widget.anitabiClient.fetchBangumiLiteFromStatic(bangumiId);
   }
 
   PilgrimageWork? _workForBangumiId(int bangumiId) {

--- a/lib/plan/pilgrimage_models.dart
+++ b/lib/plan/pilgrimage_models.dart
@@ -44,19 +44,57 @@ enum CameraPhotoAspectRatio {
   portrait3x4,
   portrait2x3,
   square1x1,
+  custom,
+}
+
+class CustomThemeColor {
+  const CustomThemeColor({required this.name, required this.value});
+
+  final String name;
+  final int value;
+
+  Map<String, Object?> toJson() => {'name': name, 'value': value};
+
+  static CustomThemeColor? fromJson(Object? value) {
+    if (value is! Map) {
+      return null;
+    }
+    final name = value['name'];
+    final colorValue = value['value'];
+    if (name is! String || colorValue is! num) {
+      return null;
+    }
+    final trimmedName = name.trim();
+    if (trimmedName.isEmpty) {
+      return null;
+    }
+    return CustomThemeColor(name: trimmedName, value: colorValue.toInt());
+  }
 }
 
 enum AppThemePalette {
+  classicGreen,
+  deepBlue,
+  cherryPink,
+  twilightPurple,
   miriaYellow,
-  classicGreen;
+  graphite,
+  aurora;
 
   String get label {
     return switch (this) {
-      AppThemePalette.miriaYellow => '鲜黄色',
-      AppThemePalette.classicGreen => '经典绿色',
+      AppThemePalette.classicGreen => '\u7ecf\u5178\u7eff',
+      AppThemePalette.deepBlue => '\u6df1\u9083\u84dd',
+      AppThemePalette.cherryPink => '\u6a31\u82b1\u7c89',
+      AppThemePalette.twilightPurple => '\u66ae\u5149\u7d2b',
+      AppThemePalette.miriaYellow => '\u7435\u73c0\u6a59',
+      AppThemePalette.graphite => '\u77f3\u58a8\u9ed1',
+      AppThemePalette.aurora => '\u81ea\u5b9a\u4e49',
     };
   }
 }
+
+enum AppThemeMode { light, dark, system }
 
 extension CameraPhotoAspectRatioLabel on CameraPhotoAspectRatio {
   String get label {
@@ -72,6 +110,7 @@ extension CameraPhotoAspectRatioLabel on CameraPhotoAspectRatio {
       CameraPhotoAspectRatio.portrait3x4 => '3:4',
       CameraPhotoAspectRatio.portrait2x3 => '2:3',
       CameraPhotoAspectRatio.square1x1 => '1:1',
+      CameraPhotoAspectRatio.custom => '\u81ea\u5b9a\u4e49',
     };
   }
 }
@@ -83,9 +122,31 @@ enum MapTileProvider {
   customMapLibreStyle,
 }
 
+enum NavigationApp {
+  googleMaps,
+  amap,
+  appleMaps,
+  baiduMaps,
+  tencentMaps,
+  browser;
+
+  String get label {
+    return switch (this) {
+      NavigationApp.googleMaps => 'Google Maps',
+      NavigationApp.amap => '\u9ad8\u5fb7\u5730\u56fe',
+      NavigationApp.appleMaps => 'Apple Maps',
+      NavigationApp.baiduMaps => '\u767e\u5ea6\u5730\u56fe',
+      NavigationApp.tencentMaps => '\u817e\u8baf\u5730\u56fe',
+      NavigationApp.browser => '\u6d4f\u89c8\u5668',
+    };
+  }
+}
+
 class AppSettings {
   const AppSettings({
     this.uiScale = 1,
+    this.fontScale = 1,
+    this.themeMode = AppThemeMode.light,
     this.cameraCaptureAspectRatio = CameraPhotoAspectRatio.auto,
     this.cameraFallbackAspectRatio = CameraPhotoAspectRatio.native,
     this.cameraMinZoom = 0.6,
@@ -94,14 +155,22 @@ class AppSettings {
     this.nearestAssignDistanceMeters = 350,
     this.themePalette = AppThemePalette.classicGreen,
     this.mapTileProvider = MapTileProvider.openFreeMap,
+    this.navigationApp = NavigationApp.googleMaps,
     this.customXyzTileUrl = '',
     this.customMapLibreStyleUrl = '',
     this.saveVisitPhotoToGallery = true,
     this.comparisonShowPilgrimName = false,
     this.comparisonPilgrimName = '',
+    this.customThemeColorName = '\u81ea\u5b9a\u4e49',
+    this.customThemeColorValue = 0xFF16C6A8,
+    this.customThemeColors = const [],
+    this.customCameraAspectRatioWidth = 1,
+    this.customCameraAspectRatioHeight = 1,
   });
 
   final double uiScale;
+  final double fontScale;
+  final AppThemeMode themeMode;
   final CameraPhotoAspectRatio cameraCaptureAspectRatio;
   final CameraPhotoAspectRatio cameraFallbackAspectRatio;
   final double cameraMinZoom;
@@ -110,14 +179,22 @@ class AppSettings {
   final double nearestAssignDistanceMeters;
   final AppThemePalette themePalette;
   final MapTileProvider mapTileProvider;
+  final NavigationApp navigationApp;
   final String customXyzTileUrl;
   final String customMapLibreStyleUrl;
   final bool saveVisitPhotoToGallery;
   final bool comparisonShowPilgrimName;
   final String comparisonPilgrimName;
+  final String customThemeColorName;
+  final int customThemeColorValue;
+  final List<CustomThemeColor> customThemeColors;
+  final double customCameraAspectRatioWidth;
+  final double customCameraAspectRatioHeight;
 
   AppSettings copyWith({
     double? uiScale,
+    double? fontScale,
+    AppThemeMode? themeMode,
     CameraPhotoAspectRatio? cameraCaptureAspectRatio,
     CameraPhotoAspectRatio? cameraFallbackAspectRatio,
     double? cameraMinZoom,
@@ -126,14 +203,22 @@ class AppSettings {
     double? nearestAssignDistanceMeters,
     AppThemePalette? themePalette,
     MapTileProvider? mapTileProvider,
+    NavigationApp? navigationApp,
     String? customXyzTileUrl,
     String? customMapLibreStyleUrl,
     bool? saveVisitPhotoToGallery,
     bool? comparisonShowPilgrimName,
     String? comparisonPilgrimName,
+    String? customThemeColorName,
+    int? customThemeColorValue,
+    List<CustomThemeColor>? customThemeColors,
+    double? customCameraAspectRatioWidth,
+    double? customCameraAspectRatioHeight,
   }) {
     return AppSettings(
       uiScale: uiScale ?? this.uiScale,
+      fontScale: fontScale ?? this.fontScale,
+      themeMode: themeMode ?? this.themeMode,
       cameraCaptureAspectRatio:
           cameraCaptureAspectRatio ?? this.cameraCaptureAspectRatio,
       cameraFallbackAspectRatio:
@@ -145,6 +230,7 @@ class AppSettings {
           nearestAssignDistanceMeters ?? this.nearestAssignDistanceMeters,
       themePalette: themePalette ?? this.themePalette,
       mapTileProvider: mapTileProvider ?? this.mapTileProvider,
+      navigationApp: navigationApp ?? this.navigationApp,
       customXyzTileUrl: customXyzTileUrl ?? this.customXyzTileUrl,
       customMapLibreStyleUrl:
           customMapLibreStyleUrl ?? this.customMapLibreStyleUrl,
@@ -154,6 +240,14 @@ class AppSettings {
           comparisonShowPilgrimName ?? this.comparisonShowPilgrimName,
       comparisonPilgrimName:
           comparisonPilgrimName ?? this.comparisonPilgrimName,
+      customThemeColorName: customThemeColorName ?? this.customThemeColorName,
+      customThemeColorValue:
+          customThemeColorValue ?? this.customThemeColorValue,
+      customThemeColors: customThemeColors ?? this.customThemeColors,
+      customCameraAspectRatioWidth:
+          customCameraAspectRatioWidth ?? this.customCameraAspectRatioWidth,
+      customCameraAspectRatioHeight:
+          customCameraAspectRatioHeight ?? this.customCameraAspectRatioHeight,
     );
   }
 }

--- a/lib/records/visit_record_detail_screen.dart
+++ b/lib/records/visit_record_detail_screen.dart
@@ -121,62 +121,16 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
                 label: '拍摄时间',
                 value: _formatDateTime(_record.capturedAt),
               ),
-              _DetailRow(
-                icon: Icons.layers_outlined,
-                label: '参考模式',
-                value: _record.referenceMode,
-              ),
-              _DetailRow(
-                icon: Icons.photo_outlined,
-                label: _record.hasColorGrading ? '显示照片' : '照片路径',
-                value: _record.displayPhotoPath,
-              ),
-              if (_record.hasColorGrading)
-                _DetailRow(
-                  icon: Icons.photo_library_outlined,
-                  label: '原图',
-                  value: _record.sourcePhotoPath,
-                ),
-              if (referenceImagePath != null || referenceImageUrl != null)
-                _DetailRow(
-                  icon: Icons.image_outlined,
-                  label: '参考图',
-                  value: referenceImagePath ?? referenceImageUrl!,
-                ),
               if (resolvedPoint != null) ...[
-                _DetailRow(
-                  icon: Icons.flag_outlined,
-                  label: '状态',
-                  value: _statusLabel(
-                    widget.controller.statusFor(resolvedPoint),
-                  ),
-                ),
                 _DetailRow(
                   icon: Icons.grid_view_outlined,
                   label: '片区',
                   value: _groupName(resolvedPoint, group),
                 ),
                 _DetailRow(
-                  icon: Icons.adjust_outlined,
-                  label: '关键点',
-                  value: _groupAnchorLabel(group),
-                ),
-                _DetailRow(
-                  icon: Icons.movie_filter_outlined,
-                  label: '作品',
-                  value:
-                      '${resolvedPoint.work.title} / ${resolvedPoint.work.subtitle}',
-                ),
-                _DetailRow(
                   icon: Icons.local_movies_outlined,
                   label: '场景',
                   value: resolvedPoint.displayEpisodeLabel,
-                ),
-                _DetailRow(
-                  icon: Icons.location_on_outlined,
-                  label: '坐标',
-                  value:
-                      '${resolvedPoint.position.latitude.toStringAsFixed(5)}, ${resolvedPoint.position.longitude.toStringAsFixed(5)}',
                 ),
               ],
             ],
@@ -399,22 +353,6 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
       return '未分组';
     }
     return group?.name ?? '未知片区';
-  }
-
-  String _groupAnchorLabel(PilgrimagePlanGroup? group) {
-    final anchorName = group?.anchorName;
-    if (anchorName == null || anchorName.trim().isEmpty) {
-      return '未设置关键点';
-    }
-    return anchorName;
-  }
-
-  String _statusLabel(VisitStatus status) {
-    return switch (status) {
-      VisitStatus.current => '当前目标',
-      VisitStatus.completed => '已完成',
-      VisitStatus.pending => '待访问',
-    };
   }
 
   String? _colorGradingSummary() {

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -1,9 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
-import '../app_version.dart';
 import '../app_theme.dart';
+import '../app_version.dart';
 import '../camera_reference/camera_zoom_capabilities.dart';
+import '../data/pilgrimage_repository.dart';
 import '../desktop/tauri_bridge.dart';
 import '../map/map_tile_config.dart';
 import '../plan/pilgrimage_models.dart';
@@ -12,11 +13,13 @@ import '../widgets/copyable_text.dart';
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({
     required this.settings,
+    required this.repository,
     required this.onChanged,
     super.key,
   });
 
   final AppSettings settings;
+  final PilgrimageRepository repository;
   final ValueChanged<AppSettings> onChanged;
 
   @override
@@ -76,512 +79,216 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final settings = widget.settings;
-    final onChanged = widget.onChanged;
-    final zoomRangeMin = _zoomCapabilities.minZoom;
-    final zoomRangeMax = _zoomCapabilities.maxZoom.clamp(
-      zoomRangeMin,
-      cameraZoomUpperLimit,
-    );
-    final cameraMinZoom = settings.cameraMinZoom.clamp(
-      zoomRangeMin,
-      zoomRangeMax,
-    );
-    final cameraMaxZoom = settings.cameraMaxZoom.clamp(
-      cameraMinZoom,
-      zoomRangeMax,
-    );
-    final zoomSliderValues = RangeValues(
-      cameraZoomSliderValueFromRealZoom(
-        minZoom: zoomRangeMin,
-        maxZoom: zoomRangeMax,
-        realZoom: cameraMinZoom,
-      ),
-      cameraZoomSliderValueFromRealZoom(
-        minZoom: zoomRangeMin,
-        maxZoom: zoomRangeMax,
-        realZoom: cameraMaxZoom,
-      ),
-    );
 
     return Scaffold(
-      appBar: AppBar(title: const Text('设置')),
+      appBar: AppBar(
+        title: const Text(
+          '设置',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
+        ),
+        actions: [
+          IconButton(
+            tooltip: '恢复初始设置',
+            onPressed: _confirmResetSettings,
+            icon: const Icon(Icons.restart_alt_outlined),
+          ),
+        ],
+      ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         children: [
-          _SettingsSection(
-            title: '显示',
-            children: [
-              Row(
-                children: [
-                  const Icon(
-                    Icons.palette_outlined,
-                    color: AppColors.textSecondary,
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Text(
-                      '主题色 ${settings.themePalette.label}',
-                      style: const TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 10),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: AppThemePalette.values
-                    .map((palette) {
-                      final selected = settings.themePalette == palette;
-                      return ChoiceChip(
-                        label: Text(palette.label),
-                        avatar: _ThemeSwatch(palette: palette),
-                        selected: selected,
-                        onSelected: (_) {
-                          onChanged(settings.copyWith(themePalette: palette));
-                        },
-                      );
-                    })
-                    .toList(growable: false),
-              ),
-              const SizedBox(height: 18),
-              Row(
-                children: [
-                  const Icon(
-                    Icons.zoom_out_map_outlined,
-                    color: AppColors.textSecondary,
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Text(
-                      '页面缩放 ${(settings.uiScale * 100).round()}%',
-                      style: const TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              Slider(
-                min: 0.5,
-                max: 2,
-                divisions: 30,
-                value: settings.uiScale.clamp(0.5, 2.0),
-                label: '${(settings.uiScale * 100).round()}%',
-                onChanged: (value) {
-                  onChanged(settings.copyWith(uiScale: value));
-                },
-              ),
-              const SizedBox(height: 8),
-              Row(
-                children: [
-                  const Icon(
-                    Icons.zoom_in_outlined,
-                    color: AppColors.textSecondary,
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Text(
-                      '相机缩放 ${settings.cameraMinZoom.toStringAsFixed(1)}x - ${settings.cameraMaxZoom.toStringAsFixed(1)}x',
-                      style: const TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              RangeSlider(
-                min: 0,
-                max: 1,
-                divisions: 200,
-                values: zoomSliderValues,
-                labels: RangeLabels(
-                  '${cameraMinZoom.toStringAsFixed(1)}x',
-                  '${cameraMaxZoom.toStringAsFixed(1)}x',
+          _SettingsCard(
+            header: _SettingsCardHeader(
+              icon: Icons.palette_outlined,
+              title: '外观设置',
+              subtitle: '主题色、缩放、显示等',
+              onTap: () => _pushDetail(
+                _AppearanceSettingsPage(
+                  settings: settings,
+                  onChanged: widget.onChanged,
                 ),
-                onChanged: (values) {
-                  final minZoom = realZoomFromCameraSliderValue(
-                    minZoom: zoomRangeMin,
-                    maxZoom: zoomRangeMax,
-                    sliderValue: values.start,
-                  ).snapToZoomStep();
-                  final maxZoom = realZoomFromCameraSliderValue(
-                    minZoom: zoomRangeMin,
-                    maxZoom: zoomRangeMax,
-                    sliderValue: values.end,
-                  ).snapToZoomStep();
-                  onChanged(
-                    settings.copyWith(
-                      cameraMinZoom: minZoom.clamp(zoomRangeMin, zoomRangeMax),
-                      cameraMaxZoom: maxZoom.clamp(minZoom, zoomRangeMax),
+              ),
+            ),
+            children: [
+              _SummaryGrid(
+                children: [
+                  _SummaryTile(
+                    icon: Icons.circle,
+                    title: '主题色',
+                    value: settings.themePalette.label,
+                    swatch: _ThemeSwatch(
+                      palette: settings.themePalette,
+                      customColorValue: settings.customThemeColorValue,
                     ),
+                    onTap: () => _pushDetail(
+                      _AppearanceSettingsPage(
+                        settings: settings,
+                        onChanged: widget.onChanged,
+                      ),
+                    ),
+                  ),
+                  _SummaryTile(
+                    icon: Icons.zoom_out_map_outlined,
+                    title: '页面缩放',
+                    value: '${(settings.uiScale * 100).round()}%',
+                    onTap: () => _pushDetail(
+                      _AppearanceSettingsPage(
+                        settings: settings,
+                        onChanged: widget.onChanged,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _SettingsCard(
+            header: _SettingsCardHeader(
+              icon: Icons.photo_camera_outlined,
+              title: '拍摄设置',
+              subtitle: '照片比例、参考图比例、备份等',
+              onTap: () => _pushDetail(
+                _CameraSettingsPage(
+                  settings: settings,
+                  onChanged: widget.onChanged,
+                  zoomCapabilities: _zoomCapabilities,
+                ),
+              ),
+            ),
+            children: [
+              _SummaryGrid(
+                children: [
+                  _SummaryTile(
+                    icon: Icons.crop_outlined,
+                    title: '拍摄图片比例',
+                    value: settings.cameraCaptureAspectRatio.label,
+                    onTap: () => _pushDetail(
+                      _CameraSettingsPage(
+                        settings: settings,
+                        onChanged: widget.onChanged,
+                        zoomCapabilities: _zoomCapabilities,
+                      ),
+                    ),
+                  ),
+                  _SummaryTile(
+                    icon: Icons.view_sidebar_outlined,
+                    title: '相机缩放',
+                    value:
+                        '${settings.cameraMinZoom.toStringAsFixed(1)}x-${settings.cameraMaxZoom.toStringAsFixed(1)}x',
+                    onTap: () => _pushDetail(
+                      _CameraSettingsPage(
+                        settings: settings,
+                        onChanged: widget.onChanged,
+                        zoomCapabilities: _zoomCapabilities,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const _SettingsDivider(),
+              _SummarySwitchTile(
+                icon: Icons.cloud_upload_outlined,
+                title: '照片备份',
+                subtitle: '保存巡礼照片到相册',
+                value: settings.saveVisitPhotoToGallery,
+                onChanged: (value) {
+                  widget.onChanged(
+                    settings.copyWith(saveVisitPhotoToGallery: value),
                   );
                 },
               ),
-              const SizedBox(height: 8),
-              Row(
-                children: [
-                  const Icon(
-                    Icons.photo_size_select_large_outlined,
-                    color: AppColors.textSecondary,
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Text(
-                      '参考图显示 ${(settings.referenceImageScale * 100).round()}%',
-                      style: const TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              Slider(
-                min: 0.8,
-                max: 1,
-                divisions: 20,
-                value: settings.referenceImageScale.clamp(0.8, 1.0),
-                label: '${(settings.referenceImageScale * 100).round()}%',
-                onChanged: (value) {
-                  onChanged(settings.copyWith(referenceImageScale: value));
-                },
-              ),
             ],
           ),
           const SizedBox(height: 12),
-          _SettingsSection(
-            title: '拍摄图片比例',
-            children: [
-              const Text(
-                '自动会优先跟随参考图比例；选择固定比例后会按该比例拍摄。',
-                style: TextStyle(
-                  color: AppColors.textSecondary,
-                  fontSize: 13,
-                  letterSpacing: 0,
+          _SettingsCard(
+            header: _SettingsCardHeader(
+              icon: Icons.map_outlined,
+              title: '\u5730\u56fe\u4e0e\u5bfc\u822a\u8bbe\u7f6e',
+              subtitle:
+                  '\u5730\u56fe\u6e90\u3001\u6837\u5f0f\u3001\u5bfc\u822a\u8f6f\u4ef6\u7b49',
+              onTap: () => _pushDetail(
+                _MapSettingsPage(
+                  settings: settings,
+                  onChanged: widget.onChanged,
+                  showMapUrlDialog: _showMapUrlDialog,
                 ),
               ),
-              const SizedBox(height: 10),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children:
-                    [
-                          CameraPhotoAspectRatio.auto,
-                          ..._cameraAspectRatioGroup(
-                            includePortrait: true,
-                            includeSquare: false,
-                          ),
-                        ]
-                        .map((ratio) {
-                          final selected =
-                              settings.cameraCaptureAspectRatio == ratio;
-                          return ChoiceChip(
-                            label: Text(ratio.label),
-                            selected: selected,
-                            onSelected: (_) {
-                              onChanged(
-                                settings.copyWith(
-                                  cameraCaptureAspectRatio: ratio,
-                                ),
-                              );
-                            },
-                          );
-                        })
-                        .toList(growable: false),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          _SettingsSection(
-            title: '无参考图时比例',
-            children: [
-              const Text(
-                '拍摄图片比例为自动、且没有参考图可对齐时使用。',
-                style: TextStyle(
-                  color: AppColors.textSecondary,
-                  fontSize: 13,
-                  letterSpacing: 0,
-                ),
-              ),
-              const SizedBox(height: 10),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children:
-                    [
-                          CameraPhotoAspectRatio.native,
-                          ..._cameraAspectRatioGroup(
-                            includePortrait: true,
-                            includeSquare: false,
-                          ),
-                        ]
-                        .map((ratio) {
-                          final selected =
-                              settings.cameraFallbackAspectRatio == ratio;
-                          return ChoiceChip(
-                            label: Text(ratio.label),
-                            selected: selected,
-                            onSelected: (_) {
-                              onChanged(
-                                settings.copyWith(
-                                  cameraFallbackAspectRatio: ratio,
-                                ),
-                              );
-                            },
-                          );
-                        })
-                        .toList(growable: false),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          if (_shouldShowGalleryBackupOption) ...[
-            _SettingsSection(
-              title: '照片备份',
-              children: [
-                SwitchListTile(
-                  contentPadding: EdgeInsets.zero,
-                  secondary: const Icon(
-                    Icons.photo_library_outlined,
-                    color: AppColors.textSecondary,
-                  ),
-                  title: const Text(
-                    '保存巡礼照片到相册',
-                    style: TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.w800,
-                      letterSpacing: 0,
-                    ),
-                  ),
-                  subtitle: const Text(
-                    '保存记录时同时备份一张巡礼照片。',
-                    style: TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 13,
-                      letterSpacing: 0,
-                    ),
-                  ),
-                  value: settings.saveVisitPhotoToGallery,
-                  onChanged: (value) {
-                    onChanged(
-                      settings.copyWith(saveVisitPhotoToGallery: value),
-                    );
-                  },
-                ),
-              ],
             ),
-            const SizedBox(height: 12),
-          ],
-          _SettingsSection(
-            title: '地图',
-            children: [
-              Row(
-                children: [
-                  const Icon(
-                    Icons.map_outlined,
-                    color: AppColors.textSecondary,
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Text(
-                      '地图源 ${mapTileProviderOption(settings.mapTileProvider).label}',
-                      style: const TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ),
-                ],
+          ),
+          const SizedBox(height: 12),
+          _SettingsCard(
+            header: _SettingsCardHeader(
+              icon: Icons.cleaning_services_outlined,
+              title: '清除缓存',
+              subtitle: '完整参考图缓存',
+              onTap: () => _pushDetail(
+                _CacheCleanupSettingsPage(repository: widget.repository),
               ),
-              const SizedBox(height: 10),
-              Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: mapTileProviderOptions
-                    .map((option) {
-                      final selected =
-                          settings.mapTileProvider == option.provider;
-                      return ChoiceChip(
-                        label: Text(option.label),
-                        selected: selected,
-                        onSelected: (_) {
-                          onChanged(
-                            settings.copyWith(mapTileProvider: option.provider),
-                          );
-                        },
-                      );
-                    })
-                    .toList(growable: false),
-              ),
-              const SizedBox(height: 10),
-              Text(
-                mapTileProviderOption(settings.mapTileProvider).description,
-                style: const TextStyle(
-                  color: AppColors.textSecondary,
-                  fontSize: 13,
-                  letterSpacing: 0,
-                ),
-              ),
-              if (settings.mapTileProvider == MapTileProvider.customXyz) ...[
-                const SizedBox(height: 12),
-                _MapUrlRow(
-                  icon: Icons.grid_3x3_outlined,
-                  label: settings.customXyzTileUrl.trim().isEmpty
-                      ? '未设置自定义 XYZ URL'
-                      : settings.customXyzTileUrl.trim(),
-                  onTap: () => _showMapUrlDialog(
-                    title: '自定义 XYZ URL',
-                    initialValue: settings.customXyzTileUrl,
-                    helperText: 'URL 需要包含 {z}、{x}、{y}。',
-                    validator: (value) =>
-                        isValidXyzTileUrl(value.trim()) ? null : 'URL 格式无效',
-                    onSaved: (value) {
-                      onChanged(
-                        settings.copyWith(customXyzTileUrl: value.trim()),
-                      );
-                    },
-                  ),
-                ),
-              ],
-              if (settings.mapTileProvider ==
-                  MapTileProvider.customMapLibreStyle) ...[
-                const SizedBox(height: 12),
-                _MapUrlRow(
-                  icon: Icons.data_object_outlined,
-                  label: settings.customMapLibreStyleUrl.trim().isEmpty
-                      ? '未设置 MapLibre style URL'
-                      : settings.customMapLibreStyleUrl.trim(),
-                  onTap: () => _showMapUrlDialog(
-                    title: 'MapLibre style URL',
-                    initialValue: settings.customMapLibreStyleUrl,
-                    helperText: 'URL 需要指向可公开读取的 style JSON。',
-                    validator: (value) {
-                      final testSettings = settings.copyWith(
-                        customMapLibreStyleUrl: value.trim(),
-                      );
-                      return validateMapTileSettings(testSettings);
-                    },
-                    onSaved: (value) {
-                      onChanged(
-                        settings.copyWith(customMapLibreStyleUrl: value.trim()),
-                      );
-                    },
-                  ),
-                ),
-              ],
-              if (validateMapTileSettings(settings) != null) ...[
-                const SizedBox(height: 10),
-                _InfoRow(
-                  icon: Icons.error_outline,
-                  text: validateMapTileSettings(settings)!,
-                ),
-              ],
-            ],
+            ),
           ),
           const SizedBox(height: 12),
           if (_shouldShowDesktopSection) ...[
-            _SettingsSection(
-              title: '桌面端',
-              children: [
-                _InfoRow(
-                  icon: Icons.desktop_windows_outlined,
-                  text: _desktopLauncherStatusText,
+            _SettingsCard(
+              header: _SettingsCardHeader(
+                icon: Icons.desktop_windows_outlined,
+                title: '桌面端',
+                subtitle: '启动器、数据目录等',
+                onTap: () => _pushDetail(
+                  _DesktopSettingsPage(
+                    desktopLauncherInfo: _desktopLauncherInfo,
+                    desktopLauncherStatusText: _desktopLauncherStatusText,
+                  ),
                 ),
-                if (_desktopLauncherInfo != null) ...[
-                  const SizedBox(height: 10),
-                  _InfoRow(
-                    icon: Icons.folder_outlined,
-                    text: _desktopLauncherInfo!.dataDir,
-                  ),
-                  const SizedBox(height: 10),
-                  _InfoRow(
-                    icon: Icons.inventory_2_outlined,
-                    text: _desktopLauncherInfo!.assetsDir,
-                  ),
-                ],
-              ],
+              ),
             ),
             const SizedBox(height: 12),
           ],
-          _SettingsSection(
-            title: '关于',
-            children: [
-              const Row(
-                children: [
-                  _AppIconMark(),
-                  SizedBox(width: 12),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        CopyableText(
-                          text: 'MiriaGo',
-                          copyLabel: 'MiriaGo',
-                          style: TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.w900,
-                            letterSpacing: 0,
-                          ),
-                        ),
-                        SizedBox(height: 3),
-                        Text(
-                          '动漫圣地巡礼计划与拍摄参考工具',
-                          style: TextStyle(
-                            color: AppColors.textSecondary,
-                            fontSize: 13,
-                            letterSpacing: 0,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
+          _SettingsCard(
+            header: _SettingsCardHeader(
+              icon: Icons.info_outline,
+              title: '关于 MiriaGo',
+              subtitle: '版本信息、开源许可等',
+              onTap: () => _pushDetail(
+                _AboutSettingsPage(appVersionLabel: _appVersionLabel),
               ),
-              const SizedBox(height: 14),
-              _InfoRow(
-                icon: Icons.new_releases_outlined,
-                text: '版本 ${_appVersionLabel ?? '读取中'}',
-              ),
-              const SizedBox(height: 10),
-              const _InfoRow(icon: Icons.person_outline, text: 'BilyHurington'),
-              const SizedBox(height: 10),
-              const _InfoRow(
-                icon: Icons.mail_outline,
-                text: 'bilyhurington@gmail.com',
-              ),
-              const SizedBox(height: 10),
-              const _InfoRow(
-                icon: Icons.code_outlined,
-                text: 'github.com/BilyHurington/MiriaGo',
-              ),
-              const SizedBox(height: 10),
-              const _InfoRow(icon: Icons.balance_outlined, text: 'MIT License'),
-              const SizedBox(height: 12),
-              const Text(
-                '地图可使用 OpenFreeMap、OpenStreetMap 或自定义服务；作品搜索使用 Bangumi；巡礼点位与参考图来自 Anitabi。第三方数据、截图和图片版权归原平台、贡献者或权利方所有。',
-                style: TextStyle(
-                  color: AppColors.textSecondary,
-                  fontSize: 13,
-                  height: 1.45,
-                  letterSpacing: 0,
-                ),
-              ),
-            ],
+            ),
           ),
         ],
       ),
     );
+  }
+
+  Future<void> _pushDetail(Widget page) {
+    return Navigator.of(
+      context,
+    ).push(MaterialPageRoute<void>(builder: (_) => page));
+  }
+
+  Future<void> _confirmResetSettings() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('恢复初始设置'),
+          content: const Text('所有外观、拍摄和地图设置将恢复为默认值。'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('恢复'),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) {
+      return;
+    }
+    widget.onChanged(const AppSettings());
   }
 
   String get _desktopLauncherStatusText {
@@ -603,14 +310,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   bool get _shouldShowDesktopSection => kIsWeb;
-
-  bool get _shouldShowGalleryBackupOption {
-    if (kIsWeb) {
-      return false;
-    }
-    return defaultTargetPlatform == TargetPlatform.android ||
-        defaultTargetPlatform == TargetPlatform.iOS;
-  }
 
   Future<void> _showMapUrlDialog({
     required String title,
@@ -665,27 +364,1235 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 }
 
-List<CameraPhotoAspectRatio> _cameraAspectRatioGroup({
-  required bool includePortrait,
-  required bool includeSquare,
-}) {
-  return [
-    CameraPhotoAspectRatio.landscape16x9,
-    CameraPhotoAspectRatio.cinema21x9,
-    CameraPhotoAspectRatio.standard4x3,
-    CameraPhotoAspectRatio.photo3x2,
-    if (includePortrait) ...[
-      CameraPhotoAspectRatio.portrait9x16,
-      CameraPhotoAspectRatio.portrait9x21,
-      CameraPhotoAspectRatio.portrait3x4,
-      CameraPhotoAspectRatio.portrait2x3,
-    ],
-    if (includeSquare) CameraPhotoAspectRatio.square1x1,
+class _AppearanceSettingsPage extends StatefulWidget {
+  const _AppearanceSettingsPage({
+    required this.settings,
+    required this.onChanged,
+  });
+
+  final AppSettings settings;
+  final ValueChanged<AppSettings> onChanged;
+
+  @override
+  State<_AppearanceSettingsPage> createState() =>
+      _AppearanceSettingsPageState();
+}
+
+class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
+  late AppSettings _settings;
+  static const _visibleThemePalettes = [
+    AppThemePalette.classicGreen,
+    AppThemePalette.deepBlue,
+    AppThemePalette.cherryPink,
+    AppThemePalette.graphite,
   ];
+
+  @override
+  void initState() {
+    super.initState();
+    _settings = widget.settings;
+  }
+
+  void _update(AppSettings settings) {
+    setState(() {
+      _settings = settings;
+    });
+    widget.onChanged(settings);
+  }
+
+  Future<void> _showCustomThemeColorDialog() async {
+    final result = await showDialog<CustomThemeColor>(
+      context: context,
+      builder: (context) => _CustomThemeColorDialog(settings: _settings),
+    );
+    if (result == null) {
+      return;
+    }
+
+    final colors = [
+      ..._settings.customThemeColors.where(
+        (color) => color.name != result.name && color.value != result.value,
+      ),
+      result,
+    ];
+    _update(
+      _settings.copyWith(
+        themePalette: AppThemePalette.aurora,
+        customThemeColorName: result.name,
+        customThemeColorValue: result.value,
+        customThemeColors: colors,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = _settings;
+    final uiScale = settings.uiScale.clamp(0.8, 1.2);
+    final fontScale = settings.fontScale.clamp(0.8, 1.2);
+    AppColors.palette = settings.themePalette;
+    AppColors.customAccentValue = settings.customThemeColorValue;
+
+    return Theme(
+      data: AppTheme.light(
+        palette: settings.themePalette,
+        customAccentValue: settings.customThemeColorValue,
+      ),
+      child: _ScaledDetailScaffold(
+        title: '\u5916\u89c2\u8bbe\u7f6e',
+        uiScale: settings.uiScale,
+        fontScale: settings.fontScale,
+        children: [
+          _AppearancePanel(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const _InlineSectionTitle(
+                  title: '\u4e3b\u9898\u8272',
+                  subtitle: '\u5f71\u54cd\u5e94\u7528\u6574\u4f53\u914d\u8272',
+                ),
+                const SizedBox(height: 16),
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      for (final palette in _visibleThemePalettes)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 18),
+                          child: _ThemeColorOption(
+                            palette: palette,
+                            selected:
+                                settings.themePalette == palette &&
+                                palette != AppThemePalette.aurora,
+                            onTap: () {
+                              _update(settings.copyWith(themePalette: palette));
+                            },
+                          ),
+                        ),
+                      for (final color in settings.customThemeColors)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 18),
+                          child: _CustomThemeColorOption(
+                            color: color,
+                            selected:
+                                settings.themePalette ==
+                                    AppThemePalette.aurora &&
+                                settings.customThemeColorValue == color.value,
+                            onTap: () {
+                              _update(
+                                settings.copyWith(
+                                  themePalette: AppThemePalette.aurora,
+                                  customThemeColorName: color.name,
+                                  customThemeColorValue: color.value,
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      Padding(
+                        padding: const EdgeInsets.only(right: 4),
+                        child: _AddThemeColorOption(
+                          selected:
+                              settings.themePalette == AppThemePalette.aurora,
+                          colorValue: settings.customThemeColorValue,
+                          label: settings.customThemeColorName,
+                          onTap: _showCustomThemeColorDialog,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 22),
+                const Text('\u4e3b\u9898\u6a21\u5f0f', style: _titleTextStyle),
+                const SizedBox(height: 10),
+                Row(
+                  children: [
+                    Expanded(
+                      child: _ModeButton(
+                        icon: Icons.wb_sunny_outlined,
+                        label: '\u6d45\u8272\u6a21\u5f0f',
+                        selected: settings.themeMode == AppThemeMode.light,
+                        onTap: () {
+                          _update(
+                            settings.copyWith(themeMode: AppThemeMode.light),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: _ModeButton(
+                        icon: Icons.dark_mode_outlined,
+                        label: '\u6df1\u8272\u6a21\u5f0f',
+                        selected: settings.themeMode == AppThemeMode.dark,
+                        onTap: () {
+                          _update(
+                            settings.copyWith(themeMode: AppThemeMode.dark),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: _ModeButton(
+                        icon: Icons.phone_iphone_outlined,
+                        label: '\u8ddf\u968f\u7cfb\u7edf',
+                        selected: settings.themeMode == AppThemeMode.system,
+                        onTap: () {
+                          _update(
+                            settings.copyWith(themeMode: AppThemeMode.system),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 14),
+          _AppearancePanel(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Icon(
+                      Icons.fit_screen_outlined,
+                      color: AppColors.textSecondary,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 8),
+                    const Expanded(
+                      child: Text(
+                        '\u9875\u9762\u7f29\u653e',
+                        style: _titleTextStyle,
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Text(
+                      '${(uiScale * 100).round()}%',
+                      style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w900,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                const Padding(
+                  padding: EdgeInsets.only(left: 28, right: 8),
+                  child: Text(
+                    '\u8c03\u6574\u754c\u9762\u6574\u4f53\u5927\u5c0f\uff08\u4e0d\u5f71\u54cd\u53c2\u8003\u56fe\uff09',
+                    style: _captionTextStyle,
+                  ),
+                ),
+                const SizedBox(height: 14),
+                _PercentScaleControl(
+                  value: uiScale,
+                  min: 0.8,
+                  max: 1.2,
+                  divisions: 4,
+                  tickLabels: const ['80%', '90%', '100%', '110%', '120%'],
+                  showStepper: false,
+                  onChanged: (value) {
+                    _update(settings.copyWith(uiScale: value));
+                  },
+                ),
+                const SizedBox(height: 18),
+                Row(
+                  children: [
+                    const Text('Aa', style: _titleTextStyle),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Row(
+                        children: [
+                          _FontSizeButton(
+                            label: '\u5c0f',
+                            selected: fontScale <= 0.9,
+                            onTap: () =>
+                                _update(settings.copyWith(fontScale: 0.9)),
+                          ),
+                          const SizedBox(width: 10),
+                          _FontSizeButton(
+                            label: '\u6807\u51c6',
+                            selected: fontScale > 0.9 && fontScale < 1.1,
+                            onTap: () =>
+                                _update(settings.copyWith(fontScale: 1)),
+                          ),
+                          const SizedBox(width: 10),
+                          _FontSizeButton(
+                            label: '\u5927',
+                            selected: fontScale >= 1.1 && fontScale < 1.2,
+                            onTap: () =>
+                                _update(settings.copyWith(fontScale: 1.1)),
+                          ),
+                          const SizedBox(width: 10),
+                          _FontSizeButton(
+                            label: '\u7279\u5927',
+                            selected: fontScale >= 1.2,
+                            onTap: () =>
+                                _update(settings.copyWith(fontScale: 1.2)),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CameraSettingsPage extends StatefulWidget {
+  const _CameraSettingsPage({
+    required this.settings,
+    required this.onChanged,
+    required this.zoomCapabilities,
+  });
+
+  final AppSettings settings;
+  final ValueChanged<AppSettings> onChanged;
+  final CameraZoomCapabilities zoomCapabilities;
+
+  @override
+  State<_CameraSettingsPage> createState() => _CameraSettingsPageState();
+}
+
+class _CameraSettingsPageState extends State<_CameraSettingsPage> {
+  late AppSettings _settings;
+
+  @override
+  void initState() {
+    super.initState();
+    _settings = widget.settings;
+  }
+
+  void _update(AppSettings settings) {
+    setState(() {
+      _settings = settings;
+    });
+    widget.onChanged(settings);
+  }
+
+  Future<void> _showCustomAspectRatioDialog({
+    required bool fallbackRatio,
+  }) async {
+    final result = await showDialog<({double width, double height})>(
+      context: context,
+      builder: (context) => _CustomAspectRatioDialog(settings: _settings),
+    );
+    if (result == null) {
+      return;
+    }
+
+    final updated = _settings.copyWith(
+      customCameraAspectRatioWidth: result.width,
+      customCameraAspectRatioHeight: result.height,
+      cameraCaptureAspectRatio: fallbackRatio
+          ? _settings.cameraCaptureAspectRatio
+          : CameraPhotoAspectRatio.custom,
+      cameraFallbackAspectRatio: fallbackRatio
+          ? CameraPhotoAspectRatio.custom
+          : _settings.cameraFallbackAspectRatio,
+    );
+    _update(updated);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = _settings;
+    final zoomRangeMin = widget.zoomCapabilities.minZoom;
+    final zoomRangeMax = widget.zoomCapabilities.maxZoom.clamp(
+      zoomRangeMin,
+      cameraZoomUpperLimit,
+    );
+    final cameraMinZoom = settings.cameraMinZoom.clamp(
+      zoomRangeMin,
+      zoomRangeMax,
+    );
+    final cameraMaxZoom = settings.cameraMaxZoom.clamp(
+      cameraMinZoom,
+      zoomRangeMax,
+    );
+    final zoomSliderValues = RangeValues(
+      cameraZoomSliderValueFromRealZoom(
+        minZoom: zoomRangeMin,
+        maxZoom: zoomRangeMax,
+        realZoom: cameraMinZoom,
+      ),
+      cameraZoomSliderValueFromRealZoom(
+        minZoom: zoomRangeMin,
+        maxZoom: zoomRangeMax,
+        realZoom: cameraMaxZoom,
+      ),
+    );
+
+    return _ScaledDetailScaffold(
+      title: '拍摄设置',
+      uiScale: settings.uiScale,
+      fontScale: settings.fontScale,
+      children: [
+        _SettingsSection(
+          title: '\u62cd\u6444\u56fe\u7247\u6bd4\u4f8b',
+          children: [
+            const Text(
+              '\u81ea\u52a8\u4f1a\u4f18\u5148\u8ddf\u968f\u53c2\u8003\u56fe\u6bd4\u4f8b\uff1b\u9009\u62e9\u56fa\u5b9a\u6bd4\u4f8b\u540e\u4f1a\u6309\u8be5\u6bd4\u4f8b\u62cd\u6444\u3002',
+              style: _secondaryTextStyle,
+            ),
+            const SizedBox(height: 10),
+            _AspectRatioGrid(
+              ratios: const [
+                CameraPhotoAspectRatio.auto,
+                CameraPhotoAspectRatio.landscape16x9,
+                CameraPhotoAspectRatio.cinema21x9,
+                CameraPhotoAspectRatio.standard4x3,
+                CameraPhotoAspectRatio.photo3x2,
+                CameraPhotoAspectRatio.square1x1,
+                CameraPhotoAspectRatio.portrait9x16,
+                CameraPhotoAspectRatio.portrait9x21,
+                CameraPhotoAspectRatio.portrait3x4,
+                CameraPhotoAspectRatio.portrait2x3,
+              ],
+              selectedRatio: settings.cameraCaptureAspectRatio,
+              onSelected: (ratio) {
+                _update(settings.copyWith(cameraCaptureAspectRatio: ratio));
+              },
+              customSelected:
+                  settings.cameraCaptureAspectRatio ==
+                  CameraPhotoAspectRatio.custom,
+              onCustomSelected: () =>
+                  _showCustomAspectRatioDialog(fallbackRatio: false),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _SettingsSection(
+          title: '\u65e0\u53c2\u8003\u56fe\u65f6\u6bd4\u4f8b',
+          children: [
+            const Text(
+              '\u62cd\u6444\u56fe\u7247\u6bd4\u4f8b\u4e3a\u81ea\u52a8\u3001\u4e14\u6ca1\u6709\u53c2\u8003\u56fe\u53ef\u5bf9\u9f50\u65f6\u4f7f\u7528\u3002',
+              style: _secondaryTextStyle,
+            ),
+            const SizedBox(height: 10),
+            _AspectRatioGrid(
+              ratios: const [
+                CameraPhotoAspectRatio.native,
+                CameraPhotoAspectRatio.landscape16x9,
+                CameraPhotoAspectRatio.cinema21x9,
+                CameraPhotoAspectRatio.standard4x3,
+                CameraPhotoAspectRatio.photo3x2,
+                CameraPhotoAspectRatio.square1x1,
+                CameraPhotoAspectRatio.portrait9x16,
+                CameraPhotoAspectRatio.portrait9x21,
+                CameraPhotoAspectRatio.portrait3x4,
+                CameraPhotoAspectRatio.portrait2x3,
+              ],
+              selectedRatio: settings.cameraFallbackAspectRatio,
+              onSelected: (ratio) {
+                _update(settings.copyWith(cameraFallbackAspectRatio: ratio));
+              },
+              customSelected:
+                  settings.cameraFallbackAspectRatio ==
+                  CameraPhotoAspectRatio.custom,
+              onCustomSelected: () =>
+                  _showCustomAspectRatioDialog(fallbackRatio: true),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _SettingsSection(
+          title:
+              '\u53c2\u8003\u56fe\u663e\u793a ${(settings.referenceImageScale * 100).round()}%',
+          children: [
+            _PercentScaleControl(
+              value: settings.referenceImageScale.clamp(0.8, 1.0),
+              min: 0.8,
+              max: 1.0,
+              divisions: 4,
+              tickLabels: const ['80%', '85%', '90%', '95%', '100%'],
+              showStepper: false,
+              onChanged: (value) {
+                _update(settings.copyWith(referenceImageScale: value));
+              },
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _SettingsSection(
+          title:
+              '\u76f8\u673a\u7f29\u653e ${cameraMinZoom.toStringAsFixed(1)}x - ${cameraMaxZoom.toStringAsFixed(1)}x',
+          children: [
+            SliderTheme(
+              data: SliderTheme.of(context).copyWith(
+                rangeThumbShape: const RoundRangeSliderThumbShape(
+                  enabledThumbRadius: 7,
+                  pressedElevation: 3,
+                ),
+                rangeValueIndicatorShape:
+                    const PaddleRangeSliderValueIndicatorShape(),
+                showValueIndicator: ShowValueIndicator.onlyForDiscrete,
+              ),
+              child: RangeSlider(
+                min: 0,
+                max: 1,
+                divisions: 200,
+                values: zoomSliderValues,
+                labels: RangeLabels(
+                  '${cameraMinZoom.toStringAsFixed(1)}x',
+                  '${cameraMaxZoom.toStringAsFixed(1)}x',
+                ),
+                onChanged: (values) {
+                  final minZoom = realZoomFromCameraSliderValue(
+                    minZoom: zoomRangeMin,
+                    maxZoom: zoomRangeMax,
+                    sliderValue: values.start,
+                  ).snapToZoomStep();
+                  final maxZoom = realZoomFromCameraSliderValue(
+                    minZoom: zoomRangeMin,
+                    maxZoom: zoomRangeMax,
+                    sliderValue: values.end,
+                  ).snapToZoomStep();
+                  _update(
+                    settings.copyWith(
+                      cameraMinZoom: minZoom.clamp(zoomRangeMin, zoomRangeMax),
+                      cameraMaxZoom: maxZoom.clamp(minZoom, zoomRangeMax),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _SettingsSection(
+          title: '照片备份',
+          children: [
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              secondary: const Icon(
+                Icons.cloud_upload_outlined,
+                color: AppColors.textSecondary,
+              ),
+              title: const Text('保存巡礼照片到相册', style: _titleTextStyle),
+              subtitle: const Text(
+                '保存记录时同时备份一张巡礼照片。',
+                style: _secondaryTextStyle,
+              ),
+              value: settings.saveVisitPhotoToGallery,
+              onChanged: (value) {
+                _update(settings.copyWith(saveVisitPhotoToGallery: value));
+              },
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _MapSettingsPage extends StatefulWidget {
+  const _MapSettingsPage({
+    required this.settings,
+    required this.onChanged,
+    required this.showMapUrlDialog,
+  });
+
+  final AppSettings settings;
+  final ValueChanged<AppSettings> onChanged;
+  final Future<void> Function({
+    required String title,
+    required String initialValue,
+    required String helperText,
+    required String? Function(String value) validator,
+    required ValueChanged<String> onSaved,
+  })
+  showMapUrlDialog;
+
+  @override
+  State<_MapSettingsPage> createState() => _MapSettingsPageState();
+}
+
+class _MapSettingsPageState extends State<_MapSettingsPage> {
+  late AppSettings _settings;
+
+  @override
+  void initState() {
+    super.initState();
+    _settings = widget.settings;
+  }
+
+  void _update(AppSettings settings) {
+    setState(() {
+      _settings = settings;
+    });
+    widget.onChanged(settings);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final settings = _settings;
+
+    return _ScaledDetailScaffold(
+      title: '\u5730\u56fe\u4e0e\u5bfc\u822a\u8bbe\u7f6e',
+      uiScale: settings.uiScale,
+      fontScale: settings.fontScale,
+      children: [
+        _SettingsSection(
+          title:
+              '\u5730\u56fe\u6e90 ${mapTileProviderOption(settings.mapTileProvider).label}',
+          children: [
+            _MapSourceGrid(
+              selectedProvider: settings.mapTileProvider,
+              onSelected: (provider) {
+                _update(settings.copyWith(mapTileProvider: provider));
+              },
+            ),
+            const SizedBox(height: 10),
+            Text(
+              mapTileProviderOption(settings.mapTileProvider).description,
+              style: _secondaryTextStyle,
+            ),
+            if (settings.mapTileProvider == MapTileProvider.customXyz) ...[
+              const SizedBox(height: 12),
+              _MapUrlRow(
+                icon: Icons.grid_3x3_outlined,
+                label: settings.customXyzTileUrl.trim().isEmpty
+                    ? '未设置自定义 XYZ URL'
+                    : settings.customXyzTileUrl.trim(),
+                onTap: () => widget.showMapUrlDialog(
+                  title: '自定义 XYZ URL',
+                  initialValue: settings.customXyzTileUrl,
+                  helperText: 'URL 需要包含 {z}、{x}、{y}。',
+                  validator: (value) =>
+                      isValidXyzTileUrl(value.trim()) ? null : 'URL 格式无效',
+                  onSaved: (value) {
+                    _update(settings.copyWith(customXyzTileUrl: value.trim()));
+                  },
+                ),
+              ),
+            ],
+            if (settings.mapTileProvider ==
+                MapTileProvider.customMapLibreStyle) ...[
+              const SizedBox(height: 12),
+              _MapUrlRow(
+                icon: Icons.data_object_outlined,
+                label: settings.customMapLibreStyleUrl.trim().isEmpty
+                    ? '未设置 MapLibre style URL'
+                    : settings.customMapLibreStyleUrl.trim(),
+                onTap: () => widget.showMapUrlDialog(
+                  title: 'MapLibre style URL',
+                  initialValue: settings.customMapLibreStyleUrl,
+                  helperText: 'URL 需要指向可公开读取的 style JSON。',
+                  validator: (value) {
+                    final testSettings = settings.copyWith(
+                      customMapLibreStyleUrl: value.trim(),
+                    );
+                    return validateMapTileSettings(testSettings);
+                  },
+                  onSaved: (value) {
+                    _update(
+                      settings.copyWith(customMapLibreStyleUrl: value.trim()),
+                    );
+                  },
+                ),
+              ),
+            ],
+            if (validateMapTileSettings(settings) != null) ...[
+              const SizedBox(height: 10),
+              _InfoRow(
+                icon: Icons.error_outline,
+                text: validateMapTileSettings(settings)!,
+              ),
+            ],
+          ],
+        ),
+        const SizedBox(height: 12),
+        _SettingsSection(
+          title: '\u5bfc\u822a\u8f6f\u4ef6 ${settings.navigationApp.label}',
+          children: [
+            _NavigationAppGrid(
+              selectedApp: settings.navigationApp,
+              onSelected: (app) {
+                _update(settings.copyWith(navigationApp: app));
+              },
+            ),
+            const SizedBox(height: 10),
+            const Text(
+              '\u4ec5\u4fdd\u7559\u754c\u9762\u9009\u9879\uff0c\u6682\u4e0d\u63a5\u5165\u5b9e\u9645\u5bfc\u822a\u8df3\u8f6c\u3002',
+              style: _secondaryTextStyle,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _CacheCleanupSettingsPage extends StatefulWidget {
+  const _CacheCleanupSettingsPage({required this.repository});
+
+  final PilgrimageRepository repository;
+
+  @override
+  State<_CacheCleanupSettingsPage> createState() =>
+      _CacheCleanupSettingsPageState();
+}
+
+class _CacheCleanupSettingsPageState extends State<_CacheCleanupSettingsPage> {
+  final Set<String> _selectedPlanIds = <String>{};
+  Future<List<PilgrimagePlan>>? _plansFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _plansFuture = widget.repository.loadPlans();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _DetailScaffold(
+      title: '清除缓存',
+      children: [
+        FutureBuilder<List<PilgrimagePlan>>(
+          future: _plansFuture,
+          builder: (context, snapshot) {
+            final plans = snapshot.data;
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const _SettingsSection(
+                title: '计划',
+                children: [
+                  Center(
+                    child: SizedBox(
+                      width: 22,
+                      height: 22,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                ],
+              );
+            }
+            if (snapshot.hasError || plans == null) {
+              return _SettingsSection(
+                title: '计划',
+                children: [
+                  const _InfoRow(icon: Icons.error_outline, text: '计划列表读取失败'),
+                  const SizedBox(height: 12),
+                  OutlinedButton.icon(
+                    onPressed: () {
+                      setState(() {
+                        _plansFuture = widget.repository.loadPlans();
+                      });
+                    },
+                    icon: const Icon(Icons.refresh, size: 18),
+                    label: const Text('重试'),
+                  ),
+                ],
+              );
+            }
+
+            _selectedPlanIds.removeWhere(
+              (id) => plans.every((plan) => plan.id != id),
+            );
+
+            return Column(
+              children: [
+                _SettingsSection(
+                  title: '选择计划',
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            '已选择 ${_selectedPlanIds.length} / ${plans.length} 个计划',
+                            style: _secondaryTextStyle,
+                          ),
+                        ),
+                        IconButton(
+                          tooltip: '全选',
+                          onPressed: () {
+                            setState(() {
+                              _selectedPlanIds
+                                ..clear()
+                                ..addAll(plans.map((plan) => plan.id));
+                            });
+                          },
+                          icon: const Icon(Icons.select_all_outlined),
+                        ),
+                        IconButton(
+                          tooltip: '清空',
+                          onPressed: _selectedPlanIds.isEmpty
+                              ? null
+                              : () {
+                                  setState(() {
+                                    _selectedPlanIds.clear();
+                                  });
+                                },
+                          icon: const Icon(Icons.deselect_outlined),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    ...plans.map(
+                      (plan) => CheckboxListTile(
+                        contentPadding: EdgeInsets.zero,
+                        controlAffinity: ListTileControlAffinity.leading,
+                        title: Text(plan.name, style: _titleTextStyle),
+                        subtitle: Text(
+                          '${plan.area} / ${plan.points.length} 个点位',
+                          style: _secondaryTextStyle,
+                        ),
+                        value: _selectedPlanIds.contains(plan.id),
+                        onChanged: (value) {
+                          setState(() {
+                            if (value == true) {
+                              _selectedPlanIds.add(plan.id);
+                            } else {
+                              _selectedPlanIds.remove(plan.id);
+                            }
+                          });
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                const _FullReferenceCacheSection(),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _selectedPlanIds.isEmpty
+                        ? null
+                        : _showCachePlaceholder,
+                    icon: const Icon(Icons.cleaning_services_outlined),
+                    label: const Text(
+                      '\u6e05\u9664\u5b8c\u6574\u53c2\u8003\u56fe\u7f13\u5b58',
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  void _showCachePlaceholder() {
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('清除缓存功能尚未接入，仅展示界面。')));
+  }
+}
+
+class _DesktopSettingsPage extends StatelessWidget {
+  const _DesktopSettingsPage({
+    required this.desktopLauncherInfo,
+    required this.desktopLauncherStatusText,
+  });
+
+  final DesktopLauncherInfo? desktopLauncherInfo;
+  final String desktopLauncherStatusText;
+
+  @override
+  Widget build(BuildContext context) {
+    return _DetailScaffold(
+      title: '桌面端',
+      children: [
+        _SettingsSection(
+          title: '启动器',
+          children: [
+            _InfoRow(
+              icon: Icons.desktop_windows_outlined,
+              text: desktopLauncherStatusText,
+            ),
+            if (desktopLauncherInfo != null) ...[
+              const SizedBox(height: 10),
+              _InfoRow(
+                icon: Icons.folder_outlined,
+                text: desktopLauncherInfo!.dataDir,
+              ),
+              const SizedBox(height: 10),
+              _InfoRow(
+                icon: Icons.inventory_2_outlined,
+                text: desktopLauncherInfo!.assetsDir,
+              ),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _AboutSettingsPage extends StatelessWidget {
+  const _AboutSettingsPage({required this.appVersionLabel});
+
+  final String? appVersionLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return _DetailScaffold(
+      title: '关于 MiriaGo',
+      children: [
+        _SettingsSection(
+          title: '应用信息',
+          children: [
+            Row(
+              children: [
+                const _AppIconMark(),
+                const SizedBox(width: 14),
+                const Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      CopyableText(
+                        text: 'MiriaGo',
+                        copyLabel: 'MiriaGo',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w900,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      SizedBox(height: 3),
+                      Text('动漫圣地巡礼计划与拍摄参考工具', style: _secondaryTextStyle),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 14),
+            _AboutInfoTile(
+              icon: Icons.new_releases_outlined,
+              label: '当前版本',
+              value: appVersionLabel ?? '读取中',
+            ),
+            const _AboutInfoTile(
+              icon: Icons.person_outline,
+              label: '作者',
+              value: 'BilyHurington',
+            ),
+            const _AboutInfoTile(
+              icon: Icons.mail_outline,
+              label: '联系邮箱',
+              value: 'bilyhurington@gmail.com',
+            ),
+            const _AboutInfoTile(
+              icon: Icons.code_outlined,
+              label: '开源仓库',
+              value: 'github.com/BilyHurington/MiriaGo',
+            ),
+            const _AboutInfoTile(
+              icon: Icons.balance_outlined,
+              label: '开源许可',
+              value: 'MIT License',
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        const _SettingsSection(
+          title: '数据与版权',
+          children: [
+            Text(
+              '地图可使用 OpenFreeMap、OpenStreetMap 或自定义服务；作品搜索使用 Bangumi；巡礼点位与参考图来自 Anitabi。第三方数据、截图和图片版权归原平台、贡献者或权利方所有。',
+              style: _secondaryParagraphTextStyle,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _DetailScaffold extends StatelessWidget {
+  const _DetailScaffold({required this.title, required this.children});
+
+  final String title;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(title)),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+        children: children,
+      ),
+    );
+  }
+}
+
+class _ScaledDetailScaffold extends StatelessWidget {
+  const _ScaledDetailScaffold({
+    required this.title,
+    required this.uiScale,
+    required this.fontScale,
+    required this.children,
+  });
+
+  final String title;
+  final double uiScale;
+  final double fontScale;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return MediaQuery(
+      data: MediaQuery.of(
+        context,
+      ).copyWith(textScaler: appTextScaler(fontScale)),
+      child: AppUiScaleView(
+        scale: uiScale,
+        child: _DetailScaffold(title: title, children: children),
+      ),
+    );
+  }
+}
+
+extension _SettingsAspectRatioLabel on CameraPhotoAspectRatio {
+  String get shortLabel {
+    return switch (this) {
+      CameraPhotoAspectRatio.auto => '\u81ea\u52a8',
+      CameraPhotoAspectRatio.native => '\u539f\u751f',
+      CameraPhotoAspectRatio.landscape16x9 => '16:9',
+      CameraPhotoAspectRatio.cinema21x9 => '21:9',
+      CameraPhotoAspectRatio.standard4x3 => '4:3',
+      CameraPhotoAspectRatio.photo3x2 => '3:2',
+      CameraPhotoAspectRatio.portrait9x16 => '9:16',
+      CameraPhotoAspectRatio.portrait9x21 => '9:21',
+      CameraPhotoAspectRatio.portrait3x4 => '3:4',
+      CameraPhotoAspectRatio.portrait2x3 => '2:3',
+      CameraPhotoAspectRatio.square1x1 => '1:1',
+      CameraPhotoAspectRatio.custom => '\u81ea\u5b9a\u4e49',
+    };
+  }
+
+  String get settingHintLabel {
+    return switch (this) {
+      CameraPhotoAspectRatio.auto => '\u63a8\u8350',
+      CameraPhotoAspectRatio.native => '\u539f\u751f',
+      CameraPhotoAspectRatio.landscape16x9 => '\u5bbd\u5c4f',
+      CameraPhotoAspectRatio.cinema21x9 => '\u7535\u5f71',
+      CameraPhotoAspectRatio.standard4x3 => '\u7ecf\u5178',
+      CameraPhotoAspectRatio.photo3x2 => '\u76f8\u673a',
+      CameraPhotoAspectRatio.portrait9x16 => '\u7ad6\u5c4f',
+      CameraPhotoAspectRatio.portrait9x21 => '\u5168\u9762\u5c4f',
+      CameraPhotoAspectRatio.portrait3x4 => '\u7ad6\u5e45',
+      CameraPhotoAspectRatio.portrait2x3 => '\u7ad6\u5e45',
+      CameraPhotoAspectRatio.square1x1 => '\u65b9\u5f62',
+      CameraPhotoAspectRatio.custom => '\u81ea\u5b9a',
+    };
+  }
 }
 
 extension _ZoomStepSnap on double {
   double snapToZoomStep() => (this * 10).round() / 10;
+}
+
+class _SettingsCard extends StatelessWidget {
+  const _SettingsCard({required this.header, this.children = const []});
+
+  final _SettingsCardHeader header;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        children: [
+          header,
+          if (children.isNotEmpty) ...[const _SettingsDivider(), ...children],
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsCardHeader extends StatelessWidget {
+  const _SettingsCardHeader({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(18, 16, 16, 16),
+        child: Row(
+          children: [
+            Icon(icon, color: AppColors.textSecondary, size: 30),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title, style: _cardTitleTextStyle),
+                  const SizedBox(height: 3),
+                  Text(subtitle, style: _secondaryTextStyle),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            const Icon(
+              Icons.chevron_right,
+              color: AppColors.textSecondary,
+              size: 30,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummaryGrid extends StatelessWidget {
+  const _SummaryGrid({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final tiles = <Widget>[];
+    for (var index = 0; index < children.length; index += 1) {
+      tiles.add(
+        Expanded(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              border: index == children.length - 1
+                  ? null
+                  : const Border(right: BorderSide(color: Color(0xFFE8ECF1))),
+            ),
+            child: children[index],
+          ),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 14),
+      child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: tiles),
+    );
+  }
+}
+
+class _SummaryTile extends StatelessWidget {
+  const _SummaryTile({
+    required this.icon,
+    required this.title,
+    required this.value,
+    this.swatch,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String value;
+  final Widget? swatch;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            swatch ?? Icon(icon, color: AppColors.textSecondary, size: 28),
+            const SizedBox(width: 10),
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: _titleTextStyle,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    value,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: AppColors.accent,
+                      fontSize: 13,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SummarySwitchTile extends StatelessWidget {
+  const _SummarySwitchTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(18, 12, 16, 12),
+      child: Row(
+        children: [
+          Icon(icon, color: AppColors.textSecondary, size: 30),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: _cardTitleTextStyle),
+                const SizedBox(height: 3),
+                Text(subtitle, style: _secondaryTextStyle),
+              ],
+            ),
+          ),
+          Switch(value: value, onChanged: onChanged),
+        ],
+      ),
+    );
+  }
 }
 
 class _SettingsSection extends StatelessWidget {
@@ -709,9 +1616,9 @@ class _SettingsSection extends StatelessWidget {
           Text(
             title,
             style: const TextStyle(
-              color: AppColors.textSecondary,
-              fontSize: 13,
-              fontWeight: FontWeight.w800,
+              color: AppColors.textPrimary,
+              fontSize: 15,
+              fontWeight: FontWeight.w900,
               letterSpacing: 0,
             ),
           ),
@@ -720,6 +1627,983 @@ class _SettingsSection extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+class _AspectRatioGrid extends StatelessWidget {
+  const _AspectRatioGrid({
+    required this.ratios,
+    required this.selectedRatio,
+    required this.onSelected,
+    this.customSelected = false,
+    this.onCustomSelected,
+  });
+
+  final List<CameraPhotoAspectRatio> ratios;
+  final CameraPhotoAspectRatio selectedRatio;
+  final ValueChanged<CameraPhotoAspectRatio> onSelected;
+  final bool customSelected;
+  final VoidCallback? onCustomSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final spacing = 8.0;
+        final tileWidth = ((constraints.maxWidth - spacing * 3) / 4).clamp(
+          72.0,
+          112.0,
+        );
+        return Wrap(
+          spacing: spacing,
+          runSpacing: 10,
+          children: [
+            for (final ratio in ratios)
+              SizedBox(
+                width: tileWidth,
+                child: _AspectRatioOption(
+                  ratio: ratio,
+                  selected: selectedRatio == ratio,
+                  onTap: () => onSelected(ratio),
+                ),
+              ),
+            SizedBox(
+              width: tileWidth,
+              child: _CustomAspectRatioOption(
+                selected: customSelected,
+                onTap: onCustomSelected,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _FullReferenceCacheSection extends StatelessWidget {
+  const _FullReferenceCacheSection();
+
+  @override
+  Widget build(BuildContext context) {
+    return const _SettingsSection(
+      title: '\u7f13\u5b58\u5185\u5bb9',
+      children: [
+        _CacheTargetCard(
+          icon: Icons.photo_library_outlined,
+          title: '\u5b8c\u6574\u53c2\u8003\u56fe\u7f13\u5b58',
+          subtitle:
+              '\u6e05\u9664\u76f8\u673a\u53c2\u8003\u548c\u5927\u56fe\u67e5\u770b\u4f7f\u7528\u7684\u5b8c\u6574\u53c2\u8003\u56fe\u3002\u7f29\u7565\u56fe\u7f13\u5b58\u4f1a\u4fdd\u7559\uff0c\u4ee5\u4fdd\u6301\u5217\u8868\u548c\u5730\u56fe\u52a0\u8f7d\u901f\u5ea6\u3002',
+        ),
+      ],
+    );
+  }
+}
+
+class _CacheTargetCard extends StatelessWidget {
+  const _CacheTargetCard({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.background,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 38,
+            height: 38,
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(icon, color: AppColors.accent, size: 21),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: _titleTextStyle),
+                const SizedBox(height: 4),
+                Text(subtitle, style: _secondaryParagraphTextStyle),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CustomAspectRatioOption extends StatelessWidget {
+  const _CustomAspectRatioOption({required this.selected, this.onTap});
+
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        height: 48,
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.accent : AppColors.surface,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selected ? AppColors.accent : AppColors.border,
+          ),
+          boxShadow: selected
+              ? [
+                  BoxShadow(
+                    color: AppColors.accent.withValues(alpha: 0.16),
+                    blurRadius: 10,
+                    offset: const Offset(0, 4),
+                  ),
+                ]
+              : null,
+        ),
+        child: Center(
+          child: Text(
+            '\u81ea\u5b9a\u4e49',
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: selected ? AppColors.onAccent : AppColors.textPrimary,
+              fontSize: 13,
+              fontWeight: FontWeight.w900,
+              letterSpacing: 0,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CustomAspectRatioDialog extends StatefulWidget {
+  const _CustomAspectRatioDialog({required this.settings});
+
+  final AppSettings settings;
+
+  @override
+  State<_CustomAspectRatioDialog> createState() =>
+      _CustomAspectRatioDialogState();
+}
+
+class _CustomAspectRatioDialogState extends State<_CustomAspectRatioDialog> {
+  late final TextEditingController _widthController;
+  late final TextEditingController _heightController;
+
+  @override
+  void initState() {
+    super.initState();
+    _widthController = TextEditingController(
+      text: _formatRatioNumber(widget.settings.customCameraAspectRatioWidth),
+    );
+    _heightController = TextEditingController(
+      text: _formatRatioNumber(widget.settings.customCameraAspectRatioHeight),
+    );
+  }
+
+  @override
+  void dispose() {
+    _widthController.dispose();
+    _heightController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final width = double.tryParse(_widthController.text.trim());
+    final height = double.tryParse(_heightController.text.trim());
+    if (width == null || height == null || width <= 0 || height <= 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('\u8bf7\u8f93\u5165\u6709\u6548\u6bd4\u4f8b'),
+        ),
+      );
+      return;
+    }
+    Navigator.of(context).pop((width: width, height: height));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('\u81ea\u5b9a\u4e49\u6bd4\u4f8b'),
+      content: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _widthController,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
+              decoration: const InputDecoration(labelText: '\u5bbd'),
+            ),
+          ),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              ':',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.w900),
+            ),
+          ),
+          Expanded(
+            child: TextField(
+              controller: _heightController,
+              keyboardType: const TextInputType.numberWithOptions(
+                decimal: true,
+              ),
+              decoration: const InputDecoration(labelText: '\u9ad8'),
+              onSubmitted: (_) => _submit(),
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('\u53d6\u6d88'),
+        ),
+        FilledButton(onPressed: _submit, child: const Text('\u4fdd\u5b58')),
+      ],
+    );
+  }
+}
+
+String _formatRatioNumber(double value) {
+  if (value == value.roundToDouble()) {
+    return value.round().toString();
+  }
+  return value.toStringAsFixed(2).replaceFirst(RegExp(r'\.?0+$'), '');
+}
+
+class _AspectRatioOption extends StatelessWidget {
+  const _AspectRatioOption({
+    required this.ratio,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final CameraPhotoAspectRatio ratio;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        height: 48,
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.accent : AppColors.surface,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selected ? AppColors.accent : AppColors.border,
+          ),
+          boxShadow: selected
+              ? [
+                  BoxShadow(
+                    color: AppColors.accent.withValues(alpha: 0.16),
+                    blurRadius: 10,
+                    offset: const Offset(0, 4),
+                  ),
+                ]
+              : null,
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (selected) ...[
+                  Icon(Icons.check, size: 13, color: AppColors.onAccent),
+                  const SizedBox(width: 4),
+                ],
+                Flexible(
+                  child: Text(
+                    ratio.shortLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: selected
+                          ? AppColors.onAccent
+                          : AppColors.textPrimary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w900,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 2),
+            Text(
+              ratio.settingHintLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: selected
+                    ? AppColors.onAccent.withValues(alpha: 0.86)
+                    : AppColors.textSecondary,
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AppearancePanel extends StatelessWidget {
+  const _AppearancePanel({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.04),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+}
+
+class _InlineSectionTitle extends StatelessWidget {
+  const _InlineSectionTitle({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(title, style: _titleTextStyle),
+        const SizedBox(width: 10),
+        Flexible(child: Text(subtitle, style: _captionTextStyle)),
+      ],
+    );
+  }
+}
+
+class _ThemeColorOption extends StatelessWidget {
+  const _ThemeColorOption({
+    required this.palette,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final AppThemePalette palette;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(30),
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _ThemeSwatch(palette: palette, selected: selected),
+          const SizedBox(height: 8),
+          Text(
+            palette.label,
+            style: TextStyle(
+              color: selected ? AppColors.accent : AppColors.textPrimary,
+              fontSize: 12,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CustomThemeColorOption extends StatelessWidget {
+  const _CustomThemeColorOption({
+    required this.color,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final CustomThemeColor color;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ThemeColorButton(
+      color: Color(color.value),
+      label: color.name,
+      selected: selected,
+      icon: selected ? Icons.check : null,
+      onTap: onTap,
+    );
+  }
+}
+
+class _AddThemeColorOption extends StatelessWidget {
+  const _AddThemeColorOption({
+    required this.selected,
+    required this.colorValue,
+    required this.label,
+    required this.onTap,
+  });
+
+  final bool selected;
+  final int colorValue;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ThemeColorButton(
+      color: Color(colorValue),
+      label: label.trim().isEmpty ? '\u81ea\u5b9a\u4e49' : label.trim(),
+      selected: selected,
+      icon: Icons.add,
+      onTap: onTap,
+    );
+  }
+}
+
+class _ThemeColorButton extends StatelessWidget {
+  const _ThemeColorButton({
+    required this.color,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+    this.icon,
+  });
+
+  final Color color;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground = color.computeLuminance() > 0.55
+        ? AppColors.textPrimary
+        : Colors.white;
+    return InkWell(
+      borderRadius: BorderRadius.circular(30),
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AnimatedContainer(
+            duration: const Duration(milliseconds: 160),
+            width: selected ? 42 : 38,
+            height: selected ? 42 : 38,
+            padding: const EdgeInsets.all(4),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(
+                color: selected ? AppColors.accent : AppColors.border,
+                width: selected ? 2 : 1,
+              ),
+            ),
+            child: DecoratedBox(
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              child: icon == null
+                  ? null
+                  : Icon(icon, color: foreground, size: 18),
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: 58,
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: selected ? AppColors.accent : AppColors.textPrimary,
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CustomThemeColorDialog extends StatefulWidget {
+  const _CustomThemeColorDialog({required this.settings});
+
+  final AppSettings settings;
+
+  @override
+  State<_CustomThemeColorDialog> createState() =>
+      _CustomThemeColorDialogState();
+}
+
+class _CustomThemeColorDialogState extends State<_CustomThemeColorDialog> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _hexController;
+  late Color _color;
+
+  @override
+  void initState() {
+    super.initState();
+    _color = Color(widget.settings.customThemeColorValue);
+    _nameController = TextEditingController(
+      text: widget.settings.customThemeColorName,
+    );
+    _hexController = TextEditingController(text: _hexFromColor(_color));
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _hexController.dispose();
+    super.dispose();
+  }
+
+  void _setColor(Color color, {bool syncHex = true}) {
+    setState(() {
+      _color = color.withAlpha(255);
+      if (syncHex) {
+        _hexController.text = _hexFromColor(_color);
+      }
+    });
+  }
+
+  void _applyHex() {
+    final color = _colorFromHex(_hexController.text);
+    if (color != null) {
+      _setColor(color, syncHex: false);
+    }
+  }
+
+  void _submit() {
+    final name = _nameController.text.trim();
+    final color = _colorFromHex(_hexController.text) ?? _color;
+    if (name.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('\u8bf7\u8f93\u5165\u989c\u8272\u540d\u79f0'),
+        ),
+      );
+      return;
+    }
+    Navigator.of(
+      context,
+    ).pop(CustomThemeColor(name: name, value: color.withAlpha(255).toARGB32()));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('\u81ea\u5b9a\u4e49\u4e3b\u9898\u8272'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              height: 54,
+              decoration: BoxDecoration(
+                color: _color,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: AppColors.border),
+              ),
+            ),
+            const SizedBox(height: 14),
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: '\u540d\u79f0'),
+            ),
+            const SizedBox(height: 10),
+            TextField(
+              controller: _hexController,
+              decoration: const InputDecoration(
+                labelText: '\u8272\u53f7',
+                hintText: '#0F8B8D',
+              ),
+              onChanged: (_) => _applyHex(),
+              onSubmitted: (_) => _submit(),
+            ),
+            const SizedBox(height: 14),
+            _ColorChannelSlider(
+              label: 'R',
+              value: _color.r.round(),
+              onChanged: (value) => _setColor(
+                Color.fromARGB(255, value, _color.g.round(), _color.b.round()),
+              ),
+            ),
+            _ColorChannelSlider(
+              label: 'G',
+              value: _color.g.round(),
+              onChanged: (value) => _setColor(
+                Color.fromARGB(255, _color.r.round(), value, _color.b.round()),
+              ),
+            ),
+            _ColorChannelSlider(
+              label: 'B',
+              value: _color.b.round(),
+              onChanged: (value) => _setColor(
+                Color.fromARGB(255, _color.r.round(), _color.g.round(), value),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('\u53d6\u6d88'),
+        ),
+        FilledButton(onPressed: _submit, child: const Text('\u6dfb\u52a0')),
+      ],
+    );
+  }
+}
+
+class _ColorChannelSlider extends StatelessWidget {
+  const _ColorChannelSlider({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String label;
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(width: 18, child: Text(label, style: _captionTextStyle)),
+        Expanded(
+          child: Slider(
+            value: value.toDouble(),
+            min: 0,
+            max: 255,
+            divisions: 255,
+            label: value.toString(),
+            onChanged: (next) => onChanged(next.round()),
+          ),
+        ),
+        SizedBox(
+          width: 34,
+          child: Text(
+            value.toString(),
+            textAlign: TextAlign.right,
+            style: _captionTextStyle,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _hexFromColor(Color color) {
+  return '#${color.toARGB32().toRadixString(16).padLeft(8, '0').substring(2).toUpperCase()}';
+}
+
+Color? _colorFromHex(String source) {
+  final normalized = source.trim().replaceFirst('#', '');
+  if (!RegExp(r'^[0-9a-fA-F]{6}$').hasMatch(normalized)) {
+    return null;
+  }
+  return Color(int.parse('FF$normalized', radix: 16));
+}
+
+class _ModeButton extends StatelessWidget {
+  const _ModeButton({
+    required this.icon,
+    required this.label,
+    this.selected = false,
+    this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: onTap,
+      child: Container(
+        height: 40,
+        decoration: BoxDecoration(
+          color: selected
+              ? AppColors.accent.withValues(alpha: 0.08)
+              : AppColors.surface,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selected ? AppColors.accent : AppColors.border,
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              color: selected ? AppColors.accent : AppColors.textSecondary,
+              size: 18,
+            ),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: selected ? AppColors.accent : AppColors.textSecondary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ScaleStepper extends StatelessWidget {
+  const _ScaleStepper({
+    required this.value,
+    required this.onDecrease,
+    required this.onIncrease,
+  });
+
+  final double value;
+  final VoidCallback onDecrease;
+  final VoidCallback onIncrease;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 34,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(17),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _StepperIconButton(icon: Icons.remove, onTap: onDecrease),
+          Container(
+            width: 72,
+            alignment: Alignment.center,
+            decoration: const BoxDecoration(
+              border: Border.symmetric(
+                vertical: BorderSide(color: AppColors.border),
+              ),
+            ),
+            child: Text(
+              '${(value * 100).round()}%',
+              style: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w900,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+          _StepperIconButton(icon: Icons.add, onTap: onIncrease),
+        ],
+      ),
+    );
+  }
+}
+
+class _PercentScaleControl extends StatelessWidget {
+  const _PercentScaleControl({
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.divisions,
+    required this.tickLabels,
+    required this.onChanged,
+    this.showStepper = true,
+  });
+
+  final double value;
+  final double min;
+  final double max;
+  final int divisions;
+  final List<String> tickLabels;
+  final ValueChanged<double> onChanged;
+  final bool showStepper;
+
+  double get _step => (max - min) / divisions;
+
+  @override
+  Widget build(BuildContext context) {
+    final clampedValue = value.clamp(min, max);
+    return Column(
+      children: [
+        if (showStepper) ...[
+          Align(
+            alignment: Alignment.centerRight,
+            child: _ScaleStepper(
+              value: clampedValue,
+              onDecrease: () {
+                onChanged((clampedValue - _step).clamp(min, max));
+              },
+              onIncrease: () {
+                onChanged((clampedValue + _step).clamp(min, max));
+              },
+            ),
+          ),
+          const SizedBox(height: 8),
+        ],
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 3,
+            thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 7),
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+          ),
+          child: Slider(
+            min: min,
+            max: max,
+            divisions: divisions,
+            value: clampedValue,
+            label: '${(clampedValue * 100).round()}%',
+            onChanged: onChanged,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              for (final label in tickLabels)
+                Text(label, style: _captionTextStyle),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StepperIconButton extends StatelessWidget {
+  const _StepperIconButton({required this.icon, required this.onTap});
+
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(16),
+      onTap: onTap,
+      child: SizedBox(
+        width: 34,
+        height: 34,
+        child: Icon(icon, size: 18, color: AppColors.textSecondary),
+      ),
+    );
+  }
+}
+
+class _FontSizeButton extends StatelessWidget {
+  const _FontSizeButton({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: onTap,
+        child: Container(
+          height: 32,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: selected
+                ? AppColors.accent.withValues(alpha: 0.08)
+                : AppColors.surface,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: selected ? AppColors.accent : AppColors.border,
+            ),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              color: selected ? AppColors.accent : AppColors.textPrimary,
+              fontSize: 12,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsDivider extends StatelessWidget {
+  const _SettingsDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider(height: 1, thickness: 1, color: Color(0xFFE8ECF1));
   }
 }
 
@@ -750,11 +2634,7 @@ class _MapUrlRow extends StatelessWidget {
                 label,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: AppColors.textSecondary,
-                  fontSize: 13,
-                  letterSpacing: 0,
-                ),
+                style: _secondaryTextStyle,
               ),
             ),
             const SizedBox(width: 10),
@@ -770,49 +2650,376 @@ class _MapUrlRow extends StatelessWidget {
   }
 }
 
+class _MapSourceGrid extends StatelessWidget {
+  const _MapSourceGrid({
+    required this.selectedProvider,
+    required this.onSelected,
+  });
+
+  final MapTileProvider selectedProvider;
+  final ValueChanged<MapTileProvider> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const spacing = 10.0;
+        final tileWidth = (constraints.maxWidth - spacing) / 2;
+        return Wrap(
+          spacing: spacing,
+          runSpacing: spacing,
+          children: [
+            for (final option in mapTileProviderOptions)
+              SizedBox(
+                width: tileWidth,
+                child: _MapSourceOptionCard(
+                  option: option,
+                  selected: selectedProvider == option.provider,
+                  onTap: () => onSelected(option.provider),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _MapSourceOptionCard extends StatelessWidget {
+  const _MapSourceOptionCard({
+    required this.option,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final MapTileProviderOption option;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        height: 62,
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.accent : AppColors.surface,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selected ? AppColors.accent : AppColors.border,
+          ),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              selected ? Icons.check : _mapProviderIcon(option.provider),
+              color: selected ? AppColors.onAccent : AppColors.textSecondary,
+              size: 18,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    option.label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: selected
+                          ? AppColors.onAccent
+                          : AppColors.textPrimary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w900,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    _mapProviderHint(option.provider),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: selected
+                          ? AppColors.onAccent.withValues(alpha: 0.82)
+                          : AppColors.textSecondary,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NavigationAppGrid extends StatelessWidget {
+  const _NavigationAppGrid({
+    required this.selectedApp,
+    required this.onSelected,
+  });
+
+  final NavigationApp selectedApp;
+  final ValueChanged<NavigationApp> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const spacing = 10.0;
+        final tileWidth = (constraints.maxWidth - spacing) / 2;
+        return Wrap(
+          spacing: spacing,
+          runSpacing: spacing,
+          children: [
+            for (final app in NavigationApp.values)
+              SizedBox(
+                width: tileWidth,
+                child: _NavigationAppOptionCard(
+                  app: app,
+                  selected: selectedApp == app,
+                  onTap: () => onSelected(app),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _NavigationAppOptionCard extends StatelessWidget {
+  const _NavigationAppOptionCard({
+    required this.app,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final NavigationApp app;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 140),
+        height: 62,
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.accent : AppColors.surface,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selected ? AppColors.accent : AppColors.border,
+          ),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              selected ? Icons.check : _navigationAppIcon(app),
+              color: selected ? AppColors.onAccent : AppColors.textSecondary,
+              size: 18,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    app.label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: selected
+                          ? AppColors.onAccent
+                          : AppColors.textPrimary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w900,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    _navigationAppHint(app),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: selected
+                          ? AppColors.onAccent.withValues(alpha: 0.82)
+                          : AppColors.textSecondary,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+IconData _mapProviderIcon(MapTileProvider provider) {
+  return switch (provider) {
+    MapTileProvider.openFreeMap => Icons.map_outlined,
+    MapTileProvider.openStreetMap => Icons.public_outlined,
+    MapTileProvider.customXyz => Icons.grid_3x3_outlined,
+    MapTileProvider.customMapLibreStyle => Icons.data_object_outlined,
+  };
+}
+
+IconData _navigationAppIcon(NavigationApp app) {
+  return switch (app) {
+    NavigationApp.googleMaps => Icons.explore_outlined,
+    NavigationApp.amap => Icons.near_me_outlined,
+    NavigationApp.appleMaps => Icons.map_outlined,
+    NavigationApp.baiduMaps => Icons.assistant_direction_outlined,
+    NavigationApp.tencentMaps => Icons.navigation_outlined,
+    NavigationApp.browser => Icons.language_outlined,
+  };
+}
+
+String _navigationAppHint(NavigationApp app) {
+  return switch (app) {
+    NavigationApp.googleMaps => '\u9ed8\u8ba4\u9009\u9879',
+    NavigationApp.amap => '\u56fd\u5185\u5e38\u7528',
+    NavigationApp.appleMaps => 'iOS \u539f\u751f',
+    NavigationApp.baiduMaps => '\u57ce\u5e02\u5bfc\u822a',
+    NavigationApp.tencentMaps => '\u8f7b\u91cf\u5907\u9009',
+    NavigationApp.browser => '\u7f51\u9875\u6253\u5f00',
+  };
+}
+
+String _mapProviderHint(MapTileProvider provider) {
+  return switch (provider) {
+    MapTileProvider.openFreeMap => '\u63a8\u8350\u9ed8\u8ba4',
+    MapTileProvider.openStreetMap => '\u6807\u51c6\u74e6\u7247',
+    MapTileProvider.customXyz => '\u74e6\u7247\u6a21\u677f',
+    MapTileProvider.customMapLibreStyle => '\u6837\u5f0f URL',
+  };
+}
+
+class _AboutInfoTile extends StatelessWidget {
+  const _AboutInfoTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 10),
+      child: Row(
+        children: [
+          Icon(icon, color: AppColors.textSecondary, size: 20),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: _captionTextStyle),
+                const SizedBox(height: 2),
+                CopyableText(
+                  text: value,
+                  copyLabel: value,
+                  style: const TextStyle(fontSize: 14, letterSpacing: 0),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _AppIconMark extends StatelessWidget {
   const _AppIconMark();
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 52,
-      height: 52,
-      alignment: Alignment.center,
+      width: 58,
+      height: 58,
+      clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
-        color: AppColors.accent,
-        borderRadius: BorderRadius.circular(12),
+        color: AppColors.surfaceMuted,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.border),
         boxShadow: [
           BoxShadow(
-            color: AppColors.accent.withValues(alpha: 0.18),
+            color: Colors.black.withValues(alpha: 0.08),
             blurRadius: 12,
             offset: const Offset(0, 5),
           ),
         ],
       ),
-      child: Icon(Icons.explore_outlined, color: AppColors.onAccent, size: 28),
+      child: Image.asset('icon.jpg', fit: BoxFit.cover),
     );
   }
 }
 
 class _ThemeSwatch extends StatelessWidget {
-  const _ThemeSwatch({required this.palette});
+  const _ThemeSwatch({
+    required this.palette,
+    this.selected = false,
+    this.customColorValue,
+  });
 
   final AppThemePalette palette;
+  final bool selected;
+  final int? customColorValue;
 
   @override
   Widget build(BuildContext context) {
     final color = switch (palette) {
-      AppThemePalette.miriaYellow => AppColors.miriaYellow,
       AppThemePalette.classicGreen => AppColors.classicGreen,
+      AppThemePalette.deepBlue => AppColors.deepBlue,
+      AppThemePalette.cherryPink => AppColors.cherryPink,
+      AppThemePalette.twilightPurple => AppColors.twilightPurple,
+      AppThemePalette.miriaYellow => AppColors.miriaYellow,
+      AppThemePalette.graphite => AppColors.graphite,
+      AppThemePalette.aurora => Color(
+        customColorValue ?? AppColors.customAccentValue,
+      ),
     };
-    return Container(
-      width: 16,
-      height: 16,
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 160),
+      width: selected ? 42 : 38,
+      height: selected ? 42 : 38,
+      padding: const EdgeInsets.all(4),
       decoration: BoxDecoration(
-        color: color,
         shape: BoxShape.circle,
-        border: Border.all(color: AppColors.border),
+        border: Border.all(
+          color: selected ? AppColors.accent : AppColors.border,
+          width: selected ? 2 : 1,
+        ),
+      ),
+      child: DecoratedBox(
+        decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        child: selected
+            ? Icon(Icons.check, color: AppColors.onAccent, size: 18)
+            : null,
       ),
     );
   }
@@ -841,3 +3048,37 @@ class _InfoRow extends StatelessWidget {
     );
   }
 }
+
+const _cardTitleTextStyle = TextStyle(
+  color: AppColors.textPrimary,
+  fontSize: 16,
+  fontWeight: FontWeight.w900,
+  letterSpacing: 0,
+);
+
+const _titleTextStyle = TextStyle(
+  color: AppColors.textPrimary,
+  fontSize: 15,
+  fontWeight: FontWeight.w800,
+  letterSpacing: 0,
+);
+
+const _secondaryTextStyle = TextStyle(
+  color: AppColors.textSecondary,
+  fontSize: 13,
+  letterSpacing: 0,
+);
+
+const _captionTextStyle = TextStyle(
+  color: AppColors.textSecondary,
+  fontSize: 12,
+  fontWeight: FontWeight.w700,
+  letterSpacing: 0,
+);
+
+const _secondaryParagraphTextStyle = TextStyle(
+  color: AppColors.textSecondary,
+  fontSize: 13,
+  height: 1.45,
+  letterSpacing: 0,
+);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
+    - icon.jpg
     - docs/sample_images/
     - docs/sample_images/sample_visit_records/
 


### PR DESCRIPTION
## Summary
- Redesign settings pages and move original settings into secondary pages
- Add custom theme color and custom camera aspect ratio UI
- Add map and navigation settings UI with navigation app preference
- Improve cache, about, records, and dropdown-related settings UI

## Tests
- flutter analyze
- flutter test
- flutter build web