### PR TITLE
feat: polish plan onboarding, work forms, and record UI

### DIFF
--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -39,7 +39,10 @@ InputDecoration stableInputDecoration({
   );
 }
 
-InputDecoration _boxedFormDecoration({String? hintText}) {
+InputDecoration _boxedFormDecoration({
+  String? hintText,
+  bool reserveHelperSpace = true,
+}) {
   return InputDecoration(
     hintText: hintText,
     hintStyle: TextStyle(
@@ -47,7 +50,7 @@ InputDecoration _boxedFormDecoration({String? hintText}) {
       fontSize: 14,
       letterSpacing: 0,
     ),
-    helperText: ' ',
+    helperText: reserveHelperSpace ? ' ' : null,
     contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
     enabledBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(8),
@@ -410,35 +413,50 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
           children: [
             _FormSection(
               children: [
-                TextField(
-                  controller: _queryController,
-                  decoration: const InputDecoration(
-                    labelText: '作品名称',
-                    hintText: '例如 轻音少女',
+                _ManualWorkLabeledField(
+                  label: '作品名称',
+                  prominent: true,
+                  child: TextField(
+                    controller: _queryController,
+                    decoration: _boxedFormDecoration(
+                      hintText: '例如 轻音少女',
+                      reserveHelperSpace: false,
+                    ),
+                    textInputAction: TextInputAction.search,
+                    onSubmitted: (_) => _search(),
                   ),
-                  textInputAction: TextInputAction.search,
-                  onSubmitted: (_) => _search(),
                 ),
-                const SizedBox(height: 12),
-                _BangumiTypeFilter(
-                  selectedTypes: _selectedTypes,
-                  onChanged: (types) {
-                    setState(() {
-                      _selectedTypes = types;
-                    });
-                  },
+                const SizedBox(height: 16),
+                _ManualWorkLabeledField(
+                  label: '作品类型',
+                  prominent: true,
+                  child: _BangumiTypeFilter(
+                    selectedTypes: _selectedTypes,
+                    onChanged: (types) {
+                      setState(() {
+                        _selectedTypes = types;
+                      });
+                    },
+                  ),
                 ),
-                const SizedBox(height: 12),
-                FilledButton.icon(
-                  onPressed: _isSearching ? null : _search,
-                  icon: _isSearching
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.search, size: 18),
-                  label: Text(_isSearching ? '搜索中' : '搜索作品'),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _isSearching ? null : _search,
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(46),
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                    ),
+                    icon: _isSearching
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.search, size: 18),
+                    label: Text(_isSearching ? '搜索中' : '搜索作品'),
+                  ),
                 ),
               ],
             ),
@@ -490,26 +508,97 @@ class _BangumiTypeFilter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 8,
-      runSpacing: 6,
-      children: [
-        for (final type in _types)
-          FilterChip(
-            label: Text(type.label),
-            selected: selectedTypes.contains(type),
-            onSelected: (selected) {
-              final nextTypes = {...selectedTypes};
-              if (selected) {
-                nextTypes.add(type);
-              } else if (nextTypes.length > 1) {
-                nextTypes.remove(type);
-              }
-              onChanged(nextTypes);
-            },
-          ),
-      ],
+    return Container(
+      width: double.infinity,
+      height: 40,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (var index = 0; index < _types.length; index++) ...[
+            Expanded(child: _buildTypeItem(_types[index])),
+            if (index < _types.length - 1)
+              const VerticalDivider(
+                width: 1,
+                thickness: 1,
+                color: AppColors.border,
+              ),
+          ],
+        ],
+      ),
     );
+  }
+
+  Widget _buildTypeItem(BangumiSubjectType type) {
+    final selected = selectedTypes.contains(type);
+    return Semantics(
+      button: true,
+      selected: selected,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: () => _toggleType(type, selected),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 140),
+                curve: Curves.easeOut,
+                color: selected
+                    ? AppColors.accent.withValues(alpha: 0.08)
+                    : Colors.transparent,
+                alignment: Alignment.center,
+                child: Text(
+                  type.label,
+                  maxLines: 1,
+                  style: TextStyle(
+                    color: selected
+                        ? AppColors.accentDark
+                        : AppColors.textSecondary,
+                    fontSize: 13,
+                    fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ),
+              if (selected)
+                Positioned(
+                  left: 8,
+                  right: 8,
+                  bottom: 0,
+                  child: Container(
+                    height: 3,
+                    decoration: BoxDecoration(
+                      color: AppColors.accent,
+                      borderRadius: const BorderRadius.vertical(
+                        top: Radius.circular(3),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _toggleType(BangumiSubjectType type, bool selected) {
+    final nextTypes = {...selectedTypes};
+    if (selected) {
+      if (nextTypes.length == 1) {
+        return;
+      }
+      nextTypes.remove(type);
+    } else {
+      nextTypes.add(type);
+    }
+    onChanged(nextTypes);
   }
 }
 
@@ -1671,6 +1760,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                       child: PilgrimageWorkDropdown(
                         works: workOptions,
                         value: _selectedWork,
+                        omitScrollbarInsetWhenUnscrollable: true,
                         onChanged: (work) {
                           setState(() {
                             _selectedWork = work;
@@ -2648,9 +2738,9 @@ class _BangumiSearchHintCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: AppColors.surface,
+        color: AppColors.accent.withValues(alpha: 0.05),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
+        border: Border.all(color: AppColors.accent.withValues(alpha: 0.42)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -2658,10 +2748,14 @@ class _BangumiSearchHintCard extends StatelessWidget {
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Icon(Icons.info_outline, color: AppColors.accent, size: 16),
+              Icon(
+                Icons.manage_search_rounded,
+                color: AppColors.accent,
+                size: 17,
+              ),
               const SizedBox(width: 8),
               const Text(
-                '温馨提示',
+                '搜索说明',
                 style: TextStyle(
                   color: AppColors.textPrimary,
                   fontSize: 13,
@@ -2683,22 +2777,31 @@ class _BangumiSearchHintCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 8),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-            decoration: BoxDecoration(
-              color: AppColors.accent.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: Text(
-              'Bangumi需要国际网络环境才能正常搜索。',
-              style: TextStyle(
-                color: AppColors.accentDark,
-                fontSize: 13,
-                fontWeight: FontWeight.w800,
-                height: 1.25,
-                letterSpacing: 0,
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 1),
+                child: Icon(
+                  Icons.info_outline_rounded,
+                  color: AppColors.accent,
+                  size: 16,
+                ),
               ),
-            ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  'Bangumi需要国际网络环境才能正常搜索。',
+                  style: TextStyle(
+                    color: AppColors.accentDark,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    height: 1.35,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/reference_thumbnail_stub.dart'
 import '../widgets/image_viewer_screen.dart';
 import 'anitabi_map_import_screen.dart';
 import 'coordinate_parser.dart';
+import 'pilgrimage_work_dropdown.dart';
 import 'pilgrimage_models.dart';
 import 'reference_image_status.dart';
 import 'work_manager_screen.dart';
@@ -35,6 +36,35 @@ InputDecoration stableInputDecoration({
     prefixIcon: prefixIcon,
     suffixIcon: suffixIcon,
     helperText: ' ',
+  );
+}
+
+InputDecoration _boxedFormDecoration({String? hintText}) {
+  return InputDecoration(
+    hintText: hintText,
+    hintStyle: TextStyle(
+      color: AppColors.textSecondary.withValues(alpha: 0.42),
+      fontSize: 14,
+      letterSpacing: 0,
+    ),
+    helperText: ' ',
+    contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: AppColors.border),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: BorderSide(color: AppColors.accent, width: 1.4),
+    ),
+    errorBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: Colors.redAccent),
+    ),
+    focusedErrorBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+    ),
   );
 }
 
@@ -419,10 +449,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
                 text: 'Bangumi 搜索失败，请检查网络后重试。',
               )
             else if (_results.isEmpty)
-              const _MessageCard(
-                icon: Icons.info_outline,
-                text: '输入作品名后搜索，选择结果即可加入当前计划。',
-              )
+              const _BangumiSearchHintCard()
             else
               for (final work in _results) ...[
                 _WorkResultCard(
@@ -553,47 +580,131 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
       body: Form(
         key: _formKey,
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
           children: [
             Text(
               '加入到：${widget.plan.name}',
               style: const TextStyle(
                 color: AppColors.textSecondary,
-                fontSize: 13,
+                fontSize: 14,
                 letterSpacing: 0,
               ),
             ),
-            const SizedBox(height: 12),
-            _FormSection(
-              children: [
-                TextFormField(
-                  controller: _linkController,
-                  decoration: stableInputDecoration(
-                    labelText: 'Anitabi 链接',
-                    hintText:
-                        '例如 https://www.anitabi.cn/map?bangumiId=8290&pid=qdmnf6iqj',
+            const SizedBox(height: 18),
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                border: Border.all(color: AppColors.border),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Anitabi 链接',
+                    style: TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
                   ),
-                  keyboardType: TextInputType.url,
-                  textInputAction: TextInputAction.done,
-                  validator: _validateLink,
-                  onFieldSubmitted: (_) => _openImport(),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _linkController,
+                    decoration: InputDecoration(
+                      hintText: '粘贴 Anitabi 作品或点位链接',
+                      hintStyle: TextStyle(
+                        color: AppColors.textSecondary.withValues(alpha: 0.48),
+                        fontSize: 14,
+                        letterSpacing: 0,
+                      ),
+                      helperText: ' ',
+                      suffixIcon: const Padding(
+                        padding: EdgeInsets.only(right: 6),
+                        child: IconButton(
+                          onPressed: null,
+                          tooltip: '粘贴',
+                          icon: Icon(Icons.content_paste_outlined, size: 20),
+                        ),
+                      ),
+                      suffixIconConstraints: const BoxConstraints(
+                        minWidth: 46,
+                        minHeight: 40,
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 14,
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(color: AppColors.border),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: BorderSide(
+                          color: AppColors.accent,
+                          width: 1.4,
+                        ),
+                      ),
+                      errorBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(color: Colors.redAccent),
+                      ),
+                      focusedErrorBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(
+                          color: Colors.redAccent,
+                          width: 1.4,
+                        ),
+                      ),
+                    ),
+                    keyboardType: TextInputType.url,
+                    textInputAction: TextInputAction.done,
+                    validator: _validateLink,
+                    onFieldSubmitted: (_) => _openImport(),
+                  ),
+                  const SizedBox(height: 8),
+                  const _DashedDivider(),
+                  const SizedBox(height: 16),
+                  const _InfoHeading(),
+                  const SizedBox(height: 8),
+                  const Text(
+                    '如果链接里包含作品 ID，会只加载对应作品；\n如果还包含点位 ID，会自动选中该点位。\n没有作品 ID 的链接需要先在 Anitabi 中进入对应作品后重新复制。',
+                    style: TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                      height: 1.45,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 18),
+            const _LinkExampleCard(),
+            const SizedBox(height: 14),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _openImport,
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size.fromHeight(50),
+                  padding: const EdgeInsets.symmetric(horizontal: 18),
+                  alignment: Alignment.center,
                 ),
-                const SizedBox(height: 10),
-                const Text(
-                  '如果链接里包含作品 ID，会只加载对应作品；如果还包含点位 ID，会自动选中该点位。没有作品 ID 的链接需要先在 Anitabi 中进入对应作品后重新复制。',
+                icon: const Icon(Icons.add_location_alt_outlined, size: 21),
+                label: const Text(
+                  '打开 Anitabi 点位',
                   style: TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 12,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    height: 1,
                     letterSpacing: 0,
                   ),
                 ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            FilledButton.icon(
-              onPressed: _openImport,
-              icon: const Icon(Icons.add_location_alt_outlined, size: 18),
-              label: const Text('打开 Anitabi 点位'),
+              ),
             ),
           ],
         ),
@@ -614,6 +725,272 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
       return '链接缺少作品 ID，请先在 Anitabi 进入对应作品后复制链接';
     }
     return null;
+  }
+}
+
+class _LinkExampleCard extends StatelessWidget {
+  const _LinkExampleCard();
+
+  static const _linkPrefix = 'https://www.anitabi.cn/map?';
+  static const _bangumiId = 'bangumiId=186515';
+  static const _middle = '&';
+  static const _pointId = 'pid=95ff4037';
+  static const _suffix = '&c=139.7226%2C35.7126&z=19.1';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        border: Border.all(color: AppColors.border),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '有效链接示例',
+            style: TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: 6),
+          const _ExampleLinkText(),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExampleLinkText extends StatelessWidget {
+  const _ExampleLinkText();
+
+  @override
+  Widget build(BuildContext context) {
+    const normalStyle = TextStyle(
+      color: AppColors.textSecondary,
+      fontSize: 13,
+      fontFamily: 'monospace',
+      height: 1.25,
+      letterSpacing: 0,
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.start,
+          runSpacing: 4,
+          children: [
+            const _ExamplePlainText(
+              text: _LinkExampleCard._linkPrefix,
+              style: normalStyle,
+            ),
+            _highlight(_LinkExampleCard._bangumiId),
+            const _ExamplePlainText(
+              text: _LinkExampleCard._middle,
+              style: normalStyle,
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        _ExampleNoteRow(normalStyle: normalStyle),
+        const SizedBox(height: 6),
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.start,
+          runSpacing: 4,
+          children: [
+            _highlight(_LinkExampleCard._pointId),
+            const _ExamplePlainText(
+              text: _LinkExampleCard._suffix,
+              style: normalStyle,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  static Widget _highlight(String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.accent.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        softWrap: false,
+        style: TextStyle(
+          color: AppColors.accentDark,
+          fontSize: 13,
+          fontFamily: 'monospace',
+          fontWeight: FontWeight.w800,
+          height: 1.25,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+class _ExampleNoteRow extends StatelessWidget {
+  const _ExampleNoteRow({required this.normalStyle});
+
+  final TextStyle normalStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final textDirection = Directionality.of(context);
+        final bangumiLeft = _measureTextWidth(
+          _LinkExampleCard._linkPrefix,
+          normalStyle,
+          textDirection,
+        );
+        final bangumiNoteWidth =
+            _measureTextWidth(
+              'Bangumi 作品 ID（必须）',
+              _ExampleNote.textStyle,
+              textDirection,
+            ) +
+            _ExampleNote.horizontalPadding;
+        final resolvedBangumiLeft = bangumiLeft.clamp(
+          0,
+          (constraints.maxWidth - bangumiNoteWidth).clamp(0, double.infinity),
+        );
+
+        return SizedBox(
+          height: 18,
+          child: Stack(
+            children: [
+              const Positioned(
+                left: 0,
+                top: 0,
+                child: _ExampleNote(text: 'Anitabi 点位 ID（可选）'),
+              ),
+              Positioned(
+                left: resolvedBangumiLeft.toDouble(),
+                top: 0,
+                child: const _ExampleNote(text: 'Bangumi 作品 ID（必须）'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  double _measureTextWidth(
+    String text,
+    TextStyle style,
+    TextDirection textDirection,
+  ) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: textDirection,
+      maxLines: 1,
+    )..layout();
+    return painter.width;
+  }
+}
+
+class _ExamplePlainText extends StatelessWidget {
+  const _ExamplePlainText({required this.text, required this.style});
+
+  final String text;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 2),
+      child: Text(text, softWrap: false, style: style),
+    );
+  }
+}
+
+class _ExampleNote extends StatelessWidget {
+  const _ExampleNote({required this.text});
+
+  static const horizontalPadding = 16.0;
+  static const textStyle = TextStyle(
+    color: AppColors.textSecondary,
+    fontSize: 12,
+    fontWeight: FontWeight.w700,
+    height: 1,
+    letterSpacing: 0,
+  );
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceMuted,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(text, style: textStyle),
+    );
+  }
+}
+
+class _DashedDivider extends StatelessWidget {
+  const _DashedDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const dashWidth = 6.0;
+        const gapWidth = 4.0;
+        final dashCount = (constraints.maxWidth / (dashWidth + gapWidth))
+            .floor()
+            .clamp(1, 1000);
+        return Row(
+          children: List.generate(
+            dashCount,
+            (index) => Expanded(
+              child: Padding(
+                padding: EdgeInsets.only(
+                  right: index == dashCount - 1 ? 0 : gapWidth,
+                ),
+                child: Container(height: 1, color: AppColors.border),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _InfoHeading extends StatelessWidget {
+  const _InfoHeading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(Icons.info_outline, color: AppColors.accent, size: 15),
+        const SizedBox(width: 6),
+        const Text(
+          '使用说明',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: 13,
+            fontWeight: FontWeight.w800,
+            letterSpacing: 0,
+          ),
+        ),
+      ],
+    );
   }
 }
 
@@ -724,30 +1101,38 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
             children: [
               _FormSection(
                 children: [
-                  TextFormField(
-                    controller: _titleController,
-                    decoration: stableInputDecoration(labelText: '作品名称'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _subtitleController,
-                    decoration: const InputDecoration(
-                      labelText: '作品原名',
-                      hintText: '可选',
+                  _ManualWorkLabeledField(
+                    label: '作品名称',
+                    required: true,
+                    child: TextFormField(
+                      controller: _titleController,
+                      decoration: _boxedFormDecoration(hintText: '请输入作品的中文名称'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
                     ),
-                    textInputAction: TextInputAction.next,
                   ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _cityController,
-                    decoration: InputDecoration(
-                      labelText: '主要地区',
-                      hintText: '可选，默认 ${widget.plan.area}',
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '作品原名',
+                    child: TextFormField(
+                      controller: _subtitleController,
+                      decoration: _boxedFormDecoration(
+                        hintText: '请输入作品的原名（如日文/英文）',
+                      ),
+                      textInputAction: TextInputAction.next,
                     ),
-                    textInputAction: TextInputAction.done,
-                    onFieldSubmitted: (_) => _saveWork(),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '主要地区',
+                    child: TextFormField(
+                      controller: _cityController,
+                      decoration: _boxedFormDecoration(
+                        hintText: '输入作品主要发生或取景的地区',
+                      ),
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (_) => _saveWork(),
+                    ),
                   ),
                 ],
               ),
@@ -777,6 +1162,49 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
     }
 
     return null;
+  }
+}
+
+class _ManualWorkLabeledField extends StatelessWidget {
+  const _ManualWorkLabeledField({
+    required this.label,
+    required this.child,
+    this.required = false,
+    this.prominent = false,
+  });
+
+  final String label;
+  final Widget child;
+  final bool required;
+  final bool prominent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(text: label),
+              if (required)
+                const TextSpan(
+                  text: ' *',
+                  style: TextStyle(color: Colors.redAccent),
+                ),
+            ],
+          ),
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: prominent ? 15 : 13,
+            fontWeight: prominent ? FontWeight.w800 : FontWeight.w600,
+            letterSpacing: 0,
+          ),
+        ),
+        const SizedBox(height: 6),
+        child,
+      ],
+    );
   }
 }
 
@@ -828,6 +1256,8 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
   final _referenceController = TextEditingController();
   final _latitudeController = TextEditingController();
   final _longitudeController = TextEditingController();
+  final _latitudeFocusNode = FocusNode();
+  final _longitudeFocusNode = FocusNode();
   final _noteController = TextEditingController();
   PilgrimageWork? _selectedWork;
   StoredUserReferenceImage? _pendingReferenceImage;
@@ -886,6 +1316,8 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     _referenceController.dispose();
     _latitudeController.dispose();
     _longitudeController.dispose();
+    _latitudeFocusNode.dispose();
+    _longitudeFocusNode.dispose();
     _noteController.dispose();
     super.dispose();
   }
@@ -1052,8 +1484,23 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
   }
 
   Future<void> _pasteCoordinateFromClipboard() async {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    final coordinate = parseCoordinateText(data?.text ?? '');
+    String clipboardText = '';
+    try {
+      final data = await Clipboard.getData(Clipboard.kTextPlain);
+      clipboardText = data?.text ?? '';
+    } on Object {
+      clipboardText = '';
+    }
+
+    var coordinate = parseCoordinateText(clipboardText);
+    if (coordinate == null && mounted) {
+      final manualText = await _showCoordinatePasteDialog();
+      if (!mounted || manualText == null) {
+        return;
+      }
+      coordinate = parseCoordinateText(manualText);
+    }
+
     if (!mounted) {
       return;
     }
@@ -1063,14 +1510,69 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
       ).showReplacingSnackBar(const SnackBar(content: Text('剪切板中没有可识别的坐标。')));
       return;
     }
+    final parsedCoordinate = coordinate;
 
     setState(() {
-      _latitudeController.text = coordinate.latitude.toStringAsFixed(6);
-      _longitudeController.text = coordinate.longitude.toStringAsFixed(6);
+      _latitudeController.text = parsedCoordinate.latitude.toStringAsFixed(6);
+      _longitudeController.text = parsedCoordinate.longitude.toStringAsFixed(6);
     });
     ScaffoldMessenger.of(
       context,
-    ).showReplacingSnackBar(const SnackBar(content: Text('已填入剪切板坐标。')));
+    ).showReplacingSnackBar(const SnackBar(content: Text('已填入坐标。')));
+  }
+
+  Future<String?> _showCoordinatePasteDialog() async {
+    final controller = TextEditingController();
+    final formKey = GlobalKey<FormState>();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('粘贴坐标'),
+          content: Form(
+            key: formKey,
+            child: TextFormField(
+              controller: controller,
+              autofocus: true,
+              minLines: 2,
+              maxLines: 3,
+              decoration: stableInputDecoration(
+                labelText: '坐标文本',
+                hintText: '例如 35.712576, 139.722166',
+              ),
+              validator: (value) {
+                if (parseCoordinateText(value ?? '') == null) {
+                  return '请输入可识别的坐标';
+                }
+                return null;
+              },
+              textInputAction: TextInputAction.done,
+              onFieldSubmitted: (_) {
+                if (formKey.currentState?.validate() ?? false) {
+                  Navigator.of(dialogContext).pop(controller.text);
+                }
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () {
+                if (formKey.currentState?.validate() ?? false) {
+                  Navigator.of(dialogContext).pop(controller.text);
+                }
+              },
+              child: const Text('填入'),
+            ),
+          ],
+        );
+      },
+    );
+    controller.dispose();
+    return result;
   }
 
   void _removeReferenceImage() {
@@ -1162,53 +1664,58 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
               _FormSection(
                 children: [
                   if (hasPlanWorks)
-                    DropdownButtonFormField<PilgrimageWork>(
-                      initialValue: _selectedWork,
-                      decoration: const InputDecoration(labelText: '所属作品'),
-                      isExpanded: true,
-                      items: [
-                        for (final work in workOptions)
-                          DropdownMenuItem<PilgrimageWork>(
-                            value: work,
-                            child: Text(
-                              work.displayBangumiSubjectType == null
-                                  ? work.title
-                                  : '${work.title} · ${work.displayBangumiSubjectType!.label}',
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                      ],
-                      onChanged: (work) {
-                        setState(() {
-                          _selectedWork = work;
-                        });
-                      },
-                      validator: (work) => work == null ? '请选择作品' : null,
+                    _ManualWorkLabeledField(
+                      label: '所属作品',
+                      required: true,
+                      prominent: true,
+                      child: PilgrimageWorkDropdown(
+                        works: workOptions,
+                        value: _selectedWork,
+                        onChanged: (work) {
+                          setState(() {
+                            _selectedWork = work;
+                          });
+                        },
+                        validator: (work) => work == null ? '请选择作品' : null,
+                      ),
                     )
                   else ...[
-                    TextFormField(
-                      controller: _fallbackWorkTitleController,
-                      decoration: stableInputDecoration(labelText: '动画/作品名称'),
-                      textInputAction: TextInputAction.next,
-                      validator: _requiredText,
-                    ),
-                    const SizedBox(height: 12),
-                    TextFormField(
-                      controller: _fallbackWorkSubtitleController,
-                      decoration: const InputDecoration(
-                        labelText: '作品原名',
-                        hintText: '可选',
+                    _ManualWorkLabeledField(
+                      label: '作品名称',
+                      required: true,
+                      prominent: true,
+                      child: TextFormField(
+                        controller: _fallbackWorkTitleController,
+                        decoration: _boxedFormDecoration(
+                          hintText: '请输入作品的中文名称',
+                        ),
+                        textInputAction: TextInputAction.next,
+                        validator: _requiredText,
                       ),
-                      textInputAction: TextInputAction.next,
                     ),
-                    const SizedBox(height: 12),
-                    TextFormField(
-                      controller: _fallbackWorkCityController,
-                      decoration: InputDecoration(
-                        labelText: '作品主要地区',
-                        hintText: '可选，默认 ${widget.plan.area}',
+                    const SizedBox(height: 8),
+                    _ManualWorkLabeledField(
+                      label: '作品原名',
+                      prominent: true,
+                      child: TextFormField(
+                        controller: _fallbackWorkSubtitleController,
+                        decoration: _boxedFormDecoration(
+                          hintText: '请输入作品的原名（如日文/英文）',
+                        ),
+                        textInputAction: TextInputAction.next,
                       ),
-                      textInputAction: TextInputAction.next,
+                    ),
+                    const SizedBox(height: 8),
+                    _ManualWorkLabeledField(
+                      label: '主要地区',
+                      prominent: true,
+                      child: TextFormField(
+                        controller: _fallbackWorkCityController,
+                        decoration: _boxedFormDecoration(
+                          hintText: '输入作品主要发生或取景的地区',
+                        ),
+                        textInputAction: TextInputAction.next,
+                      ),
                     ),
                   ],
                 ],
@@ -1216,97 +1723,194 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
               const SizedBox(height: 12),
               _FormSection(
                 children: [
-                  TextFormField(
-                    controller: _nameController,
-                    decoration: stableInputDecoration(labelText: '点位名称'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _subtitleController,
-                    decoration: stableInputDecoration(labelText: '位置说明'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _episodeController,
-                    decoration: stableInputDecoration(labelText: '集数/场景标签'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _referenceController,
-                    decoration: stableInputDecoration(labelText: '参考来源'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _noteController,
-                    decoration: const InputDecoration(
-                      labelText: '备注',
-                      hintText: '可选，例如闭店、翻修、拍摄建议',
+                  _ManualWorkLabeledField(
+                    label: '点位名称',
+                    required: true,
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _nameController,
+                      decoration: _boxedFormDecoration(hintText: '请输入点位名称'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
                     ),
-                    minLines: 2,
-                    maxLines: 4,
-                    textInputAction: TextInputAction.newline,
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '位置说明',
+                    required: true,
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _subtitleController,
+                      decoration: _boxedFormDecoration(hintText: '请输入位置说明'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '集数/场景标签',
+                    required: true,
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _episodeController,
+                      decoration: _boxedFormDecoration(hintText: '请输入集数或场景标签'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '参考来源',
+                    required: true,
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _referenceController,
+                      decoration: _boxedFormDecoration(hintText: '请输入参考来源'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '备注',
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _noteController,
+                      decoration: _boxedFormDecoration(
+                        hintText: '可选，填写闭店、翻修或拍摄建议等补充信息',
+                      ),
+                      minLines: 4,
+                      maxLines: 8,
+                      keyboardType: TextInputType.multiline,
+                      textInputAction: TextInputAction.newline,
+                      textAlignVertical: TextAlignVertical.top,
+                    ),
                   ),
                 ],
               ),
               const SizedBox(height: 12),
               _FormSection(
                 children: [
+                  const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      '坐标位置',
+                      style: TextStyle(
+                        color: AppColors.textPrimary,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _CoordinateLabeledField(
+                          label: '纬度',
+                          focusNode: _latitudeFocusNode,
+                          child: TextFormField(
+                            controller: _latitudeController,
+                            focusNode: _latitudeFocusNode,
+                            decoration: _coordinateInputDecoration(
+                              hintText: '例如 34.8917',
+                            ),
+                            style: const TextStyle(
+                              color: AppColors.textPrimary,
+                              fontSize: 15,
+                              fontWeight: FontWeight.w500,
+                              letterSpacing: 0,
+                            ),
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                              signed: true,
+                            ),
+                            textInputAction: TextInputAction.next,
+                            validator: _validateLatitude,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: _CoordinateLabeledField(
+                          label: '经度',
+                          focusNode: _longitudeFocusNode,
+                          child: TextFormField(
+                            controller: _longitudeController,
+                            focusNode: _longitudeFocusNode,
+                            decoration: _coordinateInputDecoration(
+                              hintText: '例如 135.8077',
+                            ),
+                            style: const TextStyle(
+                              color: AppColors.textPrimary,
+                              fontSize: 15,
+                              fontWeight: FontWeight.w500,
+                              letterSpacing: 0,
+                            ),
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                              signed: true,
+                            ),
+                            textInputAction: TextInputAction.done,
+                            validator: _validateLongitude,
+                            onFieldSubmitted: (_) => _savePoint(),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 14),
                   Row(
                     children: [
                       Expanded(
                         child: OutlinedButton.icon(
                           onPressed: _isSaving ? null : _pickCoordinateFromMap,
-                          icon: const Icon(Icons.ads_click_outlined, size: 18),
-                          label: const Text('从地图选择坐标'),
+                          style: OutlinedButton.styleFrom(
+                            fixedSize: const Size.fromHeight(40),
+                            padding: const EdgeInsets.symmetric(horizontal: 14),
+                            foregroundColor: AppColors.accent,
+                            backgroundColor: AppColors.accent.withValues(
+                              alpha: 0.06,
+                            ),
+                            side: BorderSide(
+                              color: AppColors.accent.withValues(alpha: 0.35),
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          icon: const Icon(Icons.location_on, size: 19),
+                          label: const Text(
+                            '从地图选择',
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: 0,
+                            ),
+                          ),
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      IconButton.outlined(
-                        tooltip: '粘贴剪切板坐标',
-                        onPressed: _isSaving
-                            ? null
-                            : _pasteCoordinateFromClipboard,
-                        style: AppButtonStyles.compactOutlinedIconButton(),
-                        icon: const Icon(Icons.content_paste_outlined),
+                      const SizedBox(width: 10),
+                      SizedBox(
+                        width: 44,
+                        height: 40,
+                        child: IconButton.outlined(
+                          tooltip: '粘贴剪切板坐标',
+                          onPressed: _isSaving
+                              ? null
+                              : _pasteCoordinateFromClipboard,
+                          style: IconButton.styleFrom(
+                            foregroundColor: AppColors.textPrimary,
+                            side: const BorderSide(color: AppColors.border),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          icon: const Icon(Icons.content_paste_outlined),
+                        ),
                       ),
                     ],
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _latitudeController,
-                    decoration: stableInputDecoration(
-                      labelText: '纬度',
-                      hintText: '例如 34.8917',
-                    ),
-                    keyboardType: const TextInputType.numberWithOptions(
-                      decimal: true,
-                      signed: true,
-                    ),
-                    textInputAction: TextInputAction.next,
-                    validator: _validateLatitude,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _longitudeController,
-                    decoration: stableInputDecoration(
-                      labelText: '经度',
-                      hintText: '例如 135.8077',
-                    ),
-                    keyboardType: const TextInputType.numberWithOptions(
-                      decimal: true,
-                      signed: true,
-                    ),
-                    textInputAction: TextInputAction.done,
-                    validator: _validateLongitude,
-                    onFieldSubmitted: (_) => _savePoint(),
                   ),
                 ],
               ),
@@ -1360,6 +1964,25 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     return null;
   }
 
+  InputDecoration _coordinateInputDecoration({String? hintText}) {
+    return InputDecoration(
+      hintText: hintText,
+      hintStyle: TextStyle(
+        color: AppColors.textSecondary.withValues(alpha: 0.42),
+        fontSize: 13,
+        letterSpacing: 0,
+      ),
+      isDense: true,
+      contentPadding: EdgeInsets.zero,
+      border: InputBorder.none,
+      enabledBorder: InputBorder.none,
+      focusedBorder: InputBorder.none,
+      errorBorder: InputBorder.none,
+      focusedErrorBorder: InputBorder.none,
+      errorStyle: const TextStyle(fontSize: 11, height: 0.9),
+    );
+  }
+
   String? _validateLatitude(String? value) {
     return _validateCoordinate(value, min: -90, max: 90, emptyMessage: '请填写纬度');
   }
@@ -1390,6 +2013,67 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     }
 
     return null;
+  }
+}
+
+class _CoordinateLabeledField extends StatelessWidget {
+  const _CoordinateLabeledField({
+    required this.label,
+    required this.focusNode,
+    required this.child,
+  });
+
+  final String label;
+  final FocusNode focusNode;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: focusNode,
+      builder: (context, child) {
+        final focused = focusNode.hasFocus;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          constraints: const BoxConstraints(minHeight: 62),
+          padding: const EdgeInsets.fromLTRB(14, 9, 14, 8),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            border: Border.all(
+              color: focused ? AppColors.accent : AppColors.border,
+              width: 1.4,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text.rich(
+                TextSpan(
+                  children: [
+                    TextSpan(text: label),
+                    const TextSpan(
+                      text: ' *',
+                      style: TextStyle(color: Colors.redAccent),
+                    ),
+                  ],
+                ),
+                style: const TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0,
+                ),
+              ),
+              const SizedBox(height: 4),
+              child!,
+            ],
+          ),
+        );
+      },
+      child: child,
+    );
   }
 }
 
@@ -1682,85 +2366,90 @@ class _ManualReferenceImagePicker extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      child: Row(
-        children: [
-          Tooltip(
-            message: canPreview ? '查看大图' : '暂无参考图',
-            child: GestureDetector(
-              onTap: canPreview
-                  ? () => ImageViewerScreen.show(
-                      context,
-                      filePath: previewPath,
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Tooltip(
+              message: canPreview ? '查看大图' : '暂无参考图',
+              child: GestureDetector(
+                onTap: canPreview
+                    ? () => ImageViewerScreen.show(
+                        context,
+                        filePath: previewPath,
+                        imageUrl: imageUrl,
+                      )
+                    : null,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Container(
+                    width: 104,
+                    color: AppColors.surfaceMuted,
+                    child: ReferenceThumbnail(
+                      localPath: localPath,
                       imageUrl: imageUrl,
-                    )
-                  : null,
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: Container(
-                  width: 72,
-                  height: 72,
-                  color: AppColors.surfaceMuted,
-                  child: ReferenceThumbnail(
-                    localPath: localPath,
-                    imageUrl: imageUrl,
-                    fit: BoxFit.cover,
-                    placeholder: const Icon(
-                      Icons.image_outlined,
-                      color: AppColors.textSecondary,
+                      fit: BoxFit.cover,
+                      placeholder: const Icon(
+                        Icons.image_outlined,
+                        color: AppColors.textSecondary,
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  '参考图片',
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: 0,
-                  ),
-                ),
-                const SizedBox(height: 3),
-                Text(
-                  hasPendingSelection
-                      ? '已选择新图片，保存后生效。'
-                      : hasExistingImage
-                      ? '当前参考图，重新选择后需保存才会生效。'
-                      : '可选，保存时会复制到 App 本地目录。',
-                  style: const TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 12,
-                    letterSpacing: 0,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 6,
-                  children: [
-                    OutlinedButton.icon(
-                      onPressed: onPick,
-                      icon: const Icon(Icons.photo_library_outlined, size: 18),
-                      label: Text(hasImage ? '重新选择' : '上传参考图'),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '参考图片',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
                     ),
-                    if (hasPendingSelection)
-                      TextButton.icon(
-                        onPressed: onRemove,
-                        icon: const Icon(Icons.close_outlined, size: 18),
-                        label: const Text('移除'),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    hasPendingSelection
+                        ? '已选择新图片，保存后生效。'
+                        : hasExistingImage
+                        ? '当前参考图，重新选择后需保存才会生效。'
+                        : '可选，保存时会复制到 App 本地目录。',
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 12,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 6,
+                    children: [
+                      OutlinedButton.icon(
+                        onPressed: onPick,
+                        icon: const Icon(
+                          Icons.photo_library_outlined,
+                          size: 18,
+                        ),
+                        label: Text(hasImage ? '重新选择' : '上传参考图'),
                       ),
-                  ],
-                ),
-              ],
+                      if (hasPendingSelection)
+                        TextButton.icon(
+                          onPressed: onRemove,
+                          icon: const Icon(Icons.close_outlined, size: 18),
+                          label: const Text('移除'),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -1941,6 +2630,72 @@ class _MessageCard extends StatelessWidget {
               style: const TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 14,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BangumiSearchHintCard extends StatelessWidget {
+  const _BangumiSearchHintCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Icon(Icons.info_outline, color: AppColors.accent, size: 16),
+              const SizedBox(width: 8),
+              const Text(
+                '温馨提示',
+                style: TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  height: 1,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            '输入作品名后搜索，选择结果即可加入当前计划。',
+            style: TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 13,
+              height: 1.35,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              'Bangumi需要国际网络环境才能正常搜索。',
+              style: TextStyle(
+                color: AppColors.accentDark,
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+                height: 1.25,
                 letterSpacing: 0,
               ),
             ),

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -1214,6 +1214,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                     child: PilgrimageWorkDropdown(
                       works: works,
                       value: _selectedWork,
+                      omitScrollbarInsetWhenUnscrollable: true,
                       onChanged: _isImporting
                           ? null
                           : (work) {

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -27,7 +27,9 @@ import '../utils/limited_concurrency.dart';
 import '../utils/selected_item_order.dart';
 import 'nearest_group_assign_screen.dart';
 import 'pilgrimage_models.dart';
+import 'pilgrimage_work_dropdown.dart';
 import 'plan_group_manager_screen.dart';
+import 'work_manager_screen.dart';
 
 class AnitabiMapImportScreen extends StatefulWidget {
   AnitabiMapImportScreen({
@@ -179,6 +181,31 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     setState(() {
       _error = null;
     });
+  }
+
+  Future<void> _openWorkManager() async {
+    final didUpdate = await Navigator.of(context).push<bool>(
+      MaterialPageRoute<bool>(
+        builder: (_) => WorkManagerScreen(
+          plan: _importedPlan,
+          repository: widget.repository,
+        ),
+      ),
+    );
+    if (!mounted || didUpdate != true) {
+      return;
+    }
+
+    final plans = await widget.repository.loadPlans();
+    if (!mounted) {
+      return;
+    }
+    final updatedPlan = plans.firstWhere((plan) => plan.id == _importedPlan.id);
+    setState(() {
+      _replaceImportedPlan(updatedPlan);
+      _didUpdatePlan = true;
+    });
+    await _refreshAnitabiData();
   }
 
   Future<void> _loadPoints(PilgrimageWork work) async {
@@ -1184,22 +1211,9 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                   preferredSize: const Size.fromHeight(58),
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-                    child: DropdownButtonFormField<PilgrimageWork>(
-                      initialValue: _selectedWork,
-                      decoration: const InputDecoration(labelText: '作品'),
-                      isExpanded: true,
-                      items: [
-                        for (final work in works)
-                          DropdownMenuItem<PilgrimageWork>(
-                            value: work,
-                            child: Text(
-                              work.displayBangumiSubjectType == null
-                                  ? work.title
-                                  : '${work.title} · ${work.displayBangumiSubjectType!.label}',
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                      ],
+                    child: PilgrimageWorkDropdown(
+                      works: works,
+                      value: _selectedWork,
                       onChanged: _isImporting
                           ? null
                           : (work) {
@@ -1226,7 +1240,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
             }
 
             if (works.isEmpty) {
-              return const _EmptyImportState();
+              return _EmptyImportState(onOpenWorkManager: _openWorkManager);
             }
 
             if (!_isLoading &&
@@ -2241,22 +2255,154 @@ String? _anitabiThumbnailUrl(String? url) {
 }
 
 class _EmptyImportState extends StatelessWidget {
-  const _EmptyImportState();
+  const _EmptyImportState({required this.onOpenWorkManager});
+
+  final VoidCallback onOpenWorkManager;
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Padding(
-        padding: EdgeInsets.all(24),
-        child: Text(
-          '当前计划还没有 Bangumi 作品。请先到作品管理添加 Bangumi 作品。',
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            color: AppColors.textSecondary,
-            fontSize: 14,
-            letterSpacing: 0,
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      children: [
+        Container(
+          padding: const EdgeInsets.all(18),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: AppColors.border),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.movie_filter_outlined, color: AppColors.accent),
+                  const SizedBox(width: 8),
+                  Text(
+                    '还没有作品',
+                    style: TextStyle(
+                      color: AppColors.accentDark,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 14),
+              const _ImportWorkGuideTimeline(),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: onOpenWorkManager,
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(46),
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                  ),
+                  icon: const Icon(Icons.movie_filter_outlined, size: 20),
+                  label: const Text('作品管理'),
+                ),
+              ),
+            ],
           ),
         ),
+      ],
+    );
+  }
+}
+
+class _ImportWorkGuideTimeline extends StatelessWidget {
+  const _ImportWorkGuideTimeline();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        _ImportWorkGuideStep(
+          title: '从Bangumi导入',
+          body: '点击作品管理中的Bangumi按钮，搜索你想导入的作品并导入。之后你可以在这里直接查看对应作品在Anitabi上的点位。',
+          isLast: true,
+        ),
+      ],
+    );
+  }
+}
+
+class _ImportWorkGuideStep extends StatelessWidget {
+  const _ImportWorkGuideStep({
+    required this.title,
+    required this.body,
+    this.isLast = false,
+  });
+
+  final String title;
+  final String body;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            width: 18,
+            child: Stack(
+              children: [
+                if (!isLast)
+                  Positioned(
+                    left: 8,
+                    top: 10,
+                    bottom: 0,
+                    child: Container(width: 2, color: AppColors.border),
+                  ),
+                Positioned(
+                  left: 4,
+                  top: 5,
+                  child: Container(
+                    width: 10,
+                    height: 10,
+                    decoration: BoxDecoration(
+                      color: AppColors.accent,
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 5),
+                  Text(
+                    body,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                      height: 1.35,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/plan/pilgrimage_work_dropdown.dart
+++ b/lib/plan/pilgrimage_work_dropdown.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+
+import '../app_theme.dart';
+import 'pilgrimage_models.dart';
+
+class PilgrimageWorkDropdown extends StatelessWidget {
+  const PilgrimageWorkDropdown({
+    required this.works,
+    required this.value,
+    required this.onChanged,
+    this.validator,
+    super.key,
+  });
+
+  final List<PilgrimageWork> works;
+  final PilgrimageWork? value;
+  final ValueChanged<PilgrimageWork?>? onChanged;
+  final FormFieldValidator<PilgrimageWork>? validator;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: Theme.of(context).copyWith(
+        focusColor: Colors.transparent,
+        hoverColor: Colors.transparent,
+        highlightColor: AppColors.accent.withValues(alpha: 0.075),
+        splashColor: Colors.transparent,
+      ),
+      child: DropdownButtonFormField<PilgrimageWork>(
+        key: ValueKey(value?.id),
+        initialValue: value,
+        decoration: _decoration(),
+        isExpanded: true,
+        elevation: 2,
+        borderRadius: BorderRadius.circular(8),
+        dropdownColor: AppColors.surface,
+        menuMaxHeight: 360,
+        icon: const Padding(
+          padding: EdgeInsets.only(right: 8),
+          child: Icon(Icons.keyboard_arrow_down_rounded, size: 20),
+        ),
+        selectedItemBuilder: (context) => [
+          for (final work in works) _WorkDropdownItem(work: work),
+        ],
+        items: [
+          for (final work in works)
+            DropdownMenuItem<PilgrimageWork>(
+              value: work,
+              child: _WorkDropdownItem(
+                work: work,
+                selected: work.id == value?.id,
+                menuItem: true,
+              ),
+            ),
+        ],
+        onChanged: onChanged,
+        validator: validator,
+      ),
+    );
+  }
+
+  InputDecoration _decoration() {
+    return InputDecoration(
+      isDense: true,
+      filled: true,
+      fillColor: AppColors.surface,
+      hoverColor: AppColors.accent.withValues(alpha: 0.035),
+      contentPadding: const EdgeInsets.fromLTRB(14, 10, 4, 10),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: AppColors.border, width: 1.4),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: AppColors.accent, width: 1.4),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+      ),
+    );
+  }
+}
+
+class _WorkDropdownItem extends StatefulWidget {
+  const _WorkDropdownItem({
+    required this.work,
+    this.selected = false,
+    this.menuItem = false,
+  });
+
+  final PilgrimageWork work;
+  final bool selected;
+  final bool menuItem;
+
+  @override
+  State<_WorkDropdownItem> createState() => _WorkDropdownItemState();
+}
+
+class _WorkDropdownItemState extends State<_WorkDropdownItem> {
+  var _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final work = widget.work;
+    final selected = widget.selected;
+    final highlighted = selected || _hovered;
+    final badgeLabel =
+        work.displayBangumiSubjectType?.label ??
+        (work.source == WorkSource.manual ? '手动' : '作品');
+
+    final item = AnimatedContainer(
+      duration: const Duration(milliseconds: 100),
+      curve: Curves.easeOut,
+      width: double.infinity,
+      padding: EdgeInsets.symmetric(
+        horizontal: highlighted ? 12 : 0,
+        vertical: widget.menuItem ? 7 : 0,
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.08),
+              border: Border.all(
+                color: AppColors.accent.withValues(alpha: 0.42),
+              ),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              badgeLabel,
+              style: TextStyle(
+                color: AppColors.accent,
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                height: 1.15,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              work.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 14,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+          if (selected) ...[
+            const SizedBox(width: 8),
+            Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+          ],
+        ],
+      ),
+    );
+
+    final content = highlighted
+        ? Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Positioned(
+                left: -8,
+                top: 0,
+                right: -8,
+                bottom: 0,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: AppColors.accent.withValues(
+                      alpha: selected ? 0.1 : 0.05,
+                    ),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                ),
+              ),
+              item,
+            ],
+          )
+        : item;
+
+    return MouseRegion(
+      onEnter: widget.menuItem && !selected
+          ? (_) => setState(() => _hovered = true)
+          : null,
+      onExit: widget.menuItem && !selected
+          ? (_) => setState(() => _hovered = false)
+          : null,
+      child: content,
+    );
+  }
+}

--- a/lib/plan/pilgrimage_work_dropdown.dart
+++ b/lib/plan/pilgrimage_work_dropdown.dart
@@ -8,6 +8,7 @@ class PilgrimageWorkDropdown extends StatelessWidget {
     required this.works,
     required this.value,
     required this.onChanged,
+    this.omitScrollbarInsetWhenUnscrollable = false,
     this.validator,
     super.key,
   });
@@ -15,10 +16,17 @@ class PilgrimageWorkDropdown extends StatelessWidget {
   final List<PilgrimageWork> works;
   final PilgrimageWork? value;
   final ValueChanged<PilgrimageWork?>? onChanged;
+  final bool omitScrollbarInsetWhenUnscrollable;
   final FormFieldValidator<PilgrimageWork>? validator;
+
+  static const _maxItemsWithoutScrollbar = 7;
 
   @override
   Widget build(BuildContext context) {
+    final omitScrollbarInset =
+        omitScrollbarInsetWhenUnscrollable &&
+        works.length <= _maxItemsWithoutScrollbar;
+
     return Theme(
       data: Theme.of(context).copyWith(
         focusColor: Colors.transparent,
@@ -50,6 +58,7 @@ class PilgrimageWorkDropdown extends StatelessWidget {
                 work: work,
                 selected: work.id == value?.id,
                 menuItem: true,
+                omitScrollbarInset: omitScrollbarInset,
               ),
             ),
         ],
@@ -91,101 +100,116 @@ class _WorkDropdownItem extends StatefulWidget {
     required this.work,
     this.selected = false,
     this.menuItem = false,
+    this.omitScrollbarInset = false,
   });
 
   final PilgrimageWork work;
   final bool selected;
   final bool menuItem;
+  final bool omitScrollbarInset;
 
   @override
   State<_WorkDropdownItem> createState() => _WorkDropdownItemState();
 }
 
 class _WorkDropdownItemState extends State<_WorkDropdownItem> {
+  static const _hoverOffset = 12.0;
+  static const _menuTrailingInset = 10.0;
+  static const _menuBackgroundTrailingInset = 6.0;
+
   var _hovered = false;
 
   @override
   Widget build(BuildContext context) {
     final work = widget.work;
     final selected = widget.selected;
-    final highlighted = selected || _hovered;
+    final reserveScrollbarSpace = widget.menuItem && !widget.omitScrollbarInset;
     final badgeLabel =
         work.displayBangumiSubjectType?.label ??
         (work.source == WorkSource.manual ? '手动' : '作品');
 
-    final item = AnimatedContainer(
-      duration: const Duration(milliseconds: 100),
-      curve: Curves.easeOut,
+    final item = SizedBox(
       width: double.infinity,
-      padding: EdgeInsets.symmetric(
-        horizontal: highlighted ? 12 : 0,
-        vertical: widget.menuItem ? 7 : 0,
-      ),
-      child: Row(
-        children: [
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: AppColors.accent.withValues(alpha: 0.08),
-              border: Border.all(
-                color: AppColors.accent.withValues(alpha: 0.42),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOutCubic,
+        transform: Matrix4.translationValues(
+          _hovered && !selected ? _hoverOffset : 0,
+          0,
+          0,
+        ),
+        transformAlignment: Alignment.centerLeft,
+        padding: EdgeInsets.only(
+          right: reserveScrollbarSpace ? _menuTrailingInset : 0,
+          top: widget.menuItem ? 7 : 0,
+          bottom: widget.menuItem ? 7 : 0,
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: AppColors.accent.withValues(alpha: 0.08),
+                border: Border.all(
+                  color: AppColors.accent.withValues(alpha: 0.42),
+                ),
+                borderRadius: BorderRadius.circular(4),
               ),
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(
-              badgeLabel,
-              style: TextStyle(
-                color: AppColors.accent,
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                height: 1.15,
-                letterSpacing: 0,
-              ),
-            ),
-          ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              work.title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: AppColors.textPrimary,
-                fontSize: 14,
-                letterSpacing: 0,
+              child: Text(
+                badgeLabel,
+                style: TextStyle(
+                  color: AppColors.accent,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  height: 1.15,
+                  letterSpacing: 0,
+                ),
               ),
             ),
-          ),
-          if (selected) ...[
-            const SizedBox(width: 8),
-            Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                work.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 14,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+            if (selected) ...[
+              const SizedBox(width: 8),
+              Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+            ],
           ],
-        ],
+        ),
       ),
     );
 
-    final content = highlighted
-        ? Stack(
-            clipBehavior: Clip.none,
-            children: [
-              Positioned(
-                left: -8,
-                top: 0,
-                right: -8,
-                bottom: 0,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: AppColors.accent.withValues(
-                      alpha: selected ? 0.1 : 0.05,
-                    ),
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                ),
+    final content = Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Positioned(
+          left: -8,
+          top: 0,
+          right: reserveScrollbarSpace ? _menuBackgroundTrailingInset : -8,
+          bottom: 0,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOutCubic,
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(
+                alpha: selected ? 0.1 : (_hovered ? 0.05 : 0),
               ),
-              item,
-            ],
-          )
-        : item;
+              borderRadius: BorderRadius.circular(6),
+            ),
+          ),
+        ),
+        item,
+      ],
+    );
 
     return MouseRegion(
       onEnter: widget.menuItem && !selected

--- a/lib/plan/plan_memo_screen.dart
+++ b/lib/plan/plan_memo_screen.dart
@@ -444,7 +444,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
                     ],
                   )
                 : memo.isEmpty
-                ? const _EmptyPlanMemo()
+                ? _EmptyPlanMemo(onStart: _startEditing)
                 : _PlanMemoMarkdownPreview(
                     data: _savedMemo,
                     onTapLink: _openMarkdownLink,
@@ -797,46 +797,201 @@ class _UnsupportedMarkdownImage extends StatelessWidget {
 }
 
 class _EmptyPlanMemo extends StatelessWidget {
-  const _EmptyPlanMemo();
+  const _EmptyPlanMemo({required this.onStart});
+
+  final VoidCallback onStart;
+
+  static const _suggestions = [
+    (
+      icon: Icons.directions_transit_outlined,
+      label: '交通安排',
+      detail: '如车次、换乘方案、出发时间等',
+    ),
+    (icon: Icons.hotel_outlined, label: '酒店预约', detail: '酒店地址、入住时间、联系方式等'),
+    (
+      icon: Icons.confirmation_number_outlined,
+      label: '活动门票',
+      detail: '活动门票、预约时间、注意事项等',
+    ),
+    (
+      icon: Icons.photo_camera_outlined,
+      label: '拍摄计划',
+      detail: '拍摄地点、时间、天气备选方案等',
+    ),
+    (
+      icon: Icons.notifications_none_rounded,
+      label: '注意事项',
+      detail: '携带物品、预算、当地注意事项等',
+    ),
+  ];
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final guideWidth = (constraints.maxWidth * 0.84).clamp(0.0, 420.0);
+        return SingleChildScrollView(
+          child: SizedBox(
+            width: constraints.maxWidth,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const SizedBox(height: 20),
+                Container(
+                  width: 72,
+                  height: 72,
+                  decoration: BoxDecoration(
+                    color: AppColors.accent.withValues(alpha: 0.10),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Icon(
+                    Icons.sticky_note_2_outlined,
+                    color: AppColors.accentDark,
+                    size: 34,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  '还没有计划备忘',
+                  style: TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  '记录本次巡礼的重要事项',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: guideWidth,
+                  child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.fromLTRB(14, 12, 14, 10),
+                    decoration: BoxDecoration(
+                      color: AppColors.surfaceMuted,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: AppColors.border),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.lightbulb_outline_rounded,
+                              color: AppColors.accent,
+                              size: 18,
+                            ),
+                            const SizedBox(width: 7),
+                            Text(
+                              '可记录内容',
+                              style: TextStyle(
+                                color: AppColors.accentDark,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        for (
+                          var index = 0;
+                          index < _suggestions.length;
+                          index++
+                        ) ...[
+                          _MemoSuggestionItem(suggestion: _suggestions[index]),
+                          if (index < _suggestions.length - 1)
+                            const Divider(height: 1, indent: 42),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: guideWidth,
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: onStart,
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size.fromHeight(46),
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                      ),
+                      icon: const Icon(Icons.edit_note_rounded, size: 20),
+                      label: const Text('开始记录'),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _MemoSuggestionItem extends StatelessWidget {
+  const _MemoSuggestionItem({required this.suggestion});
+
+  final ({IconData icon, String label, String detail}) suggestion;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 56,
+      child: Row(
         children: [
           Container(
-            width: 72,
-            height: 72,
+            width: 34,
+            height: 34,
+            alignment: Alignment.center,
             decoration: BoxDecoration(
-              color: AppColors.accent.withValues(alpha: 0.10),
-              borderRadius: BorderRadius.circular(8),
+              color: AppColors.accent.withValues(alpha: 0.08),
+              shape: BoxShape.circle,
             ),
-            child: Icon(
-              Icons.sticky_note_2_outlined,
-              color: AppColors.accentDark,
-              size: 34,
-            ),
+            child: Icon(suggestion.icon, color: AppColors.accent, size: 18),
           ),
-          const SizedBox(height: 16),
-          const Text(
-            '还没有写计划备忘',
-            style: TextStyle(
-              color: AppColors.textPrimary,
-              fontSize: 18,
-              fontWeight: FontWeight.w800,
-              letterSpacing: 0,
-            ),
-          ),
-          const SizedBox(height: 8),
-          const Text(
-            '点击右上角编辑，记录交通、预约、补拍事项或其他准备内容。',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: AppColors.textSecondary,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0,
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  suggestion.label,
+                  maxLines: 1,
+                  style: const TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  suggestion.detail,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 11,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ],
             ),
           ),
         ],

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -1425,33 +1425,151 @@ class _EmptyPlanCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(Icons.route_outlined, color: AppColors.accent),
-              SizedBox(width: 8),
+              Icon(Icons.inventory_2_rounded, color: AppColors.accent),
+              const SizedBox(width: 10),
               Text(
                 '还没有点位',
                 style: TextStyle(
                   color: AppColors.accentDark,
-                  fontSize: 15,
+                  fontSize: 18,
                   fontWeight: FontWeight.w800,
                   letterSpacing: 0,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 8),
-          const Text(
-            '先从 Anitabi 或手动录入添加巡礼点，之后这里会显示当前目标和完成进度。',
-            style: TextStyle(
-              color: AppColors.textSecondary,
-              fontSize: 14,
-              letterSpacing: 0,
+          const SizedBox(height: 14),
+          const _OnboardingTimeline(),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: onAddPoints,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(46),
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+              ),
+              icon: const Icon(Icons.add_location_alt_outlined, size: 20),
+              label: const Text('添加点位'),
             ),
           ),
-          const SizedBox(height: 14),
-          FilledButton.icon(
-            onPressed: onAddPoints,
-            icon: const Icon(Icons.add_location_alt_outlined, size: 18),
-            label: const Text('添加点位'),
+        ],
+      ),
+    );
+  }
+}
+
+class _OnboardingTimeline extends StatelessWidget {
+  const _OnboardingTimeline();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        _OnboardingStep(
+          number: 1,
+          title: '加作品',
+          body: '点击右上角，选择“添加点位”，点击“作品管理”，在这里搜索你想要加入巡礼计划的作品并添加。',
+        ),
+        _OnboardingStep(
+          number: 2,
+          title: '选点位',
+          body:
+              '在“添加点位”页面点击“从作品地图导入”，在这里你可以选择并添加巡礼点位。\n你也可以在“添加点位”页面点击“从Anitabi链接导入”。通过使用有效链接，导入点位时作品也会被一起添加。',
+        ),
+        _OnboardingStep(
+          number: 3,
+          title: '划片区',
+          body:
+              '回到“计划”页，点击右上角，选择“管理计划”，在这里你可以对加入计划的点位进行更细致的管理。你可以创建片区，把距离接近的点位放到一起。',
+          isLast: true,
+        ),
+      ],
+    );
+  }
+}
+
+class _OnboardingStep extends StatelessWidget {
+  const _OnboardingStep({
+    required this.number,
+    required this.title,
+    required this.body,
+    this.isLast = false,
+  });
+
+  final int number;
+  final String title;
+  final String body;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            width: 28,
+            child: Column(
+              children: [
+                Container(
+                  width: 26,
+                  height: 26,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: AppColors.accent,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '$number',
+                    style: TextStyle(
+                      color: AppColors.onAccent,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+                if (!isLast)
+                  Expanded(child: Container(width: 2, color: AppColors.border)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(
+                    height: 26,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        title,
+                        style: const TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    body,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                      height: 1.35,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
         ],
       ),
@@ -1467,7 +1585,7 @@ class _WorkHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      margin: const EdgeInsets.fromLTRB(0, 8, 0, 12),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: AppColors.surface,

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -242,9 +242,7 @@ class _WorkManageCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sourceText = work.bangumiId == null
-        ? '手动添加'
-        : 'Bangumi #${work.bangumiId}';
+    final sourceText = work.bangumiId == null ? '手动添加' : 'Bangumi';
     final typeText = work.displayBangumiSubjectType?.label;
     final infoText = [
       work.subtitle,
@@ -324,13 +322,129 @@ class _EmptyWorkPanel extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      child: const Text(
-        '当前计划还没有作品。',
-        style: TextStyle(
-          color: AppColors.textSecondary,
-          fontSize: 14,
-          letterSpacing: 0,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.movie_filter_outlined, color: AppColors.accent),
+              const SizedBox(width: 8),
+              Text(
+                '还没有作品',
+                style: TextStyle(
+                  color: AppColors.accentDark,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          const _WorkOnboardingTimeline(),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkOnboardingTimeline extends StatelessWidget {
+  const _WorkOnboardingTimeline();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        _WorkOnboardingStep(
+          title: '从Bangumi导入',
+          body:
+              '点击上方按钮可从Bangumi搜索你想导入的作品并导入。之后你可以在“从作品地图导入点位”直接查看对应作品在Anitabi上的点位。',
         ),
+        _WorkOnboardingStep(
+          title: '手动添加作品',
+          body:
+              '若Bangumi未收录你想要添加到作品，你可以通过“手动添加”将作品加入到计划内。之后你可以通过“手动添加点位”自主上传想要巡礼的点位。',
+          isLast: true,
+        ),
+      ],
+    );
+  }
+}
+
+class _WorkOnboardingStep extends StatelessWidget {
+  const _WorkOnboardingStep({
+    required this.title,
+    required this.body,
+    this.isLast = false,
+  });
+
+  final String title;
+  final String body;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            width: 18,
+            child: Stack(
+              children: [
+                if (!isLast)
+                  Positioned(
+                    left: 8,
+                    top: 10,
+                    bottom: 0,
+                    child: Container(width: 2, color: AppColors.border),
+                  ),
+                Positioned(
+                  left: 4,
+                  top: 5,
+                  child: Container(
+                    width: 10,
+                    height: 10,
+                    decoration: BoxDecoration(
+                      color: AppColors.accent,
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 5),
+                  Text(
+                    body,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                      height: 1.35,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -198,30 +198,109 @@ class _AddWorkPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(14),
+      padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      child: Row(
-        children: [
-          Expanded(
-            child: FilledButton.icon(
-              onPressed: onBangumi,
-              icon: const Icon(Icons.search, size: 18),
-              label: const Text('Bangumi'),
+      child: SizedBox(
+        height: 56,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: _AddWorkAction(
+                icon: Icons.search_rounded,
+                title: '从 Bangumi 搜索',
+                subtitle: '自动获取信息',
+                onTap: onBangumi,
+              ),
+            ),
+            const VerticalDivider(
+              width: 9,
+              indent: 8,
+              endIndent: 8,
+              color: AppColors.border,
+            ),
+            Expanded(
+              child: _AddWorkAction(
+                icon: Icons.edit_rounded,
+                title: '手动添加作品',
+                subtitle: '未收录时使用',
+                onTap: onManual,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AddWorkAction extends StatelessWidget {
+  const _AddWorkAction({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(6),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(6),
+        child: SizedBox(
+          height: 56,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            child: Row(
+              children: [
+                Icon(icon, size: 20, color: AppColors.textPrimary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 11,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
           ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: OutlinedButton.icon(
-              onPressed: onManual,
-              icon: const Icon(Icons.edit_note, size: 18),
-              label: const Text('手动添加'),
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/records/point_visit_records_screen.dart
+++ b/lib/records/point_visit_records_screen.dart
@@ -21,34 +21,48 @@ class PointVisitRecordsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: controller,
-      builder: (context, _) {
-        final resolvedPoint = controller.pointById(point.id) ?? point;
-        final records = controller.recordsForPoint(point.id);
+    return MediaQuery(
+      data: MediaQuery.of(
+        context,
+      ).copyWith(textScaler: appTextScaler(settings.fontScale)),
+      child: AppUiScaleView(
+        scale: settings.uiScale,
+        child: AnimatedBuilder(
+          animation: controller,
+          builder: (context, _) {
+            final resolvedPoint = controller.pointById(point.id) ?? point;
+            final records = controller.recordsForPoint(point.id);
 
-        return Scaffold(
-          appBar: AppBar(title: const Text('点位拍摄记录')),
-          body: ListView(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
-            children: [
-              _PointRecordsHeader(point: resolvedPoint, count: records.length),
-              const SizedBox(height: 16),
-              if (records.isEmpty)
-                const _EmptyPointRecords()
-              else
-                for (final record in records) ...[
-                  _PointVisitRecordCard(
-                    record: record,
-                    onTap: () =>
-                        _openRecordDetail(context, record, resolvedPoint),
+            return Scaffold(
+              appBar: AppBar(title: const Text('点位拍摄记录')),
+              body: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                children: [
+                  _PointRecordsHeader(
+                    point: resolvedPoint,
+                    count: records.length,
                   ),
-                  const SizedBox(height: 10),
+                  const SizedBox(height: 16),
+                  if (records.isEmpty)
+                    const _EmptyPointRecords()
+                  else ...[
+                    const _PointRecordsListLabel(),
+                    const SizedBox(height: 8),
+                    for (final record in records) ...[
+                      _PointVisitRecordCard(
+                        record: record,
+                        onTap: () =>
+                            _openRecordDetail(context, record, resolvedPoint),
+                      ),
+                      const SizedBox(height: 10),
+                    ],
+                  ],
                 ],
-            ],
-          ),
-        );
-      },
+              ),
+            );
+          },
+        ),
+      ),
     );
   }
 
@@ -130,14 +144,31 @@ class _PointRecordsHeader extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 12),
-          Text(
-            '$count 条',
-            style: TextStyle(
-              color: AppColors.accentDark,
-              fontSize: 15,
-              fontWeight: FontWeight.w800,
-              letterSpacing: 0,
-            ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text(
+                '$count',
+                style: TextStyle(
+                  color: AppColors.accentDark,
+                  fontSize: 26,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                ),
+              ),
+              const SizedBox(width: 2),
+              Text(
+                '条',
+                style: TextStyle(
+                  color: AppColors.accentDark,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -179,6 +210,80 @@ class _EmptyPointRecords extends StatelessWidget {
   }
 }
 
+class _PointRecordsListLabel extends StatelessWidget {
+  const _PointRecordsListLabel();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.zero,
+      child: Row(
+        children: [
+          Icon(Icons.schedule, color: AppColors.accent, size: 15),
+          const SizedBox(width: 6),
+          const Text(
+            '拍摄记录',
+            style: TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 13,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecordCapturedAt {
+  const _RecordCapturedAt({required this.date, required this.time});
+
+  final String date;
+  final String time;
+}
+
+class _RecordCapturedAtText extends StatelessWidget {
+  const _RecordCapturedAtText({required this.capturedAt});
+
+  final DateTime capturedAt;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = _formatCapturedAt(capturedAt);
+    return SizedBox(
+      width: 82,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            value.time,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value.date,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _PointVisitRecordCard extends StatelessWidget {
   const _PointVisitRecordCard({required this.record, required this.onTap});
 
@@ -197,54 +302,47 @@ class _PointVisitRecordCard extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
-        child: Row(
-          children: [
-            SizedBox(
-              width: 104,
-              height: 104,
-              child: VisitRecordPhoto(path: photoPath),
-            ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      _formatCapturedAt(record.capturedAt),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Wrap(
-                      spacing: 6,
-                      runSpacing: 6,
-                      children: [
-                        _RecordMetaChip(
-                          icon: Icons.layers_outlined,
-                          label: record.referenceMode,
-                        ),
-                        if (record.hasColorGrading)
-                          const _RecordMetaChip(
-                            icon: Icons.auto_fix_high_outlined,
-                            label: '已调色',
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              SizedBox(width: 104, child: VisitRecordPhoto(path: photoPath)),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _RecordCapturedAtText(capturedAt: record.capturedAt),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
+                        children: [
+                          _RecordMetaChip(
+                            icon: Icons.layers_outlined,
+                            label: record.referenceMode,
                           ),
-                      ],
-                    ),
-                  ],
+                          if (record.hasColorGrading)
+                            const _RecordMetaChip(
+                              icon: Icons.auto_fix_high_outlined,
+                              label: '已调色',
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            const Padding(
-              padding: EdgeInsets.only(right: 10),
-              child: Icon(Icons.chevron_right, color: AppColors.textSecondary),
-            ),
-          ],
+              const Padding(
+                padding: EdgeInsets.only(right: 10),
+                child: Icon(
+                  Icons.chevron_right,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -260,13 +358,15 @@ class _RecordMetaChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+      height: 28,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
       decoration: BoxDecoration(
         color: AppColors.surfaceMuted,
         borderRadius: BorderRadius.circular(6),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Icon(icon, size: 14, color: AppColors.textSecondary),
           const SizedBox(width: 4),
@@ -276,6 +376,7 @@ class _RecordMetaChip extends StatelessWidget {
               color: AppColors.textSecondary,
               fontSize: 12,
               fontWeight: FontWeight.w700,
+              height: 1,
               letterSpacing: 0,
             ),
           ),
@@ -285,8 +386,10 @@ class _RecordMetaChip extends StatelessWidget {
   }
 }
 
-String _formatCapturedAt(DateTime value) {
+_RecordCapturedAt _formatCapturedAt(DateTime value) {
   String twoDigits(int number) => number.toString().padLeft(2, '0');
-  return '${value.year}-${twoDigits(value.month)}-${twoDigits(value.day)} '
-      '${twoDigits(value.hour)}:${twoDigits(value.minute)}';
+  return _RecordCapturedAt(
+    date: '${value.year}-${twoDigits(value.month)}-${twoDigits(value.day)}',
+    time: '${twoDigits(value.hour)}:${twoDigits(value.minute)}',
+  );
 }

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -963,10 +963,6 @@ class _VisitRecordCard extends StatelessWidget {
                       runSpacing: 6,
                       children: [
                         _RecordChip(
-                          icon: Icons.grid_view_outlined,
-                          label: groupName,
-                        ),
-                        _RecordChip(
                           icon: Icons.schedule,
                           label: _formatCapturedAt(record.capturedAt),
                         ),

--- a/test/pilgrimage_work_dropdown_test.dart
+++ b/test/pilgrimage_work_dropdown_test.dart
@@ -1,0 +1,129 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:miriago/plan/pilgrimage_models.dart';
+import 'package:miriago/plan/pilgrimage_work_dropdown.dart';
+
+void main() {
+  const works = [
+    PilgrimageWork(
+      id: 'work-1',
+      title: 'Sound! Euphonium',
+      subtitle: '',
+      city: '',
+      source: WorkSource.bangumi,
+      bangumiSubjectType: BangumiSubjectType.anime,
+    ),
+    PilgrimageWork(
+      id: 'work-2',
+      title: 'BanG Dream!',
+      subtitle: '',
+      city: '',
+      source: WorkSource.bangumi,
+      bangumiSubjectType: BangumiSubjectType.anime,
+    ),
+  ];
+
+  Future<void> pumpDropdown(
+    WidgetTester tester, {
+    List<PilgrimageWork> options = works,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: PilgrimageWorkDropdown(
+                works: options,
+                value: options.first,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(DropdownButtonFormField<PilgrimageWork>));
+    await tester.pumpAndSettle();
+  }
+
+  Future<TestGesture> hoverTitle(WidgetTester tester, Finder title) async {
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(title));
+    await tester.pump();
+    return mouse;
+  }
+
+  testWidgets('unselected menu item content slides right while hovered', (
+    tester,
+  ) async {
+    await pumpDropdown(tester);
+
+    final title = find.text('BanG Dream!');
+    final startX = tester.getTopLeft(title).dx;
+    final mouse = await hoverTitle(tester, title);
+
+    await tester.pump(const Duration(milliseconds: 80));
+    final middleX = tester.getTopLeft(title).dx;
+    expect(middleX, greaterThan(startX));
+    expect(middleX, lessThan(startX + 12));
+
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(title).dx, closeTo(startX + 12, 0.01));
+
+    await mouse.moveTo(Offset.zero);
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(title).dx, closeTo(startX, 0.01));
+  });
+
+  testWidgets('selected menu item stays still while hovered', (tester) async {
+    await pumpDropdown(tester);
+
+    final title = find.text('Sound! Euphonium').last;
+    final startX = tester.getTopLeft(title).dx;
+    final mouse = await hoverTitle(tester, title);
+
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(title).dx, closeTo(startX, 0.01));
+
+    await mouse.moveTo(Offset.zero);
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(title).dx, closeTo(startX, 0.01));
+  });
+
+  testWidgets('long menu keeps selected content clear of the scrollbar', (
+    tester,
+  ) async {
+    final manyWorks = List.generate(
+      12,
+      (index) => PilgrimageWork(
+        id: 'work-$index',
+        title: 'Work $index',
+        subtitle: '',
+        city: '',
+        source: WorkSource.bangumi,
+        bangumiSubjectType: BangumiSubjectType.anime,
+      ),
+    );
+
+    await pumpDropdown(tester, options: manyWorks);
+
+    expect(find.byType(Scrollbar), findsOneWidget);
+    final scrollbarRect = tester.getRect(find.byType(Scrollbar));
+    final selectedIconRect = tester.getRect(find.byIcon(Icons.check_circle));
+    expect(selectedIconRect.right, lessThanOrEqualTo(scrollbarRect.right - 10));
+
+    final backgrounds = find.byType(AnimatedContainer);
+    expect(backgrounds, findsWidgets);
+    for (final element in backgrounds.evaluate()) {
+      final backgroundRect = tester.getRect(
+        find.byElementPredicate((candidate) => identical(candidate, element)),
+      );
+      expect(backgroundRect.right, lessThanOrEqualTo(scrollbarRect.right - 6));
+    }
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -131,7 +131,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('计划备忘录'), findsOneWidget);
-    expect(find.text('还没有写计划备忘'), findsOneWidget);
+    expect(find.text('还没有计划备忘'), findsOneWidget);
+    expect(find.text('开始记录'), findsOneWidget);
 
     await tester.tap(find.byTooltip('编辑'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## 概述

优化计划空状态、作品管理、作品地图导入、手动表单和拍摄记录页面，统一作品选择组件及表单交互样式。

本 PR 仅涉及 Flutter 页面组件和前端交互流程，不修改数据库结构、数据模型、Repository 实现、迁移文件或 Tauri 后端。

## 主要改动

- 优化计划空状态，增加“加作品、选点位、划片区”时间轴引导
- 重做作品管理空状态及 Bangumi/手动添加引导
- 统一作品地图导入页的空状态和作品管理入口
- 优化手动添加作品、点位、坐标和参考图表单
- 新增共享 `PilgrimageWorkDropdown`，统一 Badge、选中态和 Hover 效果
- 重做 Anitabi 链接导入说明与链接示例
- 优化拍摄记录的缩略图、时间、日期和缩放适配
- 移除单条记录卡中的区域标签展示
- 重构作品管理页面的 Bangumi 搜索与手动添加入口
- 优化 Bangumi 搜索输入框、作品类型分段选择器、搜索按钮及说明卡片

## 数据与逻辑影响

- 未修改 `lib/data`、`src-tauri`、数据库 Schema 或迁移
- 未修改作品、点位和记录的持久化实现
- 原有保存点位、更新点位和加载 Anitabi 点位逻辑保持不变
- 新增交互仅包括坐标粘贴兜底，以及空导入页进入作品管理后刷新计划

## 验证

- Dart 静态分析通过
- Flutter JavaScript Web 构建成功
- 本地预览首页返回 HTTP 200
- Anitabi 静态数据代理返回 HTTP 200
- `git diff --check` 通过

## 已知测试状态

最近一次完整测试结果为 171 项通过、7 项失败：

- 2 项图片测试使用无效图片字节，实际返回 `capturedPhotoUnavailable`
- 5 项旧 Widget 测试仍按调整前的页面入口和文本定位组件

这些失败未显示数据库或 Repository 回归，相关 Widget 测试后续需要按新 UI 更新。