### PR TITLE
feat: Refine work management, comparison settings, and scaled add-content flows

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -19,6 +19,7 @@ import 'plan_transfer/plan_import_file_stub.dart'
 import 'plan_transfer/plan_import_preview_screen.dart';
 import 'records/records_screen.dart';
 import 'settings/settings_screen.dart';
+import 'widgets/app_scaled_route.dart';
 
 class AppShell extends StatefulWidget {
   AppShell({PilgrimageRepository? repository, super.key})
@@ -105,10 +106,12 @@ class _AppShellState extends State<AppShell> {
 
   Future<void> _openAddPoints() async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
+      appScaledMaterialPageRoute<bool>(
+        settings: _settings,
         builder: (_) => AddPointsScreen(
           plan: _planController?.plan,
           repository: widget.repository,
+          settings: _settings,
         ),
       ),
     );

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -39,7 +39,10 @@ InputDecoration stableInputDecoration({
   );
 }
 
-InputDecoration _boxedFormDecoration({String? hintText}) {
+InputDecoration _boxedFormDecoration({
+  String? hintText,
+  bool reserveHelperSpace = true,
+}) {
   return InputDecoration(
     hintText: hintText,
     hintStyle: TextStyle(
@@ -47,7 +50,7 @@ InputDecoration _boxedFormDecoration({String? hintText}) {
       fontSize: 14,
       letterSpacing: 0,
     ),
-    helperText: ' ',
+    helperText: reserveHelperSpace ? ' ' : null,
     contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
     enabledBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(8),
@@ -410,35 +413,50 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
           children: [
             _FormSection(
               children: [
-                TextField(
-                  controller: _queryController,
-                  decoration: const InputDecoration(
-                    labelText: '作品名称',
-                    hintText: '例如 轻音少女',
+                _ManualWorkLabeledField(
+                  label: '作品名称',
+                  prominent: true,
+                  child: TextField(
+                    controller: _queryController,
+                    decoration: _boxedFormDecoration(
+                      hintText: '例如 轻音少女',
+                      reserveHelperSpace: false,
+                    ),
+                    textInputAction: TextInputAction.search,
+                    onSubmitted: (_) => _search(),
                   ),
-                  textInputAction: TextInputAction.search,
-                  onSubmitted: (_) => _search(),
                 ),
-                const SizedBox(height: 12),
-                _BangumiTypeFilter(
-                  selectedTypes: _selectedTypes,
-                  onChanged: (types) {
-                    setState(() {
-                      _selectedTypes = types;
-                    });
-                  },
+                const SizedBox(height: 16),
+                _ManualWorkLabeledField(
+                  label: '作品类型',
+                  prominent: true,
+                  child: _BangumiTypeFilter(
+                    selectedTypes: _selectedTypes,
+                    onChanged: (types) {
+                      setState(() {
+                        _selectedTypes = types;
+                      });
+                    },
+                  ),
                 ),
-                const SizedBox(height: 12),
-                FilledButton.icon(
-                  onPressed: _isSearching ? null : _search,
-                  icon: _isSearching
-                      ? const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.search, size: 18),
-                  label: Text(_isSearching ? '搜索中' : '搜索作品'),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: _isSearching ? null : _search,
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size.fromHeight(46),
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                    ),
+                    icon: _isSearching
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.search, size: 18),
+                    label: Text(_isSearching ? '搜索中' : '搜索作品'),
+                  ),
                 ),
               ],
             ),
@@ -490,26 +508,97 @@ class _BangumiTypeFilter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(
-      spacing: 8,
-      runSpacing: 6,
-      children: [
-        for (final type in _types)
-          FilterChip(
-            label: Text(type.label),
-            selected: selectedTypes.contains(type),
-            onSelected: (selected) {
-              final nextTypes = {...selectedTypes};
-              if (selected) {
-                nextTypes.add(type);
-              } else if (nextTypes.length > 1) {
-                nextTypes.remove(type);
-              }
-              onChanged(nextTypes);
-            },
-          ),
-      ],
+    return Container(
+      width: double.infinity,
+      height: 40,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (var index = 0; index < _types.length; index++) ...[
+            Expanded(child: _buildTypeItem(_types[index])),
+            if (index < _types.length - 1)
+              const VerticalDivider(
+                width: 1,
+                thickness: 1,
+                color: AppColors.border,
+              ),
+          ],
+        ],
+      ),
     );
+  }
+
+  Widget _buildTypeItem(BangumiSubjectType type) {
+    final selected = selectedTypes.contains(type);
+    return Semantics(
+      button: true,
+      selected: selected,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: () => _toggleType(type, selected),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 140),
+                curve: Curves.easeOut,
+                color: selected
+                    ? AppColors.accent.withValues(alpha: 0.08)
+                    : Colors.transparent,
+                alignment: Alignment.center,
+                child: Text(
+                  type.label,
+                  maxLines: 1,
+                  style: TextStyle(
+                    color: selected
+                        ? AppColors.accentDark
+                        : AppColors.textSecondary,
+                    fontSize: 13,
+                    fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ),
+              if (selected)
+                Positioned(
+                  left: 8,
+                  right: 8,
+                  bottom: 0,
+                  child: Container(
+                    height: 3,
+                    decoration: BoxDecoration(
+                      color: AppColors.accent,
+                      borderRadius: const BorderRadius.vertical(
+                        top: Radius.circular(3),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _toggleType(BangumiSubjectType type, bool selected) {
+    final nextTypes = {...selectedTypes};
+    if (selected) {
+      if (nextTypes.length == 1) {
+        return;
+      }
+      nextTypes.remove(type);
+    } else {
+      nextTypes.add(type);
+    }
+    onChanged(nextTypes);
   }
 }
 
@@ -1671,6 +1760,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                       child: PilgrimageWorkDropdown(
                         works: workOptions,
                         value: _selectedWork,
+                        omitScrollbarInsetWhenUnscrollable: true,
                         onChanged: (work) {
                           setState(() {
                             _selectedWork = work;
@@ -2648,9 +2738,9 @@ class _BangumiSearchHintCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: AppColors.surface,
+        color: AppColors.accent.withValues(alpha: 0.05),
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
+        border: Border.all(color: AppColors.accent.withValues(alpha: 0.42)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -2658,10 +2748,14 @@ class _BangumiSearchHintCard extends StatelessWidget {
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Icon(Icons.info_outline, color: AppColors.accent, size: 16),
+              Icon(
+                Icons.manage_search_rounded,
+                color: AppColors.accent,
+                size: 17,
+              ),
               const SizedBox(width: 8),
               const Text(
-                '温馨提示',
+                '搜索说明',
                 style: TextStyle(
                   color: AppColors.textPrimary,
                   fontSize: 13,
@@ -2683,22 +2777,31 @@ class _BangumiSearchHintCard extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 8),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
-            decoration: BoxDecoration(
-              color: AppColors.accent.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: Text(
-              'Bangumi需要国际网络环境才能正常搜索。',
-              style: TextStyle(
-                color: AppColors.accentDark,
-                fontSize: 13,
-                fontWeight: FontWeight.w800,
-                height: 1.25,
-                letterSpacing: 0,
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 1),
+                child: Icon(
+                  Icons.info_outline_rounded,
+                  color: AppColors.accent,
+                  size: 16,
+                ),
               ),
-            ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  'Bangumi需要国际网络环境才能正常搜索。',
+                  style: TextStyle(
+                    color: AppColors.accentDark,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    height: 1.35,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/reference_thumbnail_stub.dart'
 import '../widgets/image_viewer_screen.dart';
 import 'anitabi_map_import_screen.dart';
 import 'coordinate_parser.dart';
+import 'pilgrimage_work_dropdown.dart';
 import 'pilgrimage_models.dart';
 import 'reference_image_status.dart';
 import 'work_manager_screen.dart';
@@ -35,6 +36,35 @@ InputDecoration stableInputDecoration({
     prefixIcon: prefixIcon,
     suffixIcon: suffixIcon,
     helperText: ' ',
+  );
+}
+
+InputDecoration _boxedFormDecoration({String? hintText}) {
+  return InputDecoration(
+    hintText: hintText,
+    hintStyle: TextStyle(
+      color: AppColors.textSecondary.withValues(alpha: 0.42),
+      fontSize: 14,
+      letterSpacing: 0,
+    ),
+    helperText: ' ',
+    contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: AppColors.border),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: BorderSide(color: AppColors.accent, width: 1.4),
+    ),
+    errorBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: Colors.redAccent),
+    ),
+    focusedErrorBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+    ),
   );
 }
 
@@ -419,10 +449,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
                 text: 'Bangumi 搜索失败，请检查网络后重试。',
               )
             else if (_results.isEmpty)
-              const _MessageCard(
-                icon: Icons.info_outline,
-                text: '输入作品名后搜索，选择结果即可加入当前计划。',
-              )
+              const _BangumiSearchHintCard()
             else
               for (final work in _results) ...[
                 _WorkResultCard(
@@ -553,47 +580,131 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
       body: Form(
         key: _formKey,
         child: ListView(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
           children: [
             Text(
               '加入到：${widget.plan.name}',
               style: const TextStyle(
                 color: AppColors.textSecondary,
-                fontSize: 13,
+                fontSize: 14,
                 letterSpacing: 0,
               ),
             ),
-            const SizedBox(height: 12),
-            _FormSection(
-              children: [
-                TextFormField(
-                  controller: _linkController,
-                  decoration: stableInputDecoration(
-                    labelText: 'Anitabi 链接',
-                    hintText:
-                        '例如 https://www.anitabi.cn/map?bangumiId=8290&pid=qdmnf6iqj',
+            const SizedBox(height: 18),
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                border: Border.all(color: AppColors.border),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Anitabi 链接',
+                    style: TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
                   ),
-                  keyboardType: TextInputType.url,
-                  textInputAction: TextInputAction.done,
-                  validator: _validateLink,
-                  onFieldSubmitted: (_) => _openImport(),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _linkController,
+                    decoration: InputDecoration(
+                      hintText: '粘贴 Anitabi 作品或点位链接',
+                      hintStyle: TextStyle(
+                        color: AppColors.textSecondary.withValues(alpha: 0.48),
+                        fontSize: 14,
+                        letterSpacing: 0,
+                      ),
+                      helperText: ' ',
+                      suffixIcon: const Padding(
+                        padding: EdgeInsets.only(right: 6),
+                        child: IconButton(
+                          onPressed: null,
+                          tooltip: '粘贴',
+                          icon: Icon(Icons.content_paste_outlined, size: 20),
+                        ),
+                      ),
+                      suffixIconConstraints: const BoxConstraints(
+                        minWidth: 46,
+                        minHeight: 40,
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 14,
+                        vertical: 14,
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(color: AppColors.border),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: BorderSide(
+                          color: AppColors.accent,
+                          width: 1.4,
+                        ),
+                      ),
+                      errorBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(color: Colors.redAccent),
+                      ),
+                      focusedErrorBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(8),
+                        borderSide: const BorderSide(
+                          color: Colors.redAccent,
+                          width: 1.4,
+                        ),
+                      ),
+                    ),
+                    keyboardType: TextInputType.url,
+                    textInputAction: TextInputAction.done,
+                    validator: _validateLink,
+                    onFieldSubmitted: (_) => _openImport(),
+                  ),
+                  const SizedBox(height: 8),
+                  const _DashedDivider(),
+                  const SizedBox(height: 16),
+                  const _InfoHeading(),
+                  const SizedBox(height: 8),
+                  const Text(
+                    '如果链接里包含作品 ID，会只加载对应作品；\n如果还包含点位 ID，会自动选中该点位。\n没有作品 ID 的链接需要先在 Anitabi 中进入对应作品后重新复制。',
+                    style: TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                      height: 1.45,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 18),
+            const _LinkExampleCard(),
+            const SizedBox(height: 14),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _openImport,
+                style: FilledButton.styleFrom(
+                  minimumSize: const Size.fromHeight(50),
+                  padding: const EdgeInsets.symmetric(horizontal: 18),
+                  alignment: Alignment.center,
                 ),
-                const SizedBox(height: 10),
-                const Text(
-                  '如果链接里包含作品 ID，会只加载对应作品；如果还包含点位 ID，会自动选中该点位。没有作品 ID 的链接需要先在 Anitabi 中进入对应作品后重新复制。',
+                icon: const Icon(Icons.add_location_alt_outlined, size: 21),
+                label: const Text(
+                  '打开 Anitabi 点位',
                   style: TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 12,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    height: 1,
                     letterSpacing: 0,
                   ),
                 ),
-              ],
-            ),
-            const SizedBox(height: 16),
-            FilledButton.icon(
-              onPressed: _openImport,
-              icon: const Icon(Icons.add_location_alt_outlined, size: 18),
-              label: const Text('打开 Anitabi 点位'),
+              ),
             ),
           ],
         ),
@@ -614,6 +725,272 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
       return '链接缺少作品 ID，请先在 Anitabi 进入对应作品后复制链接';
     }
     return null;
+  }
+}
+
+class _LinkExampleCard extends StatelessWidget {
+  const _LinkExampleCard();
+
+  static const _linkPrefix = 'https://www.anitabi.cn/map?';
+  static const _bangumiId = 'bangumiId=186515';
+  static const _middle = '&';
+  static const _pointId = 'pid=95ff4037';
+  static const _suffix = '&c=139.7226%2C35.7126&z=19.1';
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        border: Border.all(color: AppColors.border),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '有效链接示例',
+            style: TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 14,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: 6),
+          const _ExampleLinkText(),
+        ],
+      ),
+    );
+  }
+}
+
+class _ExampleLinkText extends StatelessWidget {
+  const _ExampleLinkText();
+
+  @override
+  Widget build(BuildContext context) {
+    const normalStyle = TextStyle(
+      color: AppColors.textSecondary,
+      fontSize: 13,
+      fontFamily: 'monospace',
+      height: 1.25,
+      letterSpacing: 0,
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.start,
+          runSpacing: 4,
+          children: [
+            const _ExamplePlainText(
+              text: _LinkExampleCard._linkPrefix,
+              style: normalStyle,
+            ),
+            _highlight(_LinkExampleCard._bangumiId),
+            const _ExamplePlainText(
+              text: _LinkExampleCard._middle,
+              style: normalStyle,
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        _ExampleNoteRow(normalStyle: normalStyle),
+        const SizedBox(height: 6),
+        Wrap(
+          crossAxisAlignment: WrapCrossAlignment.start,
+          runSpacing: 4,
+          children: [
+            _highlight(_LinkExampleCard._pointId),
+            const _ExamplePlainText(
+              text: _LinkExampleCard._suffix,
+              style: normalStyle,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  static Widget _highlight(String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColors.accent.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        softWrap: false,
+        style: TextStyle(
+          color: AppColors.accentDark,
+          fontSize: 13,
+          fontFamily: 'monospace',
+          fontWeight: FontWeight.w800,
+          height: 1.25,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+class _ExampleNoteRow extends StatelessWidget {
+  const _ExampleNoteRow({required this.normalStyle});
+
+  final TextStyle normalStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final textDirection = Directionality.of(context);
+        final bangumiLeft = _measureTextWidth(
+          _LinkExampleCard._linkPrefix,
+          normalStyle,
+          textDirection,
+        );
+        final bangumiNoteWidth =
+            _measureTextWidth(
+              'Bangumi 作品 ID（必须）',
+              _ExampleNote.textStyle,
+              textDirection,
+            ) +
+            _ExampleNote.horizontalPadding;
+        final resolvedBangumiLeft = bangumiLeft.clamp(
+          0,
+          (constraints.maxWidth - bangumiNoteWidth).clamp(0, double.infinity),
+        );
+
+        return SizedBox(
+          height: 18,
+          child: Stack(
+            children: [
+              const Positioned(
+                left: 0,
+                top: 0,
+                child: _ExampleNote(text: 'Anitabi 点位 ID（可选）'),
+              ),
+              Positioned(
+                left: resolvedBangumiLeft.toDouble(),
+                top: 0,
+                child: const _ExampleNote(text: 'Bangumi 作品 ID（必须）'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  double _measureTextWidth(
+    String text,
+    TextStyle style,
+    TextDirection textDirection,
+  ) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: textDirection,
+      maxLines: 1,
+    )..layout();
+    return painter.width;
+  }
+}
+
+class _ExamplePlainText extends StatelessWidget {
+  const _ExamplePlainText({required this.text, required this.style});
+
+  final String text;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 2),
+      child: Text(text, softWrap: false, style: style),
+    );
+  }
+}
+
+class _ExampleNote extends StatelessWidget {
+  const _ExampleNote({required this.text});
+
+  static const horizontalPadding = 16.0;
+  static const textStyle = TextStyle(
+    color: AppColors.textSecondary,
+    fontSize: 12,
+    fontWeight: FontWeight.w700,
+    height: 1,
+    letterSpacing: 0,
+  );
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceMuted,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(text, style: textStyle),
+    );
+  }
+}
+
+class _DashedDivider extends StatelessWidget {
+  const _DashedDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const dashWidth = 6.0;
+        const gapWidth = 4.0;
+        final dashCount = (constraints.maxWidth / (dashWidth + gapWidth))
+            .floor()
+            .clamp(1, 1000);
+        return Row(
+          children: List.generate(
+            dashCount,
+            (index) => Expanded(
+              child: Padding(
+                padding: EdgeInsets.only(
+                  right: index == dashCount - 1 ? 0 : gapWidth,
+                ),
+                child: Container(height: 1, color: AppColors.border),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _InfoHeading extends StatelessWidget {
+  const _InfoHeading();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(Icons.info_outline, color: AppColors.accent, size: 15),
+        const SizedBox(width: 6),
+        const Text(
+          '使用说明',
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: 13,
+            fontWeight: FontWeight.w800,
+            letterSpacing: 0,
+          ),
+        ),
+      ],
+    );
   }
 }
 
@@ -724,30 +1101,38 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
             children: [
               _FormSection(
                 children: [
-                  TextFormField(
-                    controller: _titleController,
-                    decoration: stableInputDecoration(labelText: '作品名称'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _subtitleController,
-                    decoration: const InputDecoration(
-                      labelText: '作品原名',
-                      hintText: '可选',
+                  _ManualWorkLabeledField(
+                    label: '作品名称',
+                    required: true,
+                    child: TextFormField(
+                      controller: _titleController,
+                      decoration: _boxedFormDecoration(hintText: '请输入作品的中文名称'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
                     ),
-                    textInputAction: TextInputAction.next,
                   ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _cityController,
-                    decoration: InputDecoration(
-                      labelText: '主要地区',
-                      hintText: '可选，默认 ${widget.plan.area}',
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '作品原名',
+                    child: TextFormField(
+                      controller: _subtitleController,
+                      decoration: _boxedFormDecoration(
+                        hintText: '请输入作品的原名（如日文/英文）',
+                      ),
+                      textInputAction: TextInputAction.next,
                     ),
-                    textInputAction: TextInputAction.done,
-                    onFieldSubmitted: (_) => _saveWork(),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '主要地区',
+                    child: TextFormField(
+                      controller: _cityController,
+                      decoration: _boxedFormDecoration(
+                        hintText: '输入作品主要发生或取景的地区',
+                      ),
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (_) => _saveWork(),
+                    ),
                   ),
                 ],
               ),
@@ -777,6 +1162,49 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
     }
 
     return null;
+  }
+}
+
+class _ManualWorkLabeledField extends StatelessWidget {
+  const _ManualWorkLabeledField({
+    required this.label,
+    required this.child,
+    this.required = false,
+    this.prominent = false,
+  });
+
+  final String label;
+  final Widget child;
+  final bool required;
+  final bool prominent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(text: label),
+              if (required)
+                const TextSpan(
+                  text: ' *',
+                  style: TextStyle(color: Colors.redAccent),
+                ),
+            ],
+          ),
+          style: TextStyle(
+            color: AppColors.textPrimary,
+            fontSize: prominent ? 15 : 13,
+            fontWeight: prominent ? FontWeight.w800 : FontWeight.w600,
+            letterSpacing: 0,
+          ),
+        ),
+        const SizedBox(height: 6),
+        child,
+      ],
+    );
   }
 }
 
@@ -828,6 +1256,8 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
   final _referenceController = TextEditingController();
   final _latitudeController = TextEditingController();
   final _longitudeController = TextEditingController();
+  final _latitudeFocusNode = FocusNode();
+  final _longitudeFocusNode = FocusNode();
   final _noteController = TextEditingController();
   PilgrimageWork? _selectedWork;
   StoredUserReferenceImage? _pendingReferenceImage;
@@ -886,6 +1316,8 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     _referenceController.dispose();
     _latitudeController.dispose();
     _longitudeController.dispose();
+    _latitudeFocusNode.dispose();
+    _longitudeFocusNode.dispose();
     _noteController.dispose();
     super.dispose();
   }
@@ -1052,8 +1484,23 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
   }
 
   Future<void> _pasteCoordinateFromClipboard() async {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    final coordinate = parseCoordinateText(data?.text ?? '');
+    String clipboardText = '';
+    try {
+      final data = await Clipboard.getData(Clipboard.kTextPlain);
+      clipboardText = data?.text ?? '';
+    } on Object {
+      clipboardText = '';
+    }
+
+    var coordinate = parseCoordinateText(clipboardText);
+    if (coordinate == null && mounted) {
+      final manualText = await _showCoordinatePasteDialog();
+      if (!mounted || manualText == null) {
+        return;
+      }
+      coordinate = parseCoordinateText(manualText);
+    }
+
     if (!mounted) {
       return;
     }
@@ -1063,14 +1510,69 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
       ).showReplacingSnackBar(const SnackBar(content: Text('剪切板中没有可识别的坐标。')));
       return;
     }
+    final parsedCoordinate = coordinate;
 
     setState(() {
-      _latitudeController.text = coordinate.latitude.toStringAsFixed(6);
-      _longitudeController.text = coordinate.longitude.toStringAsFixed(6);
+      _latitudeController.text = parsedCoordinate.latitude.toStringAsFixed(6);
+      _longitudeController.text = parsedCoordinate.longitude.toStringAsFixed(6);
     });
     ScaffoldMessenger.of(
       context,
-    ).showReplacingSnackBar(const SnackBar(content: Text('已填入剪切板坐标。')));
+    ).showReplacingSnackBar(const SnackBar(content: Text('已填入坐标。')));
+  }
+
+  Future<String?> _showCoordinatePasteDialog() async {
+    final controller = TextEditingController();
+    final formKey = GlobalKey<FormState>();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('粘贴坐标'),
+          content: Form(
+            key: formKey,
+            child: TextFormField(
+              controller: controller,
+              autofocus: true,
+              minLines: 2,
+              maxLines: 3,
+              decoration: stableInputDecoration(
+                labelText: '坐标文本',
+                hintText: '例如 35.712576, 139.722166',
+              ),
+              validator: (value) {
+                if (parseCoordinateText(value ?? '') == null) {
+                  return '请输入可识别的坐标';
+                }
+                return null;
+              },
+              textInputAction: TextInputAction.done,
+              onFieldSubmitted: (_) {
+                if (formKey.currentState?.validate() ?? false) {
+                  Navigator.of(dialogContext).pop(controller.text);
+                }
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () {
+                if (formKey.currentState?.validate() ?? false) {
+                  Navigator.of(dialogContext).pop(controller.text);
+                }
+              },
+              child: const Text('填入'),
+            ),
+          ],
+        );
+      },
+    );
+    controller.dispose();
+    return result;
   }
 
   void _removeReferenceImage() {
@@ -1162,53 +1664,58 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
               _FormSection(
                 children: [
                   if (hasPlanWorks)
-                    DropdownButtonFormField<PilgrimageWork>(
-                      initialValue: _selectedWork,
-                      decoration: const InputDecoration(labelText: '所属作品'),
-                      isExpanded: true,
-                      items: [
-                        for (final work in workOptions)
-                          DropdownMenuItem<PilgrimageWork>(
-                            value: work,
-                            child: Text(
-                              work.displayBangumiSubjectType == null
-                                  ? work.title
-                                  : '${work.title} · ${work.displayBangumiSubjectType!.label}',
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                      ],
-                      onChanged: (work) {
-                        setState(() {
-                          _selectedWork = work;
-                        });
-                      },
-                      validator: (work) => work == null ? '请选择作品' : null,
+                    _ManualWorkLabeledField(
+                      label: '所属作品',
+                      required: true,
+                      prominent: true,
+                      child: PilgrimageWorkDropdown(
+                        works: workOptions,
+                        value: _selectedWork,
+                        onChanged: (work) {
+                          setState(() {
+                            _selectedWork = work;
+                          });
+                        },
+                        validator: (work) => work == null ? '请选择作品' : null,
+                      ),
                     )
                   else ...[
-                    TextFormField(
-                      controller: _fallbackWorkTitleController,
-                      decoration: stableInputDecoration(labelText: '动画/作品名称'),
-                      textInputAction: TextInputAction.next,
-                      validator: _requiredText,
-                    ),
-                    const SizedBox(height: 12),
-                    TextFormField(
-                      controller: _fallbackWorkSubtitleController,
-                      decoration: const InputDecoration(
-                        labelText: '作品原名',
-                        hintText: '可选',
+                    _ManualWorkLabeledField(
+                      label: '作品名称',
+                      required: true,
+                      prominent: true,
+                      child: TextFormField(
+                        controller: _fallbackWorkTitleController,
+                        decoration: _boxedFormDecoration(
+                          hintText: '请输入作品的中文名称',
+                        ),
+                        textInputAction: TextInputAction.next,
+                        validator: _requiredText,
                       ),
-                      textInputAction: TextInputAction.next,
                     ),
-                    const SizedBox(height: 12),
-                    TextFormField(
-                      controller: _fallbackWorkCityController,
-                      decoration: InputDecoration(
-                        labelText: '作品主要地区',
-                        hintText: '可选，默认 ${widget.plan.area}',
+                    const SizedBox(height: 8),
+                    _ManualWorkLabeledField(
+                      label: '作品原名',
+                      prominent: true,
+                      child: TextFormField(
+                        controller: _fallbackWorkSubtitleController,
+                        decoration: _boxedFormDecoration(
+                          hintText: '请输入作品的原名（如日文/英文）',
+                        ),
+                        textInputAction: TextInputAction.next,
                       ),
-                      textInputAction: TextInputAction.next,
+                    ),
+                    const SizedBox(height: 8),
+                    _ManualWorkLabeledField(
+                      label: '主要地区',
+                      prominent: true,
+                      child: TextFormField(
+                        controller: _fallbackWorkCityController,
+                        decoration: _boxedFormDecoration(
+                          hintText: '输入作品主要发生或取景的地区',
+                        ),
+                        textInputAction: TextInputAction.next,
+                      ),
                     ),
                   ],
                 ],
@@ -1216,97 +1723,194 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
               const SizedBox(height: 12),
               _FormSection(
                 children: [
-                  TextFormField(
-                    controller: _nameController,
-                    decoration: stableInputDecoration(labelText: '点位名称'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _subtitleController,
-                    decoration: stableInputDecoration(labelText: '位置说明'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _episodeController,
-                    decoration: stableInputDecoration(labelText: '集数/场景标签'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _referenceController,
-                    decoration: stableInputDecoration(labelText: '参考来源'),
-                    textInputAction: TextInputAction.next,
-                    validator: _requiredText,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _noteController,
-                    decoration: const InputDecoration(
-                      labelText: '备注',
-                      hintText: '可选，例如闭店、翻修、拍摄建议',
+                  _ManualWorkLabeledField(
+                    label: '点位名称',
+                    required: true,
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _nameController,
+                      decoration: _boxedFormDecoration(hintText: '请输入点位名称'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
                     ),
-                    minLines: 2,
-                    maxLines: 4,
-                    textInputAction: TextInputAction.newline,
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '位置说明',
+                    required: true,
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _subtitleController,
+                      decoration: _boxedFormDecoration(hintText: '请输入位置说明'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '集数/场景标签',
+                    required: true,
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _episodeController,
+                      decoration: _boxedFormDecoration(hintText: '请输入集数或场景标签'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '参考来源',
+                    required: true,
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _referenceController,
+                      decoration: _boxedFormDecoration(hintText: '请输入参考来源'),
+                      textInputAction: TextInputAction.next,
+                      validator: _requiredText,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
+                    label: '备注',
+                    prominent: true,
+                    child: TextFormField(
+                      controller: _noteController,
+                      decoration: _boxedFormDecoration(
+                        hintText: '可选，填写闭店、翻修或拍摄建议等补充信息',
+                      ),
+                      minLines: 4,
+                      maxLines: 8,
+                      keyboardType: TextInputType.multiline,
+                      textInputAction: TextInputAction.newline,
+                      textAlignVertical: TextAlignVertical.top,
+                    ),
                   ),
                 ],
               ),
               const SizedBox(height: 12),
               _FormSection(
                 children: [
+                  const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      '坐标位置',
+                      style: TextStyle(
+                        color: AppColors.textPrimary,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _CoordinateLabeledField(
+                          label: '纬度',
+                          focusNode: _latitudeFocusNode,
+                          child: TextFormField(
+                            controller: _latitudeController,
+                            focusNode: _latitudeFocusNode,
+                            decoration: _coordinateInputDecoration(
+                              hintText: '例如 34.8917',
+                            ),
+                            style: const TextStyle(
+                              color: AppColors.textPrimary,
+                              fontSize: 15,
+                              fontWeight: FontWeight.w500,
+                              letterSpacing: 0,
+                            ),
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                              signed: true,
+                            ),
+                            textInputAction: TextInputAction.next,
+                            validator: _validateLatitude,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: _CoordinateLabeledField(
+                          label: '经度',
+                          focusNode: _longitudeFocusNode,
+                          child: TextFormField(
+                            controller: _longitudeController,
+                            focusNode: _longitudeFocusNode,
+                            decoration: _coordinateInputDecoration(
+                              hintText: '例如 135.8077',
+                            ),
+                            style: const TextStyle(
+                              color: AppColors.textPrimary,
+                              fontSize: 15,
+                              fontWeight: FontWeight.w500,
+                              letterSpacing: 0,
+                            ),
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                              signed: true,
+                            ),
+                            textInputAction: TextInputAction.done,
+                            validator: _validateLongitude,
+                            onFieldSubmitted: (_) => _savePoint(),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 14),
                   Row(
                     children: [
                       Expanded(
                         child: OutlinedButton.icon(
                           onPressed: _isSaving ? null : _pickCoordinateFromMap,
-                          icon: const Icon(Icons.ads_click_outlined, size: 18),
-                          label: const Text('从地图选择坐标'),
+                          style: OutlinedButton.styleFrom(
+                            fixedSize: const Size.fromHeight(40),
+                            padding: const EdgeInsets.symmetric(horizontal: 14),
+                            foregroundColor: AppColors.accent,
+                            backgroundColor: AppColors.accent.withValues(
+                              alpha: 0.06,
+                            ),
+                            side: BorderSide(
+                              color: AppColors.accent.withValues(alpha: 0.35),
+                            ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          icon: const Icon(Icons.location_on, size: 19),
+                          label: const Text(
+                            '从地图选择',
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: 0,
+                            ),
+                          ),
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      IconButton.outlined(
-                        tooltip: '粘贴剪切板坐标',
-                        onPressed: _isSaving
-                            ? null
-                            : _pasteCoordinateFromClipboard,
-                        style: AppButtonStyles.compactOutlinedIconButton(),
-                        icon: const Icon(Icons.content_paste_outlined),
+                      const SizedBox(width: 10),
+                      SizedBox(
+                        width: 44,
+                        height: 40,
+                        child: IconButton.outlined(
+                          tooltip: '粘贴剪切板坐标',
+                          onPressed: _isSaving
+                              ? null
+                              : _pasteCoordinateFromClipboard,
+                          style: IconButton.styleFrom(
+                            foregroundColor: AppColors.textPrimary,
+                            side: const BorderSide(color: AppColors.border),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          icon: const Icon(Icons.content_paste_outlined),
+                        ),
                       ),
                     ],
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _latitudeController,
-                    decoration: stableInputDecoration(
-                      labelText: '纬度',
-                      hintText: '例如 34.8917',
-                    ),
-                    keyboardType: const TextInputType.numberWithOptions(
-                      decimal: true,
-                      signed: true,
-                    ),
-                    textInputAction: TextInputAction.next,
-                    validator: _validateLatitude,
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _longitudeController,
-                    decoration: stableInputDecoration(
-                      labelText: '经度',
-                      hintText: '例如 135.8077',
-                    ),
-                    keyboardType: const TextInputType.numberWithOptions(
-                      decimal: true,
-                      signed: true,
-                    ),
-                    textInputAction: TextInputAction.done,
-                    validator: _validateLongitude,
-                    onFieldSubmitted: (_) => _savePoint(),
                   ),
                 ],
               ),
@@ -1360,6 +1964,25 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     return null;
   }
 
+  InputDecoration _coordinateInputDecoration({String? hintText}) {
+    return InputDecoration(
+      hintText: hintText,
+      hintStyle: TextStyle(
+        color: AppColors.textSecondary.withValues(alpha: 0.42),
+        fontSize: 13,
+        letterSpacing: 0,
+      ),
+      isDense: true,
+      contentPadding: EdgeInsets.zero,
+      border: InputBorder.none,
+      enabledBorder: InputBorder.none,
+      focusedBorder: InputBorder.none,
+      errorBorder: InputBorder.none,
+      focusedErrorBorder: InputBorder.none,
+      errorStyle: const TextStyle(fontSize: 11, height: 0.9),
+    );
+  }
+
   String? _validateLatitude(String? value) {
     return _validateCoordinate(value, min: -90, max: 90, emptyMessage: '请填写纬度');
   }
@@ -1390,6 +2013,67 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     }
 
     return null;
+  }
+}
+
+class _CoordinateLabeledField extends StatelessWidget {
+  const _CoordinateLabeledField({
+    required this.label,
+    required this.focusNode,
+    required this.child,
+  });
+
+  final String label;
+  final FocusNode focusNode;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: focusNode,
+      builder: (context, child) {
+        final focused = focusNode.hasFocus;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
+          constraints: const BoxConstraints(minHeight: 62),
+          padding: const EdgeInsets.fromLTRB(14, 9, 14, 8),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            border: Border.all(
+              color: focused ? AppColors.accent : AppColors.border,
+              width: 1.4,
+            ),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text.rich(
+                TextSpan(
+                  children: [
+                    TextSpan(text: label),
+                    const TextSpan(
+                      text: ' *',
+                      style: TextStyle(color: Colors.redAccent),
+                    ),
+                  ],
+                ),
+                style: const TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0,
+                ),
+              ),
+              const SizedBox(height: 4),
+              child!,
+            ],
+          ),
+        );
+      },
+      child: child,
+    );
   }
 }
 
@@ -1682,85 +2366,90 @@ class _ManualReferenceImagePicker extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      child: Row(
-        children: [
-          Tooltip(
-            message: canPreview ? '查看大图' : '暂无参考图',
-            child: GestureDetector(
-              onTap: canPreview
-                  ? () => ImageViewerScreen.show(
-                      context,
-                      filePath: previewPath,
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Tooltip(
+              message: canPreview ? '查看大图' : '暂无参考图',
+              child: GestureDetector(
+                onTap: canPreview
+                    ? () => ImageViewerScreen.show(
+                        context,
+                        filePath: previewPath,
+                        imageUrl: imageUrl,
+                      )
+                    : null,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Container(
+                    width: 104,
+                    color: AppColors.surfaceMuted,
+                    child: ReferenceThumbnail(
+                      localPath: localPath,
                       imageUrl: imageUrl,
-                    )
-                  : null,
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: Container(
-                  width: 72,
-                  height: 72,
-                  color: AppColors.surfaceMuted,
-                  child: ReferenceThumbnail(
-                    localPath: localPath,
-                    imageUrl: imageUrl,
-                    fit: BoxFit.cover,
-                    placeholder: const Icon(
-                      Icons.image_outlined,
-                      color: AppColors.textSecondary,
+                      fit: BoxFit.cover,
+                      placeholder: const Icon(
+                        Icons.image_outlined,
+                        color: AppColors.textSecondary,
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  '参考图片',
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: 0,
-                  ),
-                ),
-                const SizedBox(height: 3),
-                Text(
-                  hasPendingSelection
-                      ? '已选择新图片，保存后生效。'
-                      : hasExistingImage
-                      ? '当前参考图，重新选择后需保存才会生效。'
-                      : '可选，保存时会复制到 App 本地目录。',
-                  style: const TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 12,
-                    letterSpacing: 0,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 6,
-                  children: [
-                    OutlinedButton.icon(
-                      onPressed: onPick,
-                      icon: const Icon(Icons.photo_library_outlined, size: 18),
-                      label: Text(hasImage ? '重新选择' : '上传参考图'),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '参考图片',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
                     ),
-                    if (hasPendingSelection)
-                      TextButton.icon(
-                        onPressed: onRemove,
-                        icon: const Icon(Icons.close_outlined, size: 18),
-                        label: const Text('移除'),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    hasPendingSelection
+                        ? '已选择新图片，保存后生效。'
+                        : hasExistingImage
+                        ? '当前参考图，重新选择后需保存才会生效。'
+                        : '可选，保存时会复制到 App 本地目录。',
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 12,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 6,
+                    children: [
+                      OutlinedButton.icon(
+                        onPressed: onPick,
+                        icon: const Icon(
+                          Icons.photo_library_outlined,
+                          size: 18,
+                        ),
+                        label: Text(hasImage ? '重新选择' : '上传参考图'),
                       ),
-                  ],
-                ),
-              ],
+                      if (hasPendingSelection)
+                        TextButton.icon(
+                          onPressed: onRemove,
+                          icon: const Icon(Icons.close_outlined, size: 18),
+                          label: const Text('移除'),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -1941,6 +2630,72 @@ class _MessageCard extends StatelessWidget {
               style: const TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 14,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BangumiSearchHintCard extends StatelessWidget {
+  const _BangumiSearchHintCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Icon(Icons.info_outline, color: AppColors.accent, size: 16),
+              const SizedBox(width: 8),
+              const Text(
+                '温馨提示',
+                style: TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  height: 1,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            '输入作品名后搜索，选择结果即可加入当前计划。',
+            style: TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 13,
+              height: 1.35,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              'Bangumi需要国际网络环境才能正常搜索。',
+              style: TextStyle(
+                color: AppColors.accentDark,
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+                height: 1.25,
                 letterSpacing: 0,
               ),
             ),

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -71,6 +71,41 @@ InputDecoration _boxedFormDecoration({
   );
 }
 
+InputDecoration _workTypeDropdownDecoration() {
+  return InputDecoration(
+    isDense: true,
+    filled: true,
+    fillColor: AppColors.surface,
+    hoverColor: AppColors.accent.withValues(alpha: 0.035),
+    helperText: ' ',
+    contentPadding: const EdgeInsets.fromLTRB(14, 10, 4, 10),
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: AppColors.border, width: 1.4),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: BorderSide(color: AppColors.accent, width: 1.4),
+    ),
+    errorBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+    ),
+    focusedErrorBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+    ),
+  );
+}
+
+const _manualWorkSubjectTypes = [
+  BangumiSubjectType.anime,
+  BangumiSubjectType.game,
+  BangumiSubjectType.book,
+  BangumiSubjectType.music,
+  BangumiSubjectType.real,
+];
+
 class AddPointsScreen extends StatefulWidget {
   AddPointsScreen({
     required this.plan,
@@ -109,59 +144,32 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
         body: ListView(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
           children: [
-            if (currentPlan != null) ...[
-              Text(
-                '加入到：${currentPlan.name}',
-                style: const TextStyle(
-                  color: AppColors.textSecondary,
-                  fontSize: 13,
-                  letterSpacing: 0,
-                ),
-              ),
-              const SizedBox(height: 12),
-            ],
-            _WorkSummary(plan: currentPlan),
-            const SizedBox(height: 12),
-            _AddSourceCard(
-              icon: Icons.movie_filter_outlined,
-              title: '作品管理',
-              body: '管理计划作品，支持 Bangumi 搜索、手动添加和删除作品。',
-              enabled: currentPlan != null,
-              actionLabel: currentPlan == null ? '不可用' : '管理',
-              onTap: currentPlan == null
+            _LinkedWorksPanel(
+              plan: currentPlan,
+              onManage: currentPlan == null
                   ? null
                   : () => _openWorkManager(context, currentPlan),
-            ),
-            const SizedBox(height: 8),
-            _AddSourceCard(
-              icon: Icons.map_outlined,
-              title: '从作品地图导入点位',
-              body: '在 Anitabi 地图上查看作品点位，点击缩略图详情后加入计划。',
-              enabled: currentPlan != null,
-              actionLabel: currentPlan == null ? '不可用' : '打开',
-              onTap: currentPlan == null
+              onBangumi: currentPlan == null
                   ? null
-                  : () => _openAnitabiMapImport(context, currentPlan),
+                  : () => _openBangumiSearch(context, currentPlan),
+              onManual: currentPlan == null
+                  ? null
+                  : () => _openManualWorkForm(context, currentPlan),
             ),
-            const SizedBox(height: 8),
-            _AddSourceCard(
-              icon: Icons.travel_explore_outlined,
-              title: '从 Anitabi 链接导入',
-              body: '粘贴 Anitabi 作品或点位链接，快速打开对应作品地图。',
+            const SizedBox(height: 12),
+            _QuickImportPanel(
               enabled: currentPlan != null,
-              actionLabel: currentPlan == null ? '不可用' : '输入',
               onTap: currentPlan == null
                   ? null
                   : () => _openAnitabiLinkImport(context, currentPlan),
             ),
-            const SizedBox(height: 8),
-            _AddSourceCard(
-              icon: Icons.add_location_alt_outlined,
-              title: '手动添加点位',
-              body: '选择已添加作品，再输入名称、坐标和场景信息。',
+            const SizedBox(height: 12),
+            _AddPointPanel(
               enabled: currentPlan != null,
-              actionLabel: currentPlan == null ? '不可用' : '添加',
-              onTap: currentPlan == null
+              onMap: currentPlan == null
+                  ? null
+                  : () => _openAnitabiMapImport(context, currentPlan),
+              onManual: currentPlan == null
                   ? null
                   : () => _openManualPointForm(context, currentPlan),
             ),
@@ -189,6 +197,39 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
     }
 
     await _reloadPlan(plan.id);
+  }
+
+  Future<void> _openBangumiSearch(
+    BuildContext context,
+    PilgrimagePlan plan,
+  ) async {
+    await Navigator.of(context).push<bool>(
+      MaterialPageRoute<bool>(
+        builder: (_) => BangumiWorkSearchScreen(
+          plan: plan,
+          repository: widget.repository,
+          bangumiApiClient: widget.bangumiApiClient,
+        ),
+      ),
+    );
+    if (context.mounted) {
+      await _reloadPlan(plan.id);
+    }
+  }
+
+  Future<void> _openManualWorkForm(
+    BuildContext context,
+    PilgrimagePlan plan,
+  ) async {
+    await Navigator.of(context).push<bool>(
+      MaterialPageRoute<bool>(
+        builder: (_) =>
+            ManualWorkFormScreen(plan: plan, repository: widget.repository),
+      ),
+    );
+    if (context.mounted) {
+      await _reloadPlan(plan.id);
+    }
   }
 
   Future<void> _openAnitabiMapImport(
@@ -303,6 +344,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
   bool _isSearching = false;
   bool _isAdding = false;
   bool _didAdd = false;
+  bool _isTypeFilterExpanded = true;
   final Set<String> _addedWorkIds = {};
 
   @override
@@ -320,6 +362,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
     setState(() {
       _isSearching = true;
       _error = null;
+      _isTypeFilterExpanded = false;
     });
 
     try {
@@ -419,24 +462,11 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
                   child: TextField(
                     controller: _queryController,
                     decoration: _boxedFormDecoration(
-                      hintText: '例如 轻音少女',
+                      hintText: '例如：轻音少女',
                       reserveHelperSpace: false,
                     ),
                     textInputAction: TextInputAction.search,
                     onSubmitted: (_) => _search(),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                _ManualWorkLabeledField(
-                  label: '作品类型',
-                  prominent: true,
-                  child: _BangumiTypeFilter(
-                    selectedTypes: _selectedTypes,
-                    onChanged: (types) {
-                      setState(() {
-                        _selectedTypes = types;
-                      });
-                    },
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -458,6 +488,30 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
                     label: Text(_isSearching ? '搜索中' : '搜索作品'),
                   ),
                 ),
+                const SizedBox(height: 12),
+                _BangumiTypeFilterDisclosure(
+                  expanded: _isTypeFilterExpanded,
+                  selectedTypes: _selectedTypes,
+                  onToggle: () {
+                    setState(() {
+                      _isTypeFilterExpanded = !_isTypeFilterExpanded;
+                    });
+                  },
+                  onChanged: (types) {
+                    setState(() {
+                      _selectedTypes = types;
+                    });
+                  },
+                ),
+                if (_results.isEmpty && _error == null) ...[
+                  const SizedBox(height: 16),
+                  Divider(
+                    height: 1,
+                    color: AppColors.border.withValues(alpha: 0.65),
+                  ),
+                  const SizedBox(height: 12),
+                  const _BangumiSearchHintContent(),
+                ],
               ],
             ),
             const SizedBox(height: 12),
@@ -466,13 +520,12 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
                 icon: Icons.error_outline,
                 text: 'Bangumi 搜索失败，请检查网络后重试。',
               )
-            else if (_results.isEmpty)
-              const _BangumiSearchHintCard()
-            else
+            else if (_results.isNotEmpty)
               for (final work in _results) ...[
                 _WorkResultCard(
                   work: work,
-                  disabled: _isAdding || _hasWork(widget.plan, work),
+                  added: _hasWork(widget.plan, work),
+                  disabled: _isAdding,
                   onAdd: () => _addWork(work),
                 ),
                 const SizedBox(height: 8),
@@ -599,6 +652,95 @@ class _BangumiTypeFilter extends StatelessWidget {
       nextTypes.add(type);
     }
     onChanged(nextTypes);
+  }
+}
+
+class _BangumiTypeFilterDisclosure extends StatelessWidget {
+  const _BangumiTypeFilterDisclosure({
+    required this.expanded,
+    required this.selectedTypes,
+    required this.onToggle,
+    required this.onChanged,
+  });
+
+  final bool expanded;
+  final Set<BangumiSubjectType> selectedTypes;
+  final VoidCallback onToggle;
+  final ValueChanged<Set<BangumiSubjectType>> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        children: [
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: onToggle,
+              child: SizedBox(
+                height: 42,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Row(
+                    children: [
+                      const Expanded(
+                        child: Text(
+                          '筛选作品类型',
+                          style: TextStyle(
+                            color: AppColors.textPrimary,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        '已选 ${selectedTypes.length} 项',
+                        style: const TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 12,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                      AnimatedRotation(
+                        turns: expanded ? 0.5 : 0,
+                        duration: const Duration(milliseconds: 160),
+                        child: const Icon(
+                          Icons.keyboard_arrow_down_rounded,
+                          size: 20,
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 160),
+            curve: Curves.easeOut,
+            child: expanded
+                ? Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                    child: _BangumiTypeFilter(
+                      selectedTypes: selectedTypes,
+                      onChanged: onChanged,
+                    ),
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -755,17 +897,28 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
                     onFieldSubmitted: (_) => _openImport(),
                   ),
                   const SizedBox(height: 8),
-                  const _DashedDivider(),
-                  const SizedBox(height: 16),
-                  const _InfoHeading(),
-                  const SizedBox(height: 8),
-                  const Text(
-                    '如果链接里包含作品 ID，会只加载对应作品；\n如果还包含点位 ID，会自动选中该点位。\n没有作品 ID 的链接需要先在 Anitabi 中进入对应作品后重新复制。',
-                    style: TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 13,
-                      height: 1.45,
-                      letterSpacing: 0,
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: _openImport,
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size.fromHeight(50),
+                        padding: const EdgeInsets.symmetric(horizontal: 18),
+                        alignment: Alignment.center,
+                      ),
+                      icon: const Icon(
+                        Icons.add_location_alt_outlined,
+                        size: 21,
+                      ),
+                      label: const Text(
+                        '打开 Anitabi 点位',
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                          height: 1,
+                          letterSpacing: 0,
+                        ),
+                      ),
                     ),
                   ),
                 ],
@@ -773,28 +926,6 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
             ),
             const SizedBox(height: 18),
             const _LinkExampleCard(),
-            const SizedBox(height: 14),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton.icon(
-                onPressed: _openImport,
-                style: FilledButton.styleFrom(
-                  minimumSize: const Size.fromHeight(50),
-                  padding: const EdgeInsets.symmetric(horizontal: 18),
-                  alignment: Alignment.center,
-                ),
-                icon: const Icon(Icons.add_location_alt_outlined, size: 21),
-                label: const Text(
-                  '打开 Anitabi 点位',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w800,
-                    height: 1,
-                    letterSpacing: 0,
-                  ),
-                ),
-              ),
-            ),
           ],
         ),
       ),
@@ -849,6 +980,16 @@ class _LinkExampleCard extends StatelessWidget {
           ),
           const SizedBox(height: 6),
           const _ExampleLinkText(),
+          const SizedBox(height: 12),
+          const Text(
+            '如果链接里包含作品 ID，会只加载对应作品；\n如果还包含点位 ID，会自动选中该点位。\n没有作品 ID 的链接需要先在 Anitabi 中进入对应作品后重新复制。',
+            style: TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 13,
+              height: 1.45,
+              letterSpacing: 0,
+            ),
+          ),
         ],
       ),
     );
@@ -1030,59 +1171,6 @@ class _ExampleNote extends StatelessWidget {
   }
 }
 
-class _DashedDivider extends StatelessWidget {
-  const _DashedDivider();
-
-  @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        const dashWidth = 6.0;
-        const gapWidth = 4.0;
-        final dashCount = (constraints.maxWidth / (dashWidth + gapWidth))
-            .floor()
-            .clamp(1, 1000);
-        return Row(
-          children: List.generate(
-            dashCount,
-            (index) => Expanded(
-              child: Padding(
-                padding: EdgeInsets.only(
-                  right: index == dashCount - 1 ? 0 : gapWidth,
-                ),
-                child: Container(height: 1, color: AppColors.border),
-              ),
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-
-class _InfoHeading extends StatelessWidget {
-  const _InfoHeading();
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Icon(Icons.info_outline, color: AppColors.accent, size: 15),
-        const SizedBox(width: 6),
-        const Text(
-          '使用说明',
-          style: TextStyle(
-            color: AppColors.textPrimary,
-            fontSize: 13,
-            fontWeight: FontWeight.w800,
-            letterSpacing: 0,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
 class ManualWorkFormScreen extends StatefulWidget {
   const ManualWorkFormScreen({
     required this.plan,
@@ -1102,6 +1190,7 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
   final _titleController = TextEditingController();
   final _subtitleController = TextEditingController();
   final _cityController = TextEditingController();
+  BangumiSubjectType _selectedSubjectType = BangumiSubjectType.anime;
   bool _isSaving = false;
   bool _didAdd = false;
 
@@ -1131,9 +1220,10 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
       final work = PilgrimageWork(
         id: 'manual-work-${now.microsecondsSinceEpoch}',
         title: title,
-        subtitle: subtitle.isEmpty ? 'Manual Work' : subtitle,
+        subtitle: subtitle.isEmpty ? '暂无作品原名' : subtitle,
         city: city.isEmpty ? widget.plan.area : city,
         source: WorkSource.manual,
+        bangumiSubjectType: _selectedSubjectType,
       );
 
       await widget.repository.addWorkToPlan(planId: widget.plan.id, work: work);
@@ -1213,6 +1303,65 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
                   ),
                   const SizedBox(height: 8),
                   _ManualWorkLabeledField(
+                    label: '作品类型',
+                    required: true,
+                    child: Theme(
+                      data: Theme.of(context).copyWith(
+                        focusColor: Colors.transparent,
+                        hoverColor: Colors.transparent,
+                        highlightColor: AppColors.accent.withValues(
+                          alpha: 0.075,
+                        ),
+                        splashColor: Colors.transparent,
+                      ),
+                      child: DropdownButtonFormField<BangumiSubjectType>(
+                        key: ValueKey(_selectedSubjectType),
+                        initialValue: _selectedSubjectType,
+                        decoration: _workTypeDropdownDecoration(),
+                        isExpanded: true,
+                        elevation: 2,
+                        borderRadius: BorderRadius.circular(8),
+                        dropdownColor: AppColors.surface,
+                        menuMaxHeight: 360,
+                        icon: const Padding(
+                          padding: EdgeInsets.only(right: 8),
+                          child: Icon(
+                            Icons.keyboard_arrow_down_rounded,
+                            size: 20,
+                          ),
+                        ),
+                        selectedItemBuilder: (context) => [
+                          for (final type in _manualWorkSubjectTypes)
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(type.label),
+                            ),
+                        ],
+                        items: [
+                          for (final type in _manualWorkSubjectTypes)
+                            DropdownMenuItem<BangumiSubjectType>(
+                              value: type,
+                              child: _ManualWorkTypeDropdownItem(
+                                type: type,
+                                selected: type == _selectedSubjectType,
+                              ),
+                            ),
+                        ],
+                        onChanged: _isSaving
+                            ? null
+                            : (type) {
+                                if (type == null) {
+                                  return;
+                                }
+                                setState(() {
+                                  _selectedSubjectType = type;
+                                });
+                              },
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  _ManualWorkLabeledField(
                     label: '主要地区',
                     child: TextFormField(
                       controller: _cityController,
@@ -1251,6 +1400,54 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
     }
 
     return null;
+  }
+}
+
+class _ManualWorkTypeDropdownItem extends StatefulWidget {
+  const _ManualWorkTypeDropdownItem({
+    required this.type,
+    required this.selected,
+  });
+
+  final BangumiSubjectType type;
+  final bool selected;
+
+  @override
+  State<_ManualWorkTypeDropdownItem> createState() =>
+      _ManualWorkTypeDropdownItemState();
+}
+
+class _ManualWorkTypeDropdownItemState
+    extends State<_ManualWorkTypeDropdownItem> {
+  var _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final hovered = _hovered && !widget.selected;
+
+    return MouseRegion(
+      onEnter: widget.selected ? null : (_) => setState(() => _hovered = true),
+      onExit: widget.selected ? null : (_) => setState(() => _hovered = false),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOutCubic,
+        width: double.infinity,
+        padding: EdgeInsets.fromLTRB(hovered ? 14 : 8, 7, 8, 7),
+        decoration: BoxDecoration(
+          color: AppColors.accent.withValues(
+            alpha: widget.selected ? 0.10 : (hovered ? 0.05 : 0),
+          ),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Row(
+          children: [
+            Expanded(child: Text(widget.type.label)),
+            if (widget.selected)
+              Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+          ],
+        ),
+      ),
+    );
   }
 }
 
@@ -1506,7 +1703,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     return PilgrimageWork(
       id: 'manual-work-${now.microsecondsSinceEpoch}',
       title: title,
-      subtitle: subtitle.isEmpty ? 'Manual Work' : subtitle,
+      subtitle: subtitle.isEmpty ? '暂无作品原名' : subtitle,
       city: city.isEmpty ? widget.plan.area : city,
       source: WorkSource.manual,
     );
@@ -2386,39 +2583,320 @@ class _ManualPointSelectionCard extends StatelessWidget {
   }
 }
 
-class _WorkSummary extends StatelessWidget {
-  const _WorkSummary({required this.plan});
+class _LinkedWorksPanel extends StatelessWidget {
+  const _LinkedWorksPanel({
+    required this.plan,
+    required this.onManage,
+    required this.onBangumi,
+    required this.onManual,
+  });
 
   final PilgrimagePlan? plan;
+  final VoidCallback? onManage;
+  final VoidCallback? onBangumi;
+  final VoidCallback? onManual;
 
   @override
   Widget build(BuildContext context) {
     final works = plan?.works ?? const <PilgrimageWork>[];
+    final pointCount = plan?.points.length ?? 0;
+    final visibleWorks = works.take(5).toList(growable: false);
+    final remainingCount = works.length - visibleWorks.length;
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      child: Row(
+      child: Column(
         children: [
-          Icon(Icons.movie_filter_outlined, color: AppColors.accent),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              works.isEmpty
-                  ? '当前计划还没有作品。先添加作品，后续可按作品导入点位。'
-                  : '当前计划已有 ${works.length} 部作品：${works.map((work) => work.title).join('、')}',
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 13,
-                letterSpacing: 0,
+          Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: onManage,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(14, 12, 10, 10),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 3,
+                          height: 20,
+                          decoration: BoxDecoration(
+                            color: AppColors.accent,
+                            borderRadius: BorderRadius.circular(3),
+                          ),
+                        ),
+                        const SizedBox(width: 9),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Text(
+                                '已关联作品',
+                                style: TextStyle(
+                                  color: AppColors.textPrimary,
+                                  fontSize: 17,
+                                  fontWeight: FontWeight.w900,
+                                  letterSpacing: 0,
+                                ),
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                '共 ${works.length} 部作品，$pointCount 个点位',
+                                style: const TextStyle(
+                                  color: AppColors.textSecondary,
+                                  fontSize: 13,
+                                  letterSpacing: 0,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              '管理作品',
+                              style: TextStyle(
+                                color: AppColors.accentDark,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
+                              ),
+                            ),
+                            SizedBox(width: 2),
+                            Icon(
+                              Icons.chevron_right_rounded,
+                              color: AppColors.accent,
+                              size: 20,
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (works.isEmpty)
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(14, 2, 14, 12),
+                      child: Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 14,
+                        ),
+                        decoration: BoxDecoration(
+                          color: AppColors.accent.withValues(alpha: 0.04),
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: const Text(
+                          '还没有关联作品，可从 Bangumi 搜索或手动添加。',
+                          style: TextStyle(
+                            color: AppColors.textSecondary,
+                            fontSize: 13,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                      ),
+                    )
+                  else
+                    SizedBox(
+                      height: 94,
+                      child: ListView.separated(
+                        padding: const EdgeInsets.fromLTRB(14, 2, 14, 10),
+                        scrollDirection: Axis.horizontal,
+                        itemCount:
+                            visibleWorks.length + (remainingCount > 0 ? 1 : 0),
+                        separatorBuilder: (_, _) => const SizedBox(width: 10),
+                        itemBuilder: (context, index) {
+                          if (index == visibleWorks.length) {
+                            return _MoreWorksIndicator(count: remainingCount);
+                          }
+                          return _LinkedWorkPreview(work: visibleWorks[index]);
+                        },
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          Divider(height: 1, color: AppColors.border.withValues(alpha: 0.55)),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: SizedBox(
+              height: 60,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(
+                    child: _WorkCreationAction(
+                      icon: Icons.search_rounded,
+                      title: '从Bangumi添加',
+                      subtitle: '自动获取信息',
+                      onTap: onBangumi,
+                    ),
+                  ),
+                  VerticalDivider(
+                    width: 9,
+                    indent: 8,
+                    endIndent: 8,
+                    thickness: 1,
+                    color: AppColors.border.withValues(alpha: 0.55),
+                  ),
+                  Expanded(
+                    child: _WorkCreationAction(
+                      icon: Icons.add_rounded,
+                      title: '手动添加作品',
+                      subtitle: '未收录时使用',
+                      onTap: onManual,
+                    ),
+                  ),
+                ],
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _LinkedWorkPreview extends StatelessWidget {
+  const _LinkedWorkPreview({required this.work});
+
+  final PilgrimageWork work;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 56,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 56,
+            height: 62,
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.06),
+              borderRadius: BorderRadius.circular(6),
+              border: Border.all(color: AppColors.border),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            work.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 12,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MoreWorksIndicator extends StatelessWidget {
+  const _MoreWorksIndicator({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: SizedBox(
+        width: 40,
+        child: Container(
+          width: 40,
+          height: 40,
+          margin: const EdgeInsets.only(top: 11),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: AppColors.accent.withValues(alpha: 0.08),
+            shape: BoxShape.circle,
+          ),
+          child: Text(
+            '+$count',
+            style: TextStyle(
+              color: AppColors.accentDark,
+              fontSize: 13,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WorkCreationAction extends StatelessWidget {
+  const _WorkCreationAction({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(6),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(6),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          child: Row(
+            children: [
+              Icon(icon, color: AppColors.accent, size: 22),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: AppColors.textPrimary,
+                        fontSize: 15,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: AppColors.textSecondary,
+                        fontSize: 12,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -2548,11 +3026,13 @@ class _ManualReferenceImagePicker extends StatelessWidget {
 class _WorkResultCard extends StatefulWidget {
   const _WorkResultCard({
     required this.work,
+    required this.added,
     required this.disabled,
     required this.onAdd,
   });
 
   final PilgrimageWork work;
+  final bool added;
   final bool disabled;
   final VoidCallback onAdd;
 
@@ -2562,14 +3042,19 @@ class _WorkResultCard extends StatefulWidget {
 
 class _WorkResultCardState extends State<_WorkResultCard> {
   var _expanded = false;
+  var _titleExpanded = false;
 
   @override
   Widget build(BuildContext context) {
     final work = widget.work;
-    final bangumiId = work.bangumiId;
+    final subtitle = work.subtitle.trim();
+    final showSubtitle =
+        subtitle.isNotEmpty &&
+        subtitle != work.title.trim() &&
+        !subtitle.startsWith('Bangumi #');
 
     return Container(
-      padding: const EdgeInsets.all(14),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(8),
@@ -2577,83 +3062,106 @@ class _WorkResultCardState extends State<_WorkResultCard> {
       ),
       child: Row(
         children: [
-          Icon(
-            _iconForType(work.displayBangumiSubjectType),
-            color: AppColors.accent,
+          Semantics(
+            label: '作品封面预留',
+            child: Container(
+              width: 58,
+              height: 78,
+              decoration: BoxDecoration(
+                color: AppColors.surfaceMuted,
+                borderRadius: BorderRadius.circular(4),
+                border: Border.all(color: AppColors.border),
+              ),
+            ),
           ),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  work.title,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: 0,
-                  ),
-                ),
-                const SizedBox(height: 6),
-                Wrap(
-                  spacing: 6,
-                  runSpacing: 4,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: [
-                    if (work.displayBangumiSubjectType != null)
-                      _SubjectTypePill(type: work.displayBangumiSubjectType!),
-                    if (bangumiId != null)
-                      _InfoPill(label: 'Bangumi #$bangumiId'),
-                  ],
-                ),
-                const SizedBox(height: 5),
                 InkWell(
                   onTap: () {
                     setState(() {
-                      _expanded = !_expanded;
+                      _titleExpanded = !_titleExpanded;
                     });
                   },
                   borderRadius: BorderRadius.circular(4),
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 2),
+                    padding: EdgeInsets.zero,
                     child: Text(
-                      work.subtitle,
-                      maxLines: _expanded ? null : 1,
-                      overflow: _expanded
+                      work.title,
+                      maxLines: _titleExpanded ? null : 1,
+                      overflow: _titleExpanded
                           ? TextOverflow.visible
                           : TextOverflow.ellipsis,
                       style: const TextStyle(
-                        color: AppColors.textSecondary,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ),
+                ),
+                InkWell(
+                  onTap: showSubtitle
+                      ? () {
+                          setState(() {
+                            _expanded = !_expanded;
+                          });
+                        }
+                      : null,
+                  borderRadius: BorderRadius.circular(4),
+                  child: Padding(
+                    padding: const EdgeInsets.only(top: 1),
+                    child: Text(
+                      showSubtitle ? subtitle : '暂无作品原名',
+                      maxLines: showSubtitle && _expanded ? null : 1,
+                      overflow: showSubtitle && _expanded
+                          ? TextOverflow.visible
+                          : TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: showSubtitle
+                            ? AppColors.textSecondary
+                            : AppColors.textSecondary.withValues(alpha: 0.55),
                         fontSize: 12,
                         letterSpacing: 0,
                       ),
                     ),
                   ),
                 ),
+                if (work.displayBangumiSubjectType != null) ...[
+                  const SizedBox(height: 6),
+                  _SubjectTypePill(type: work.displayBangumiSubjectType!),
+                ],
               ],
             ),
           ),
           const SizedBox(width: 12),
-          TextButton(
-            onPressed: widget.disabled ? null : widget.onAdd,
-            child: Text(widget.disabled ? '已添加' : '加入'),
-          ),
+          if (widget.added)
+            FilledButton(
+              onPressed: null,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size(88, 40),
+                padding: const EdgeInsets.symmetric(horizontal: 14),
+                disabledBackgroundColor: AppColors.accent.withValues(
+                  alpha: 0.10,
+                ),
+                disabledForegroundColor: AppColors.accentDark,
+              ),
+              child: const Text('已添加'),
+            )
+          else
+            OutlinedButton(
+              onPressed: widget.disabled ? null : widget.onAdd,
+              style: OutlinedButton.styleFrom(
+                minimumSize: const Size(88, 40),
+                padding: const EdgeInsets.symmetric(horizontal: 14),
+              ),
+              child: const Text('加入'),
+            ),
         ],
       ),
     );
-  }
-
-  IconData _iconForType(BangumiSubjectType? type) {
-    return switch (type) {
-      BangumiSubjectType.book => Icons.menu_book_outlined,
-      BangumiSubjectType.anime => Icons.movie_filter_outlined,
-      BangumiSubjectType.music => Icons.music_note_outlined,
-      BangumiSubjectType.game => Icons.sports_esports_outlined,
-      BangumiSubjectType.real => Icons.live_tv_outlined,
-      null => Icons.movie_filter_outlined,
-    };
   }
 }
 
@@ -2730,44 +3238,39 @@ class _MessageCard extends StatelessWidget {
   }
 }
 
-class _BangumiSearchHintCard extends StatelessWidget {
-  const _BangumiSearchHintCard();
+class _BangumiSearchHintContent extends StatelessWidget {
+  const _BangumiSearchHintContent();
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColors.accent.withValues(alpha: 0.05),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.accent.withValues(alpha: 0.42)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Icon(
-                Icons.manage_search_rounded,
-                color: AppColors.accent,
-                size: 17,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.manage_search_rounded,
+              color: AppColors.accent,
+              size: 17,
+            ),
+            const SizedBox(width: 8),
+            const Text(
+              '搜索说明',
+              style: TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 15,
+                fontWeight: FontWeight.w800,
+                height: 1,
+                letterSpacing: 0,
               ),
-              const SizedBox(width: 8),
-              const Text(
-                '搜索说明',
-                style: TextStyle(
-                  color: AppColors.textPrimary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w800,
-                  height: 1,
-                  letterSpacing: 0,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          const Text(
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        const Padding(
+          padding: EdgeInsets.only(left: 25),
+          child: Text(
             '输入作品名后搜索，选择结果即可加入当前计划。',
             style: TextStyle(
               color: AppColors.textSecondary,
@@ -2776,8 +3279,11 @@ class _BangumiSearchHintCard extends StatelessWidget {
               letterSpacing: 0,
             ),
           ),
-          const SizedBox(height: 8),
-          Row(
+        ),
+        const SizedBox(height: 8),
+        Padding(
+          padding: const EdgeInsets.only(left: 25),
+          child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Padding(
@@ -2803,8 +3309,8 @@ class _BangumiSearchHintCard extends StatelessWidget {
               ),
             ],
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }
@@ -2828,82 +3334,307 @@ class _FormSection extends StatelessWidget {
   }
 }
 
-class _AddSourceCard extends StatelessWidget {
-  const _AddSourceCard({
-    required this.icon,
-    required this.title,
-    required this.body,
-    required this.enabled,
-    required this.actionLabel,
-    required this.onTap,
-  });
+class _QuickImportPanel extends StatelessWidget {
+  const _QuickImportPanel({required this.enabled, required this.onTap});
 
-  final IconData icon;
-  final String title;
-  final String body;
   final bool enabled;
-  final String actionLabel;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: AppColors.surface,
+      color: AppColors.accent.withValues(alpha: 0.04),
       borderRadius: BorderRadius.circular(8),
       child: InkWell(
-        borderRadius: BorderRadius.circular(8),
         onTap: enabled ? onTap : null,
+        borderRadius: BorderRadius.circular(8),
         child: Container(
-          padding: const EdgeInsets.all(16),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: AppColors.border),
+            border: Border.all(color: AppColors.accent.withValues(alpha: 0.32)),
           ),
-          child: Row(
+          child: Column(
             children: [
-              Icon(
-                icon,
-                color: enabled ? AppColors.accent : AppColors.textSecondary,
-                size: 30,
-              ),
-              const SizedBox(width: 12),
-              Expanded(
+              Padding(
+                padding: const EdgeInsets.fromLTRB(14, 12, 12, 12),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text(
-                      title,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      body,
-                      style: const TextStyle(
-                        color: AppColors.textSecondary,
-                        fontSize: 13,
-                        letterSpacing: 0,
-                      ),
+                    Row(
+                      children: [
+                        Container(
+                          width: 46,
+                          height: 46,
+                          alignment: Alignment.center,
+                          decoration: BoxDecoration(
+                            color: AppColors.accent.withValues(alpha: 0.08),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: Icon(
+                            Icons.link_rounded,
+                            color: AppColors.accent,
+                            size: 26,
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                children: [
+                                  const Text(
+                                    '快速导入',
+                                    style: TextStyle(
+                                      color: AppColors.textPrimary,
+                                      fontSize: 17,
+                                      fontWeight: FontWeight.w900,
+                                      letterSpacing: 0,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 7),
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 6,
+                                      vertical: 2,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: AppColors.accent.withValues(
+                                        alpha: 0.10,
+                                      ),
+                                      borderRadius: BorderRadius.circular(4),
+                                    ),
+                                    child: Text(
+                                      '推荐',
+                                      style: TextStyle(
+                                        color: AppColors.accentDark,
+                                        fontSize: 11,
+                                        fontWeight: FontWeight.w800,
+                                        letterSpacing: 0,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 3),
+                              const Text(
+                                '在导入Anitabi点位的同时自动导入作品',
+                                style: TextStyle(
+                                  color: AppColors.textSecondary,
+                                  fontSize: 13,
+                                  letterSpacing: 0,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Icon(
+                          Icons.chevron_right_rounded,
+                          color: enabled
+                              ? AppColors.accent
+                              : AppColors.textSecondary,
+                        ),
+                      ],
                     ),
                   ],
                 ),
               ),
-              const SizedBox(width: 12),
-              Text(
-                actionLabel,
-                style: TextStyle(
-                  color: enabled
-                      ? AppColors.accentDark
-                      : AppColors.textSecondary,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 0,
-                ),
-              ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AddPointPanel extends StatelessWidget {
+  const _AddPointPanel({
+    required this.enabled,
+    required this.onMap,
+    required this.onManual,
+  });
+
+  final bool enabled;
+  final VoidCallback? onMap;
+  final VoidCallback? onManual;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.accent.withValues(alpha: 0.28)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(4, 2, 4, 10),
+            child: Row(
+              children: [
+                Container(
+                  width: 3,
+                  height: 20,
+                  decoration: BoxDecoration(
+                    color: AppColors.accent,
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                ),
+                const SizedBox(width: 9),
+                const Text(
+                  '添加点位',
+                  style: TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 17,
+                    fontWeight: FontWeight.w900,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          _PointCreationAction(
+            icon: Icons.map_outlined,
+            title: '从作品地图导入点位',
+            subtitle: '在作品地图上选择并导入点位',
+            recommended: true,
+            enabled: enabled,
+            onTap: onMap,
+          ),
+          Divider(
+            height: 1,
+            indent: 12,
+            endIndent: 12,
+            color: AppColors.border.withValues(alpha: 0.60),
+          ),
+          _PointCreationAction(
+            icon: Icons.edit_location_alt_outlined,
+            title: '手动添加点位',
+            subtitle: '手动输入点位信息，逐个添加',
+            enabled: enabled,
+            onTap: onManual,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PointCreationAction extends StatelessWidget {
+  const _PointCreationAction({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.enabled,
+    required this.onTap,
+    this.recommended = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final bool enabled;
+  final VoidCallback? onTap;
+  final bool recommended;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(7),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: enabled ? onTap : null,
+          borderRadius: BorderRadius.circular(7),
+          child: SizedBox(
+            height: 72,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Row(
+                children: [
+                  Container(
+                    width: 42,
+                    height: 42,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: AppColors.accent.withValues(alpha: 0.08),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Icon(icon, color: AppColors.accent, size: 24),
+                  ),
+                  const SizedBox(width: 11),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Flexible(
+                              child: Text(
+                                title,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  color: AppColors.textPrimary,
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w800,
+                                  letterSpacing: 0,
+                                ),
+                              ),
+                            ),
+                            if (recommended) ...[
+                              const SizedBox(width: 6),
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 5,
+                                  vertical: 2,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: AppColors.accent.withValues(
+                                    alpha: 0.10,
+                                  ),
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                child: Text(
+                                  '推荐',
+                                  style: TextStyle(
+                                    color: AppColors.accentDark,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w800,
+                                    letterSpacing: 0,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                        const SizedBox(height: 3),
+                        Text(
+                          subtitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(
+                            color: AppColors.textSecondary,
+                            fontSize: 13,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    Icons.chevron_right_rounded,
+                    color: enabled ? AppColors.accent : AppColors.textSecondary,
+                    size: 22,
+                  ),
+                ],
+              ),
+            ),
           ),
         ),
       ),

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/snackbar_helper.dart';
 import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
 import '../widgets/image_viewer_screen.dart';
+import '../widgets/app_scaled_route.dart';
 import 'anitabi_map_import_screen.dart';
 import 'coordinate_parser.dart';
 import 'pilgrimage_work_dropdown.dart';
@@ -110,12 +111,14 @@ class AddPointsScreen extends StatefulWidget {
   AddPointsScreen({
     required this.plan,
     required this.repository,
+    required this.settings,
     BangumiApiClient? bangumiApiClient,
     super.key,
   }) : bangumiApiClient = bangumiApiClient ?? BangumiApiClient();
 
   final PilgrimagePlan? plan;
   final PilgrimageRepository repository;
+  final AppSettings settings;
   final BangumiApiClient bangumiApiClient;
 
   @override
@@ -184,10 +187,12 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
     PilgrimagePlan plan,
   ) async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
         builder: (_) => WorkManagerScreen(
           plan: plan,
           repository: widget.repository,
+          settings: widget.settings,
           bangumiApiClient: widget.bangumiApiClient,
         ),
       ),
@@ -204,7 +209,8 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
     PilgrimagePlan plan,
   ) async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
         builder: (_) => BangumiWorkSearchScreen(
           plan: plan,
           repository: widget.repository,
@@ -222,9 +228,13 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
     PilgrimagePlan plan,
   ) async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
-        builder: (_) =>
-            ManualWorkFormScreen(plan: plan, repository: widget.repository),
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
+        builder: (_) => ManualWorkFormScreen(
+          plan: plan,
+          repository: widget.repository,
+          settings: widget.settings,
+        ),
       ),
     );
     if (context.mounted) {
@@ -237,9 +247,13 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
     PilgrimagePlan plan,
   ) async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
-        builder: (_) =>
-            AnitabiMapImportScreen(plan: plan, repository: widget.repository),
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
+        builder: (_) => AnitabiMapImportScreen(
+          plan: plan,
+          repository: widget.repository,
+          initialSettings: widget.settings,
+        ),
       ),
     );
     if (!context.mounted) {
@@ -258,9 +272,13 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
     PilgrimagePlan plan,
   ) async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
-        builder: (_) =>
-            _AnitabiLinkImportScreen(plan: plan, repository: widget.repository),
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
+        builder: (_) => _AnitabiLinkImportScreen(
+          plan: plan,
+          repository: widget.repository,
+          settings: widget.settings,
+        ),
       ),
     );
     if (!context.mounted) {
@@ -279,9 +297,13 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
     PilgrimagePlan plan,
   ) async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
-        builder: (_) =>
-            _ManualPointFormScreen(plan: plan, repository: widget.repository),
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
+        builder: (_) => _ManualPointFormScreen(
+          plan: plan,
+          repository: widget.repository,
+          settings: widget.settings,
+        ),
       ),
     );
     if (!context.mounted) {
@@ -748,10 +770,12 @@ class _AnitabiLinkImportScreen extends StatefulWidget {
   const _AnitabiLinkImportScreen({
     required this.plan,
     required this.repository,
+    required this.settings,
   });
 
   final PilgrimagePlan plan;
   final PilgrimageRepository repository;
+  final AppSettings settings;
 
   @override
   State<_AnitabiLinkImportScreen> createState() =>
@@ -780,10 +804,12 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
     }
     final oldPointCount = widget.plan.points.length;
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
         builder: (_) => AnitabiMapImportScreen(
           plan: widget.plan,
           repository: widget.repository,
+          initialSettings: widget.settings,
           initialBangumiId: link.bangumiId,
           initialPointId: link.pointId,
         ),
@@ -1175,11 +1201,13 @@ class ManualWorkFormScreen extends StatefulWidget {
   const ManualWorkFormScreen({
     required this.plan,
     required this.repository,
+    required this.settings,
     super.key,
   });
 
   final PilgrimagePlan plan;
   final PilgrimageRepository repository;
+  final AppSettings settings;
 
   @override
   State<ManualWorkFormScreen> createState() => ManualWorkFormScreenState();
@@ -1322,7 +1350,11 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
                         elevation: 2,
                         borderRadius: BorderRadius.circular(8),
                         dropdownColor: AppColors.surface,
-                        menuMaxHeight: 360,
+                        itemHeight: null,
+                        menuMaxHeight: appScaledOverlayExtent(
+                          widget.settings,
+                          360,
+                        ),
                         icon: const Padding(
                           padding: EdgeInsets.only(right: 8),
                           child: Icon(
@@ -1341,9 +1373,18 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
                           for (final type in _manualWorkSubjectTypes)
                             DropdownMenuItem<BangumiSubjectType>(
                               value: type,
-                              child: _ManualWorkTypeDropdownItem(
-                                type: type,
-                                selected: type == _selectedSubjectType,
+                              child: SizedBox(
+                                height: appScaledOverlayExtent(
+                                  widget.settings,
+                                  48,
+                                ),
+                                child: AppScaledOverlayContent(
+                                  settings: widget.settings,
+                                  child: _ManualWorkTypeDropdownItem(
+                                    type: type,
+                                    selected: type == _selectedSubjectType,
+                                  ),
+                                ),
                               ),
                             ),
                         ],
@@ -1432,7 +1473,9 @@ class _ManualWorkTypeDropdownItemState
         duration: const Duration(milliseconds: 200),
         curve: Curves.easeOutCubic,
         width: double.infinity,
-        padding: EdgeInsets.fromLTRB(hovered ? 14 : 8, 7, 8, 7),
+        margin: const EdgeInsets.symmetric(vertical: 6),
+        alignment: Alignment.centerLeft,
+        padding: EdgeInsets.fromLTRB(hovered ? 14 : 8, 0, 8, 0),
         decoration: BoxDecoration(
           color: AppColors.accent.withValues(
             alpha: widget.selected ? 0.10 : (hovered ? 0.05 : 0),
@@ -1440,6 +1483,7 @@ class _ManualWorkTypeDropdownItemState
           borderRadius: BorderRadius.circular(6),
         ),
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Expanded(child: Text(widget.type.label)),
             if (widget.selected)
@@ -1498,11 +1542,13 @@ class _ManualPointFormScreen extends StatefulWidget {
   const _ManualPointFormScreen({
     required this.plan,
     required this.repository,
+    this.settings,
     this.editingPoint,
   });
 
   final PilgrimagePlan plan;
   final PilgrimageRepository repository;
+  final AppSettings? settings;
   final PilgrimagePoint? editingPoint;
 
   @override
@@ -1752,7 +1798,8 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
 
     final initialPosition = _currentPositionInput() ?? _planCenter;
     final picked = await Navigator.of(context).push<LatLng>(
-      MaterialPageRoute<LatLng>(
+      appScaledMaterialPageRoute<LatLng>(
+        settings: settings,
         builder: (_) => _ManualPointMapPickerScreen(
           initialPosition: initialPosition,
           settings: settings,
@@ -1957,6 +2004,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                       child: PilgrimageWorkDropdown(
                         works: workOptions,
                         value: _selectedWork,
+                        settings: widget.settings ?? const AppSettings(),
                         omitScrollbarInsetWhenUnscrollable: true,
                         onChanged: (work) {
                           setState(() {

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -1214,6 +1214,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                     child: PilgrimageWorkDropdown(
                       works: works,
                       value: _selectedWork,
+                      omitScrollbarInsetWhenUnscrollable: true,
                       onChanged: _isImporting
                           ? null
                           : (work) {

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -23,6 +23,7 @@ import '../widgets/image_load_limiter.dart';
 import '../widgets/map_thumbnail_marker.dart';
 import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
+import '../widgets/app_scaled_route.dart';
 import '../utils/limited_concurrency.dart';
 import '../utils/selected_item_order.dart';
 import 'nearest_group_assign_screen.dart';
@@ -37,6 +38,7 @@ class AnitabiMapImportScreen extends StatefulWidget {
     required this.repository,
     this.initialBangumiId,
     this.initialPointId,
+    this.initialSettings,
     AnitabiClient? anitabiClient,
     super.key,
   }) : anitabiClient = anitabiClient ?? AnitabiClient();
@@ -45,6 +47,7 @@ class AnitabiMapImportScreen extends StatefulWidget {
   final PilgrimageRepository repository;
   final int? initialBangumiId;
   final String? initialPointId;
+  final AppSettings? initialSettings;
   final AnitabiClient anitabiClient;
 
   @override
@@ -61,7 +64,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
   late final Set<String> _importedPointIds;
   late PilgrimagePlan _importedPlan = widget.plan;
   PilgrimageWork? _selectedWork;
-  AppSettings _settings = const AppSettings();
+  late AppSettings _settings = widget.initialSettings ?? const AppSettings();
   AnitabiBangumiLite? _lite;
   List<AnitabiPoint> _points = const [];
   AnitabiPoint? _selectedPoint;
@@ -185,10 +188,12 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
 
   Future<void> _openWorkManager() async {
     final didUpdate = await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
+      appScaledMaterialPageRoute<bool>(
+        settings: _settings,
         builder: (_) => WorkManagerScreen(
           plan: _importedPlan,
           repository: widget.repository,
+          settings: _settings,
         ),
       ),
     );
@@ -1021,7 +1026,8 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
 
   Future<void> _openGroupManager() async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute(
+      appScaledMaterialPageRoute<bool>(
+        settings: _settings,
         builder: (_) => PlanGroupManagerScreen(
           plan: _importedPlan,
           repository: widget.repository,
@@ -1039,7 +1045,8 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       return;
     }
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute(
+      appScaledMaterialPageRoute<bool>(
+        settings: settings,
         builder: (_) => NearestGroupAssignScreen(
           plan: _importedPlan,
           settings: settings,
@@ -1214,6 +1221,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                     child: PilgrimageWorkDropdown(
                       works: works,
                       value: _selectedWork,
+                      settings: _settings,
                       omitScrollbarInsetWhenUnscrollable: true,
                       onChanged: _isImporting
                           ? null

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -27,7 +27,9 @@ import '../utils/limited_concurrency.dart';
 import '../utils/selected_item_order.dart';
 import 'nearest_group_assign_screen.dart';
 import 'pilgrimage_models.dart';
+import 'pilgrimage_work_dropdown.dart';
 import 'plan_group_manager_screen.dart';
+import 'work_manager_screen.dart';
 
 class AnitabiMapImportScreen extends StatefulWidget {
   AnitabiMapImportScreen({
@@ -179,6 +181,31 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     setState(() {
       _error = null;
     });
+  }
+
+  Future<void> _openWorkManager() async {
+    final didUpdate = await Navigator.of(context).push<bool>(
+      MaterialPageRoute<bool>(
+        builder: (_) => WorkManagerScreen(
+          plan: _importedPlan,
+          repository: widget.repository,
+        ),
+      ),
+    );
+    if (!mounted || didUpdate != true) {
+      return;
+    }
+
+    final plans = await widget.repository.loadPlans();
+    if (!mounted) {
+      return;
+    }
+    final updatedPlan = plans.firstWhere((plan) => plan.id == _importedPlan.id);
+    setState(() {
+      _replaceImportedPlan(updatedPlan);
+      _didUpdatePlan = true;
+    });
+    await _refreshAnitabiData();
   }
 
   Future<void> _loadPoints(PilgrimageWork work) async {
@@ -1184,22 +1211,9 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                   preferredSize: const Size.fromHeight(58),
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
-                    child: DropdownButtonFormField<PilgrimageWork>(
-                      initialValue: _selectedWork,
-                      decoration: const InputDecoration(labelText: '作品'),
-                      isExpanded: true,
-                      items: [
-                        for (final work in works)
-                          DropdownMenuItem<PilgrimageWork>(
-                            value: work,
-                            child: Text(
-                              work.displayBangumiSubjectType == null
-                                  ? work.title
-                                  : '${work.title} · ${work.displayBangumiSubjectType!.label}',
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                      ],
+                    child: PilgrimageWorkDropdown(
+                      works: works,
+                      value: _selectedWork,
                       onChanged: _isImporting
                           ? null
                           : (work) {
@@ -1226,7 +1240,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
             }
 
             if (works.isEmpty) {
-              return const _EmptyImportState();
+              return _EmptyImportState(onOpenWorkManager: _openWorkManager);
             }
 
             if (!_isLoading &&
@@ -2241,22 +2255,154 @@ String? _anitabiThumbnailUrl(String? url) {
 }
 
 class _EmptyImportState extends StatelessWidget {
-  const _EmptyImportState();
+  const _EmptyImportState({required this.onOpenWorkManager});
+
+  final VoidCallback onOpenWorkManager;
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Padding(
-        padding: EdgeInsets.all(24),
-        child: Text(
-          '当前计划还没有 Bangumi 作品。请先到作品管理添加 Bangumi 作品。',
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            color: AppColors.textSecondary,
-            fontSize: 14,
-            letterSpacing: 0,
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      children: [
+        Container(
+          padding: const EdgeInsets.all(18),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: AppColors.border),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.movie_filter_outlined, color: AppColors.accent),
+                  const SizedBox(width: 8),
+                  Text(
+                    '还没有作品',
+                    style: TextStyle(
+                      color: AppColors.accentDark,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 14),
+              const _ImportWorkGuideTimeline(),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: onOpenWorkManager,
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(46),
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                  ),
+                  icon: const Icon(Icons.movie_filter_outlined, size: 20),
+                  label: const Text('作品管理'),
+                ),
+              ),
+            ],
           ),
         ),
+      ],
+    );
+  }
+}
+
+class _ImportWorkGuideTimeline extends StatelessWidget {
+  const _ImportWorkGuideTimeline();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        _ImportWorkGuideStep(
+          title: '从Bangumi导入',
+          body: '点击作品管理中的Bangumi按钮，搜索你想导入的作品并导入。之后你可以在这里直接查看对应作品在Anitabi上的点位。',
+          isLast: true,
+        ),
+      ],
+    );
+  }
+}
+
+class _ImportWorkGuideStep extends StatelessWidget {
+  const _ImportWorkGuideStep({
+    required this.title,
+    required this.body,
+    this.isLast = false,
+  });
+
+  final String title;
+  final String body;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            width: 18,
+            child: Stack(
+              children: [
+                if (!isLast)
+                  Positioned(
+                    left: 8,
+                    top: 10,
+                    bottom: 0,
+                    child: Container(width: 2, color: AppColors.border),
+                  ),
+                Positioned(
+                  left: 4,
+                  top: 5,
+                  child: Container(
+                    width: 10,
+                    height: 10,
+                    decoration: BoxDecoration(
+                      color: AppColors.accent,
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 5),
+                  Text(
+                    body,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                      height: 1.35,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/plan/pilgrimage_work_dropdown.dart
+++ b/lib/plan/pilgrimage_work_dropdown.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../app_theme.dart';
+import '../widgets/app_scaled_route.dart';
 import 'pilgrimage_models.dart';
 
 class PilgrimageWorkDropdown extends StatelessWidget {
@@ -10,6 +11,7 @@ class PilgrimageWorkDropdown extends StatelessWidget {
     required this.onChanged,
     this.omitScrollbarInsetWhenUnscrollable = false,
     this.validator,
+    this.settings = const AppSettings(),
     super.key,
   });
 
@@ -18,6 +20,7 @@ class PilgrimageWorkDropdown extends StatelessWidget {
   final ValueChanged<PilgrimageWork?>? onChanged;
   final bool omitScrollbarInsetWhenUnscrollable;
   final FormFieldValidator<PilgrimageWork>? validator;
+  final AppSettings settings;
 
   static const _maxItemsWithoutScrollbar = 7;
 
@@ -42,7 +45,8 @@ class PilgrimageWorkDropdown extends StatelessWidget {
         elevation: 2,
         borderRadius: BorderRadius.circular(8),
         dropdownColor: AppColors.surface,
-        menuMaxHeight: 360,
+        itemHeight: null,
+        menuMaxHeight: appScaledOverlayExtent(settings, 360),
         icon: const Padding(
           padding: EdgeInsets.only(right: 8),
           child: Icon(Icons.keyboard_arrow_down_rounded, size: 20),
@@ -54,11 +58,17 @@ class PilgrimageWorkDropdown extends StatelessWidget {
           for (final work in works)
             DropdownMenuItem<PilgrimageWork>(
               value: work,
-              child: _WorkDropdownItem(
-                work: work,
-                selected: work.id == value?.id,
-                menuItem: true,
-                omitScrollbarInset: omitScrollbarInset,
+              child: SizedBox(
+                height: appScaledOverlayExtent(settings, 48),
+                child: AppScaledOverlayContent(
+                  settings: settings,
+                  child: _WorkDropdownItem(
+                    work: work,
+                    selected: work.id == value?.id,
+                    menuItem: true,
+                    omitScrollbarInset: omitScrollbarInset,
+                  ),
+                ),
               ),
             ),
         ],
@@ -130,9 +140,11 @@ class _WorkDropdownItemState extends State<_WorkDropdownItem> {
 
     final item = SizedBox(
       width: double.infinity,
+      height: widget.menuItem ? double.infinity : null,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
         curve: Curves.easeOutCubic,
+        alignment: Alignment.centerLeft,
         transform: Matrix4.translationValues(
           _hovered && !selected ? _hoverOffset : 0,
           0,
@@ -141,10 +153,9 @@ class _WorkDropdownItemState extends State<_WorkDropdownItem> {
         transformAlignment: Alignment.centerLeft,
         padding: EdgeInsets.only(
           right: reserveScrollbarSpace ? _menuTrailingInset : 0,
-          top: widget.menuItem ? 7 : 0,
-          bottom: widget.menuItem ? 7 : 0,
         ),
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
@@ -188,27 +199,32 @@ class _WorkDropdownItemState extends State<_WorkDropdownItem> {
       ),
     );
 
-    final content = Stack(
-      clipBehavior: Clip.none,
-      children: [
-        Positioned(
-          left: -8,
-          top: 0,
-          right: reserveScrollbarSpace ? _menuBackgroundTrailingInset : -8,
-          bottom: 0,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
-            curve: Curves.easeOutCubic,
-            decoration: BoxDecoration(
-              color: AppColors.accent.withValues(
-                alpha: selected ? 0.1 : (_hovered ? 0.05 : 0),
+    final content = SizedBox(
+      width: double.infinity,
+      height: widget.menuItem ? double.infinity : null,
+      child: Stack(
+        clipBehavior: Clip.none,
+        fit: widget.menuItem ? StackFit.expand : StackFit.loose,
+        children: [
+          Positioned(
+            left: -8,
+            top: 6,
+            right: reserveScrollbarSpace ? _menuBackgroundTrailingInset : -8,
+            bottom: 6,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeOutCubic,
+              decoration: BoxDecoration(
+                color: AppColors.accent.withValues(
+                  alpha: selected ? 0.1 : (_hovered ? 0.05 : 0),
+                ),
+                borderRadius: BorderRadius.circular(6),
               ),
-              borderRadius: BorderRadius.circular(6),
             ),
           ),
-        ),
-        item,
-      ],
+          item,
+        ],
+      ),
     );
 
     return MouseRegion(

--- a/lib/plan/pilgrimage_work_dropdown.dart
+++ b/lib/plan/pilgrimage_work_dropdown.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+
+import '../app_theme.dart';
+import 'pilgrimage_models.dart';
+
+class PilgrimageWorkDropdown extends StatelessWidget {
+  const PilgrimageWorkDropdown({
+    required this.works,
+    required this.value,
+    required this.onChanged,
+    this.validator,
+    super.key,
+  });
+
+  final List<PilgrimageWork> works;
+  final PilgrimageWork? value;
+  final ValueChanged<PilgrimageWork?>? onChanged;
+  final FormFieldValidator<PilgrimageWork>? validator;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: Theme.of(context).copyWith(
+        focusColor: Colors.transparent,
+        hoverColor: Colors.transparent,
+        highlightColor: AppColors.accent.withValues(alpha: 0.075),
+        splashColor: Colors.transparent,
+      ),
+      child: DropdownButtonFormField<PilgrimageWork>(
+        key: ValueKey(value?.id),
+        initialValue: value,
+        decoration: _decoration(),
+        isExpanded: true,
+        elevation: 2,
+        borderRadius: BorderRadius.circular(8),
+        dropdownColor: AppColors.surface,
+        menuMaxHeight: 360,
+        icon: const Padding(
+          padding: EdgeInsets.only(right: 8),
+          child: Icon(Icons.keyboard_arrow_down_rounded, size: 20),
+        ),
+        selectedItemBuilder: (context) => [
+          for (final work in works) _WorkDropdownItem(work: work),
+        ],
+        items: [
+          for (final work in works)
+            DropdownMenuItem<PilgrimageWork>(
+              value: work,
+              child: _WorkDropdownItem(
+                work: work,
+                selected: work.id == value?.id,
+                menuItem: true,
+              ),
+            ),
+        ],
+        onChanged: onChanged,
+        validator: validator,
+      ),
+    );
+  }
+
+  InputDecoration _decoration() {
+    return InputDecoration(
+      isDense: true,
+      filled: true,
+      fillColor: AppColors.surface,
+      hoverColor: AppColors.accent.withValues(alpha: 0.035),
+      contentPadding: const EdgeInsets.fromLTRB(14, 10, 4, 10),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: AppColors.border, width: 1.4),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: AppColors.accent, width: 1.4),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+      ),
+    );
+  }
+}
+
+class _WorkDropdownItem extends StatefulWidget {
+  const _WorkDropdownItem({
+    required this.work,
+    this.selected = false,
+    this.menuItem = false,
+  });
+
+  final PilgrimageWork work;
+  final bool selected;
+  final bool menuItem;
+
+  @override
+  State<_WorkDropdownItem> createState() => _WorkDropdownItemState();
+}
+
+class _WorkDropdownItemState extends State<_WorkDropdownItem> {
+  var _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final work = widget.work;
+    final selected = widget.selected;
+    final highlighted = selected || _hovered;
+    final badgeLabel =
+        work.displayBangumiSubjectType?.label ??
+        (work.source == WorkSource.manual ? '手动' : '作品');
+
+    final item = AnimatedContainer(
+      duration: const Duration(milliseconds: 100),
+      curve: Curves.easeOut,
+      width: double.infinity,
+      padding: EdgeInsets.symmetric(
+        horizontal: highlighted ? 12 : 0,
+        vertical: widget.menuItem ? 7 : 0,
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(alpha: 0.08),
+              border: Border.all(
+                color: AppColors.accent.withValues(alpha: 0.42),
+              ),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              badgeLabel,
+              style: TextStyle(
+                color: AppColors.accent,
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                height: 1.15,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              work.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 14,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+          if (selected) ...[
+            const SizedBox(width: 8),
+            Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+          ],
+        ],
+      ),
+    );
+
+    final content = highlighted
+        ? Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Positioned(
+                left: -8,
+                top: 0,
+                right: -8,
+                bottom: 0,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: AppColors.accent.withValues(
+                      alpha: selected ? 0.1 : 0.05,
+                    ),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                ),
+              ),
+              item,
+            ],
+          )
+        : item;
+
+    return MouseRegion(
+      onEnter: widget.menuItem && !selected
+          ? (_) => setState(() => _hovered = true)
+          : null,
+      onExit: widget.menuItem && !selected
+          ? (_) => setState(() => _hovered = false)
+          : null,
+      child: content,
+    );
+  }
+}

--- a/lib/plan/pilgrimage_work_dropdown.dart
+++ b/lib/plan/pilgrimage_work_dropdown.dart
@@ -8,6 +8,7 @@ class PilgrimageWorkDropdown extends StatelessWidget {
     required this.works,
     required this.value,
     required this.onChanged,
+    this.omitScrollbarInsetWhenUnscrollable = false,
     this.validator,
     super.key,
   });
@@ -15,10 +16,17 @@ class PilgrimageWorkDropdown extends StatelessWidget {
   final List<PilgrimageWork> works;
   final PilgrimageWork? value;
   final ValueChanged<PilgrimageWork?>? onChanged;
+  final bool omitScrollbarInsetWhenUnscrollable;
   final FormFieldValidator<PilgrimageWork>? validator;
+
+  static const _maxItemsWithoutScrollbar = 7;
 
   @override
   Widget build(BuildContext context) {
+    final omitScrollbarInset =
+        omitScrollbarInsetWhenUnscrollable &&
+        works.length <= _maxItemsWithoutScrollbar;
+
     return Theme(
       data: Theme.of(context).copyWith(
         focusColor: Colors.transparent,
@@ -50,6 +58,7 @@ class PilgrimageWorkDropdown extends StatelessWidget {
                 work: work,
                 selected: work.id == value?.id,
                 menuItem: true,
+                omitScrollbarInset: omitScrollbarInset,
               ),
             ),
         ],
@@ -91,101 +100,116 @@ class _WorkDropdownItem extends StatefulWidget {
     required this.work,
     this.selected = false,
     this.menuItem = false,
+    this.omitScrollbarInset = false,
   });
 
   final PilgrimageWork work;
   final bool selected;
   final bool menuItem;
+  final bool omitScrollbarInset;
 
   @override
   State<_WorkDropdownItem> createState() => _WorkDropdownItemState();
 }
 
 class _WorkDropdownItemState extends State<_WorkDropdownItem> {
+  static const _hoverOffset = 12.0;
+  static const _menuTrailingInset = 10.0;
+  static const _menuBackgroundTrailingInset = 6.0;
+
   var _hovered = false;
 
   @override
   Widget build(BuildContext context) {
     final work = widget.work;
     final selected = widget.selected;
-    final highlighted = selected || _hovered;
+    final reserveScrollbarSpace = widget.menuItem && !widget.omitScrollbarInset;
     final badgeLabel =
         work.displayBangumiSubjectType?.label ??
         (work.source == WorkSource.manual ? '手动' : '作品');
 
-    final item = AnimatedContainer(
-      duration: const Duration(milliseconds: 100),
-      curve: Curves.easeOut,
+    final item = SizedBox(
       width: double.infinity,
-      padding: EdgeInsets.symmetric(
-        horizontal: highlighted ? 12 : 0,
-        vertical: widget.menuItem ? 7 : 0,
-      ),
-      child: Row(
-        children: [
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: AppColors.accent.withValues(alpha: 0.08),
-              border: Border.all(
-                color: AppColors.accent.withValues(alpha: 0.42),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOutCubic,
+        transform: Matrix4.translationValues(
+          _hovered && !selected ? _hoverOffset : 0,
+          0,
+          0,
+        ),
+        transformAlignment: Alignment.centerLeft,
+        padding: EdgeInsets.only(
+          right: reserveScrollbarSpace ? _menuTrailingInset : 0,
+          top: widget.menuItem ? 7 : 0,
+          bottom: widget.menuItem ? 7 : 0,
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: AppColors.accent.withValues(alpha: 0.08),
+                border: Border.all(
+                  color: AppColors.accent.withValues(alpha: 0.42),
+                ),
+                borderRadius: BorderRadius.circular(4),
               ),
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(
-              badgeLabel,
-              style: TextStyle(
-                color: AppColors.accent,
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                height: 1.15,
-                letterSpacing: 0,
-              ),
-            ),
-          ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              work.title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: AppColors.textPrimary,
-                fontSize: 14,
-                letterSpacing: 0,
+              child: Text(
+                badgeLabel,
+                style: TextStyle(
+                  color: AppColors.accent,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  height: 1.15,
+                  letterSpacing: 0,
+                ),
               ),
             ),
-          ),
-          if (selected) ...[
-            const SizedBox(width: 8),
-            Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                work.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 14,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+            if (selected) ...[
+              const SizedBox(width: 8),
+              Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+            ],
           ],
-        ],
+        ),
       ),
     );
 
-    final content = highlighted
-        ? Stack(
-            clipBehavior: Clip.none,
-            children: [
-              Positioned(
-                left: -8,
-                top: 0,
-                right: -8,
-                bottom: 0,
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: AppColors.accent.withValues(
-                      alpha: selected ? 0.1 : 0.05,
-                    ),
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                ),
+    final content = Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Positioned(
+          left: -8,
+          top: 0,
+          right: reserveScrollbarSpace ? _menuBackgroundTrailingInset : -8,
+          bottom: 0,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOutCubic,
+            decoration: BoxDecoration(
+              color: AppColors.accent.withValues(
+                alpha: selected ? 0.1 : (_hovered ? 0.05 : 0),
               ),
-              item,
-            ],
-          )
-        : item;
+              borderRadius: BorderRadius.circular(6),
+            ),
+          ),
+        ),
+        item,
+      ],
+    );
 
     return MouseRegion(
       onEnter: widget.menuItem && !selected

--- a/lib/plan/plan_group_manager_screen.dart
+++ b/lib/plan/plan_group_manager_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_scaled_route.dart';
 import 'group_anchor_picker_screen.dart';
 import 'pilgrimage_models.dart';
 
@@ -231,7 +232,8 @@ class _PlanGroupManagerScreenState extends State<PlanGroupManagerScreen> {
       return;
     }
     final selection = await Navigator.of(context).push<GroupAnchorSelection>(
-      MaterialPageRoute(
+      appScaledMaterialPageRoute<GroupAnchorSelection>(
+        settings: settings,
         builder: (_) => GroupAnchorPickerScreen(
           group: group,
           points: _plan.points,

--- a/lib/plan/plan_memo_screen.dart
+++ b/lib/plan/plan_memo_screen.dart
@@ -444,7 +444,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
                     ],
                   )
                 : memo.isEmpty
-                ? const _EmptyPlanMemo()
+                ? _EmptyPlanMemo(onStart: _startEditing)
                 : _PlanMemoMarkdownPreview(
                     data: _savedMemo,
                     onTapLink: _openMarkdownLink,
@@ -797,46 +797,201 @@ class _UnsupportedMarkdownImage extends StatelessWidget {
 }
 
 class _EmptyPlanMemo extends StatelessWidget {
-  const _EmptyPlanMemo();
+  const _EmptyPlanMemo({required this.onStart});
+
+  final VoidCallback onStart;
+
+  static const _suggestions = [
+    (
+      icon: Icons.directions_transit_outlined,
+      label: '交通安排',
+      detail: '如车次、换乘方案、出发时间等',
+    ),
+    (icon: Icons.hotel_outlined, label: '酒店预约', detail: '酒店地址、入住时间、联系方式等'),
+    (
+      icon: Icons.confirmation_number_outlined,
+      label: '活动门票',
+      detail: '活动门票、预约时间、注意事项等',
+    ),
+    (
+      icon: Icons.photo_camera_outlined,
+      label: '拍摄计划',
+      detail: '拍摄地点、时间、天气备选方案等',
+    ),
+    (
+      icon: Icons.notifications_none_rounded,
+      label: '注意事项',
+      detail: '携带物品、预算、当地注意事项等',
+    ),
+  ];
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final guideWidth = (constraints.maxWidth * 0.84).clamp(0.0, 420.0);
+        return SingleChildScrollView(
+          child: SizedBox(
+            width: constraints.maxWidth,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const SizedBox(height: 20),
+                Container(
+                  width: 72,
+                  height: 72,
+                  decoration: BoxDecoration(
+                    color: AppColors.accent.withValues(alpha: 0.10),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Icon(
+                    Icons.sticky_note_2_outlined,
+                    color: AppColors.accentDark,
+                    size: 34,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  '还没有计划备忘',
+                  style: TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  '记录本次巡礼的重要事项',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: guideWidth,
+                  child: Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.fromLTRB(14, 12, 14, 10),
+                    decoration: BoxDecoration(
+                      color: AppColors.surfaceMuted,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: AppColors.border),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.lightbulb_outline_rounded,
+                              color: AppColors.accent,
+                              size: 18,
+                            ),
+                            const SizedBox(width: 7),
+                            Text(
+                              '可记录内容',
+                              style: TextStyle(
+                                color: AppColors.accentDark,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 8),
+                        for (
+                          var index = 0;
+                          index < _suggestions.length;
+                          index++
+                        ) ...[
+                          _MemoSuggestionItem(suggestion: _suggestions[index]),
+                          if (index < _suggestions.length - 1)
+                            const Divider(height: 1, indent: 42),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: guideWidth,
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: onStart,
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size.fromHeight(46),
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                      ),
+                      icon: const Icon(Icons.edit_note_rounded, size: 20),
+                      label: const Text('开始记录'),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _MemoSuggestionItem extends StatelessWidget {
+  const _MemoSuggestionItem({required this.suggestion});
+
+  final ({IconData icon, String label, String detail}) suggestion;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 56,
+      child: Row(
         children: [
           Container(
-            width: 72,
-            height: 72,
+            width: 34,
+            height: 34,
+            alignment: Alignment.center,
             decoration: BoxDecoration(
-              color: AppColors.accent.withValues(alpha: 0.10),
-              borderRadius: BorderRadius.circular(8),
+              color: AppColors.accent.withValues(alpha: 0.08),
+              shape: BoxShape.circle,
             ),
-            child: Icon(
-              Icons.sticky_note_2_outlined,
-              color: AppColors.accentDark,
-              size: 34,
-            ),
+            child: Icon(suggestion.icon, color: AppColors.accent, size: 18),
           ),
-          const SizedBox(height: 16),
-          const Text(
-            '还没有写计划备忘',
-            style: TextStyle(
-              color: AppColors.textPrimary,
-              fontSize: 18,
-              fontWeight: FontWeight.w800,
-              letterSpacing: 0,
-            ),
-          ),
-          const SizedBox(height: 8),
-          const Text(
-            '点击右上角编辑，记录交通、预约、补拍事项或其他准备内容。',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: AppColors.textSecondary,
-              fontSize: 14,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0,
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  suggestion.label,
+                  maxLines: 1,
+                  style: const TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  suggestion.detail,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 11,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ],
             ),
           ),
         ],

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -1425,33 +1425,151 @@ class _EmptyPlanCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(Icons.route_outlined, color: AppColors.accent),
-              SizedBox(width: 8),
+              Icon(Icons.inventory_2_rounded, color: AppColors.accent),
+              const SizedBox(width: 10),
               Text(
                 '还没有点位',
                 style: TextStyle(
                   color: AppColors.accentDark,
-                  fontSize: 15,
+                  fontSize: 18,
                   fontWeight: FontWeight.w800,
                   letterSpacing: 0,
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 8),
-          const Text(
-            '先从 Anitabi 或手动录入添加巡礼点，之后这里会显示当前目标和完成进度。',
-            style: TextStyle(
-              color: AppColors.textSecondary,
-              fontSize: 14,
-              letterSpacing: 0,
+          const SizedBox(height: 14),
+          const _OnboardingTimeline(),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: onAddPoints,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(46),
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+              ),
+              icon: const Icon(Icons.add_location_alt_outlined, size: 20),
+              label: const Text('添加点位'),
             ),
           ),
-          const SizedBox(height: 14),
-          FilledButton.icon(
-            onPressed: onAddPoints,
-            icon: const Icon(Icons.add_location_alt_outlined, size: 18),
-            label: const Text('添加点位'),
+        ],
+      ),
+    );
+  }
+}
+
+class _OnboardingTimeline extends StatelessWidget {
+  const _OnboardingTimeline();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        _OnboardingStep(
+          number: 1,
+          title: '加作品',
+          body: '点击右上角，选择“添加点位”，点击“作品管理”，在这里搜索你想要加入巡礼计划的作品并添加。',
+        ),
+        _OnboardingStep(
+          number: 2,
+          title: '选点位',
+          body:
+              '在“添加点位”页面点击“从作品地图导入”，在这里你可以选择并添加巡礼点位。\n你也可以在“添加点位”页面点击“从Anitabi链接导入”。通过使用有效链接，导入点位时作品也会被一起添加。',
+        ),
+        _OnboardingStep(
+          number: 3,
+          title: '划片区',
+          body:
+              '回到“计划”页，点击右上角，选择“管理计划”，在这里你可以对加入计划的点位进行更细致的管理。你可以创建片区，把距离接近的点位放到一起。',
+          isLast: true,
+        ),
+      ],
+    );
+  }
+}
+
+class _OnboardingStep extends StatelessWidget {
+  const _OnboardingStep({
+    required this.number,
+    required this.title,
+    required this.body,
+    this.isLast = false,
+  });
+
+  final int number;
+  final String title;
+  final String body;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            width: 28,
+            child: Column(
+              children: [
+                Container(
+                  width: 26,
+                  height: 26,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: AppColors.accent,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    '$number',
+                    style: TextStyle(
+                      color: AppColors.onAccent,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+                if (!isLast)
+                  Expanded(child: Container(width: 2, color: AppColors.border)),
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(
+                    height: 26,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        title,
+                        style: const TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    body,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                      height: 1.35,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
         ],
       ),
@@ -1467,7 +1585,7 @@ class _WorkHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      margin: const EdgeInsets.fromLTRB(0, 8, 0, 12),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         color: AppColors.surface,

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -242,9 +242,7 @@ class _WorkManageCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sourceText = work.bangumiId == null
-        ? '手动添加'
-        : 'Bangumi #${work.bangumiId}';
+    final sourceText = work.bangumiId == null ? '手动添加' : 'Bangumi';
     final typeText = work.displayBangumiSubjectType?.label;
     final infoText = [
       work.subtitle,
@@ -324,13 +322,129 @@ class _EmptyWorkPanel extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      child: const Text(
-        '当前计划还没有作品。',
-        style: TextStyle(
-          color: AppColors.textSecondary,
-          fontSize: 14,
-          letterSpacing: 0,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.movie_filter_outlined, color: AppColors.accent),
+              const SizedBox(width: 8),
+              Text(
+                '还没有作品',
+                style: TextStyle(
+                  color: AppColors.accentDark,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          const _WorkOnboardingTimeline(),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkOnboardingTimeline extends StatelessWidget {
+  const _WorkOnboardingTimeline();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        _WorkOnboardingStep(
+          title: '从Bangumi导入',
+          body:
+              '点击上方按钮可从Bangumi搜索你想导入的作品并导入。之后你可以在“从作品地图导入点位”直接查看对应作品在Anitabi上的点位。',
         ),
+        _WorkOnboardingStep(
+          title: '手动添加作品',
+          body:
+              '若Bangumi未收录你想要添加到作品，你可以通过“手动添加”将作品加入到计划内。之后你可以通过“手动添加点位”自主上传想要巡礼的点位。',
+          isLast: true,
+        ),
+      ],
+    );
+  }
+}
+
+class _WorkOnboardingStep extends StatelessWidget {
+  const _WorkOnboardingStep({
+    required this.title,
+    required this.body,
+    this.isLast = false,
+  });
+
+  final String title;
+  final String body;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(
+            width: 18,
+            child: Stack(
+              children: [
+                if (!isLast)
+                  Positioned(
+                    left: 8,
+                    top: 10,
+                    bottom: 0,
+                    child: Container(width: 2, color: AppColors.border),
+                  ),
+                Positioned(
+                  left: 4,
+                  top: 5,
+                  child: Container(
+                    width: 10,
+                    height: 10,
+                    decoration: BoxDecoration(
+                      color: AppColors.accent,
+                      borderRadius: BorderRadius.circular(5),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 5),
+                  Text(
+                    body,
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                      height: 1.35,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -198,30 +198,109 @@ class _AddWorkPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(14),
+      padding: const EdgeInsets.all(8),
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      child: Row(
-        children: [
-          Expanded(
-            child: FilledButton.icon(
-              onPressed: onBangumi,
-              icon: const Icon(Icons.search, size: 18),
-              label: const Text('Bangumi'),
+      child: SizedBox(
+        height: 56,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: _AddWorkAction(
+                icon: Icons.search_rounded,
+                title: '从 Bangumi 搜索',
+                subtitle: '自动获取信息',
+                onTap: onBangumi,
+              ),
+            ),
+            const VerticalDivider(
+              width: 9,
+              indent: 8,
+              endIndent: 8,
+              color: AppColors.border,
+            ),
+            Expanded(
+              child: _AddWorkAction(
+                icon: Icons.edit_rounded,
+                title: '手动添加作品',
+                subtitle: '未收录时使用',
+                onTap: onManual,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AddWorkAction extends StatelessWidget {
+  const _AddWorkAction({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(6),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(6),
+        child: SizedBox(
+          height: 56,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            child: Row(
+              children: [
+                Icon(icon, size: 20, color: AppColors.textPrimary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 11,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
           ),
-          const SizedBox(width: 8),
-          Expanded(
-            child: OutlinedButton.icon(
-              onPressed: onManual,
-              icon: const Icon(Icons.edit_note, size: 18),
-              label: const Text('手动添加'),
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -5,6 +5,7 @@ import '../data/bangumi_api_client.dart';
 import '../data/pilgrimage_repository.dart';
 import '../widgets/copyable_text.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_scaled_route.dart';
 import 'add_points_screen.dart';
 import 'pilgrimage_models.dart';
 
@@ -12,12 +13,14 @@ class WorkManagerScreen extends StatefulWidget {
   WorkManagerScreen({
     required this.plan,
     required this.repository,
+    required this.settings,
     BangumiApiClient? bangumiApiClient,
     super.key,
   }) : bangumiApiClient = bangumiApiClient ?? BangumiApiClient();
 
   final PilgrimagePlan plan;
   final PilgrimageRepository repository;
+  final AppSettings settings;
   final BangumiApiClient bangumiApiClient;
 
   @override
@@ -81,7 +84,8 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
 
   Future<void> _openBangumiSearch() async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
         builder: (_) => BangumiWorkSearchScreen(
           plan: _plan,
           repository: widget.repository,
@@ -96,9 +100,13 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
 
   Future<void> _openManualWorkForm() async {
     await Navigator.of(context).push<bool>(
-      MaterialPageRoute<bool>(
-        builder: (_) =>
-            ManualWorkFormScreen(plan: _plan, repository: widget.repository),
+      appScaledMaterialPageRoute<bool>(
+        settings: widget.settings,
+        builder: (_) => ManualWorkFormScreen(
+          plan: _plan,
+          repository: widget.repository,
+          settings: widget.settings,
+        ),
       ),
     );
     if (mounted) {

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -212,7 +212,7 @@ class _AddWorkPanel extends StatelessWidget {
             Expanded(
               child: _AddWorkAction(
                 icon: Icons.search_rounded,
-                title: '从 Bangumi 搜索',
+                title: '从Bangumi添加',
                 subtitle: '自动获取信息',
                 onTap: onBangumi,
               ),
@@ -306,7 +306,7 @@ class _AddWorkAction extends StatelessWidget {
   }
 }
 
-class _WorkManageCard extends StatelessWidget {
+class _WorkManageCard extends StatefulWidget {
   const _WorkManageCard({
     required this.work,
     required this.pointCount,
@@ -320,18 +320,27 @@ class _WorkManageCard extends StatelessWidget {
   final VoidCallback onDelete;
 
   @override
+  State<_WorkManageCard> createState() => _WorkManageCardState();
+}
+
+class _WorkManageCardState extends State<_WorkManageCard> {
+  var _titleExpanded = false;
+
+  @override
   Widget build(BuildContext context) {
-    final sourceText = work.bangumiId == null ? '手动添加' : 'Bangumi';
-    final typeText = work.displayBangumiSubjectType?.label;
-    final infoText = [
-      work.subtitle,
-      ?typeText,
-      sourceText,
-      '$pointCount 个点位',
-    ].where((value) => value.trim().isNotEmpty).join(' / ');
+    final work = widget.work;
+    final pointCount = widget.pointCount;
+    final subtitle = work.subtitle.trim();
+    final showSubtitle =
+        subtitle.isNotEmpty &&
+        subtitle != work.title.trim() &&
+        !subtitle.startsWith('Bangumi #') &&
+        subtitle != 'Manual Work' &&
+        subtitle != '暂无作品原名';
+    final isBangumiWork = work.bangumiId != null;
 
     return Container(
-      padding: const EdgeInsets.fromLTRB(14, 12, 6, 12),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(8),
@@ -339,7 +348,18 @@ class _WorkManageCard extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(Icons.movie_filter_outlined, color: AppColors.accentDark),
+          Semantics(
+            label: '作品封面预留',
+            child: Container(
+              width: 58,
+              height: 78,
+              decoration: BoxDecoration(
+                color: AppColors.surfaceMuted,
+                borderRadius: BorderRadius.circular(4),
+                border: Border.all(color: AppColors.border),
+              ),
+            ),
+          ),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -348,8 +368,15 @@ class _WorkManageCard extends StatelessWidget {
                 CopyableText(
                   text: work.title,
                   copyLabel: '作品名称',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                  maxLines: _titleExpanded ? null : 1,
+                  overflow: _titleExpanded
+                      ? TextOverflow.visible
+                      : TextOverflow.ellipsis,
+                  onTap: () {
+                    setState(() {
+                      _titleExpanded = !_titleExpanded;
+                    });
+                  },
                   style: const TextStyle(
                     fontSize: 16,
                     fontWeight: FontWeight.w800,
@@ -358,32 +385,92 @@ class _WorkManageCard extends StatelessWidget {
                 ),
                 const SizedBox(height: 3),
                 CopyableText(
-                  text: infoText,
+                  text: showSubtitle ? subtitle : '暂无作品原名',
                   copyText: [
                     work.title,
-                    work.subtitle,
-                    ?typeText,
-                    sourceText,
-                    '$pointCount 个点位',
+                    if (showSubtitle) subtitle,
                   ].where((value) => value.trim().isNotEmpty).join('\n'),
                   copyLabel: '作品信息',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
-                    color: AppColors.textSecondary,
+                  style: TextStyle(
+                    color: showSubtitle
+                        ? AppColors.textSecondary
+                        : AppColors.textSecondary.withValues(alpha: 0.55),
                     fontSize: 12,
                     letterSpacing: 0,
                   ),
                 ),
+                const SizedBox(height: 6),
+                Wrap(
+                  spacing: 6,
+                  runSpacing: 4,
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  children: [
+                    if (work.displayBangumiSubjectType != null)
+                      _WorkManageBadge(
+                        label: work.displayBangumiSubjectType!.label,
+                      ),
+                    _WorkManageBadge(
+                      label: isBangumiWork ? 'Bangumi' : '手动添加',
+                      emphasized: isBangumiWork,
+                    ),
+                    _WorkManageBadge(label: '$pointCount 个点位'),
+                  ],
+                ),
               ],
             ),
           ),
-          IconButton(
-            tooltip: '删除作品',
-            onPressed: disabled ? null : onDelete,
-            icon: const Icon(Icons.delete_outline),
+          const SizedBox(width: 12),
+          OutlinedButton(
+            onPressed: widget.disabled ? null : widget.onDelete,
+            style: OutlinedButton.styleFrom(
+              minimumSize: const Size(88, 40),
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+              foregroundColor: Colors.redAccent,
+              side: BorderSide(
+                color: widget.disabled
+                    ? AppColors.border
+                    : Colors.redAccent.withValues(alpha: 0.65),
+              ),
+            ),
+            child: const Text('删除'),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _WorkManageBadge extends StatelessWidget {
+  const _WorkManageBadge({required this.label, this.emphasized = false});
+
+  final String label;
+  final bool emphasized;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: emphasized
+            ? AppColors.accent.withValues(alpha: 0.08)
+            : AppColors.surfaceMuted,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(
+          color: emphasized
+              ? AppColors.accent.withValues(alpha: 0.42)
+              : AppColors.border,
+        ),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: emphasized ? AppColors.accentDark : AppColors.textSecondary,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0,
+        ),
       ),
     );
   }

--- a/lib/records/comparison_export_config_editor.dart
+++ b/lib/records/comparison_export_config_editor.dart
@@ -28,12 +28,20 @@ class ComparisonExportConfigEditor extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        _CurrentConfigSummary(config: config),
+        const SizedBox(height: 18),
+        const _SectionDivider(),
+        const SizedBox(height: 18),
+        const _SectionLabel('外观'),
+        const SizedBox(height: 12),
         ComparisonAppearanceSection(
           config: config,
           borderColorOptions: borderColorOptions,
           borderColorLabels: borderColorLabels,
           onChanged: onChanged,
         ),
+        const SizedBox(height: 20),
+        const _SectionDivider(),
         const SizedBox(height: 18),
         ComparisonMetadataSection(
           config: config,
@@ -75,37 +83,49 @@ class ComparisonAppearanceSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final automaticOutput = config.outputWidth == ComparisonOutputWidth.auto;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const _SectionLabel('外观'),
-        const SizedBox(height: 8),
         Row(
           children: [
             const _FieldLabel('边框宽度'),
             const Spacer(),
-            Text(
-              config.borderWidthPercent == 0
+            _ValueCapsule(
+              label: config.borderWidthPercent == 0
                   ? '无'
                   : '${config.borderWidthPercent.toStringAsFixed(1)}%',
-              style: TextStyle(
-                color: AppColors.accent,
-                fontSize: 14,
-                fontWeight: FontWeight.w800,
-              ),
             ),
           ],
         ),
-        Slider(
-          value: config.borderWidthPercent,
-          min: 0,
-          max: 3.0,
-          divisions: 30,
-          onChanged: (v) => onChanged(config.copyWith(borderWidthPercent: v)),
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            trackHeight: 4,
+            thumbShape: const RoundSliderThumbShape(
+              enabledThumbRadius: 7,
+              pressedElevation: 3,
+            ),
+            overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+            valueIndicatorShape: const PaddleSliderValueIndicatorShape(),
+            showValueIndicator: ShowValueIndicator.onlyForDiscrete,
+          ),
+          child: Slider(
+            value: config.borderWidthPercent,
+            min: 0,
+            max: 3.0,
+            divisions: 30,
+            label: config.borderWidthPercent == 0
+                ? '无'
+                : '${config.borderWidthPercent.toStringAsFixed(1)}%',
+            onChanged: (v) => onChanged(config.copyWith(borderWidthPercent: v)),
+          ),
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: 8),
+        const _SectionDivider(),
+        const SizedBox(height: 16),
         const _FieldLabel('边框颜色'),
-        const SizedBox(height: 6),
+        const SizedBox(height: 10),
         Wrap(
           spacing: 10,
           runSpacing: 8,
@@ -121,36 +141,306 @@ class ComparisonAppearanceSection extends StatelessWidget {
               ),
           ],
         ),
+        const SizedBox(height: 18),
+        const _SectionDivider(),
         const SizedBox(height: 16),
-        const _FieldLabel('输出宽度'),
-        const SizedBox(height: 6),
+        _ToggleSetting(
+          title: '自动输出宽度',
+          subtitle: '根据图片尺寸自动确定输出宽度',
+          value: automaticOutput,
+          switchKey: const ValueKey('comparison-output-auto'),
+          onChanged: (useAutomatic) {
+            onChanged(
+              config.copyWith(
+                outputWidth: useAutomatic
+                    ? ComparisonOutputWidth.auto
+                    : ComparisonOutputWidth.w1920,
+              ),
+            );
+          },
+        ),
+        AnimatedSize(
+          duration: const Duration(milliseconds: 160),
+          curve: Curves.easeOut,
+          child: automaticOutput
+              ? const SizedBox.shrink()
+              : Padding(
+                  padding: const EdgeInsets.only(top: 10),
+                  child: _OutputWidthSelector(
+                    selectedWidth: config.outputWidth,
+                    onSelected: (width) =>
+                        onChanged(config.copyWith(outputWidth: width)),
+                  ),
+                ),
+        ),
+        const SizedBox(height: 18),
+        const _SectionDivider(),
+        const SizedBox(height: 8),
+        _ToggleSetting(
+          title: '显示标签',
+          subtitle: '在参考图上显示“参考”字样，在你拍的巡礼图上显示“巡礼”字样',
+          value: config.showLabels,
+          onChanged: (value) => onChanged(config.copyWith(showLabels: value)),
+        ),
+      ],
+    );
+  }
+}
+
+class _CurrentConfigSummary extends StatelessWidget {
+  const _CurrentConfigSummary({required this.config});
+
+  final ComparisonExportConfig config;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderLabel = config.borderWidthPercent == 0
+        ? '无边框'
+        : '${config.borderWidthPercent.toStringAsFixed(1)}% 边框';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionLabel('当前配置'),
+        const SizedBox(height: 8),
         Wrap(
           spacing: 8,
           runSpacing: 8,
-          children: ComparisonOutputWidth.values
-              .map((ow) {
-                return _OptionChip(
-                  label: ow.label,
-                  selected: config.outputWidth == ow,
-                  onSelected: () => onChanged(config.copyWith(outputWidth: ow)),
-                );
-              })
-              .toList(growable: false),
-        ),
-        const SizedBox(height: 16),
-        Row(
           children: [
-            const Text(
-              '显示标签',
-              style: TextStyle(fontSize: 14, letterSpacing: 0),
+            _SummaryChip(
+              label: config.outputWidth == ComparisonOutputWidth.auto
+                  ? '自动宽度'
+                  : config.outputWidth.label,
             ),
-            const Spacer(),
-            Switch(
-              value: config.showLabels,
-              onChanged: (v) => onChanged(config.copyWith(showLabels: v)),
-            ),
+            _SummaryChip(label: borderLabel),
+            _SummaryChip(label: config.showLabels ? '显示标签' : '隐藏标签'),
           ],
         ),
+      ],
+    );
+  }
+}
+
+class _SummaryChip extends StatelessWidget {
+  const _SummaryChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceMuted,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: AppColors.textSecondary,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+class _ValueCapsule extends StatelessWidget {
+  const _ValueCapsule({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(minWidth: 48, minHeight: 32),
+      alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceMuted,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: AppColors.textPrimary,
+          fontSize: 13,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+class _OutputWidthSelector extends StatelessWidget {
+  const _OutputWidthSelector({
+    required this.selectedWidth,
+    required this.onSelected,
+  });
+
+  final ComparisonOutputWidth selectedWidth;
+  final ValueChanged<ComparisonOutputWidth> onSelected;
+
+  static const _fixedWidths = [
+    ComparisonOutputWidth.w1080,
+    ComparisonOutputWidth.w1920,
+    ComparisonOutputWidth.w2560,
+    ComparisonOutputWidth.w3840,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: 40,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (var index = 0; index < _fixedWidths.length; index++) ...[
+            Expanded(
+              child: _OutputWidthOption(
+                key: ValueKey('comparison-output-${_fixedWidths[index].name}'),
+                label: _fixedWidths[index].label,
+                selected: selectedWidth == _fixedWidths[index],
+                onTap: () => onSelected(_fixedWidths[index]),
+              ),
+            ),
+            if (index < _fixedWidths.length - 1)
+              const VerticalDivider(
+                width: 1,
+                thickness: 1,
+                color: AppColors.surfaceMuted,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _OutputWidthOption extends StatelessWidget {
+  const _OutputWidthOption({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      selected: selected,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 140),
+                color: selected
+                    ? AppColors.accent.withValues(alpha: 0.08)
+                    : Colors.transparent,
+                alignment: Alignment.center,
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  style: TextStyle(
+                    color: selected
+                        ? AppColors.accentDark
+                        : AppColors.textSecondary,
+                    fontSize: 12,
+                    fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ),
+              if (selected)
+                Positioned(
+                  left: 8,
+                  right: 8,
+                  bottom: 0,
+                  child: Container(
+                    height: 3,
+                    decoration: BoxDecoration(
+                      color: AppColors.accent,
+                      borderRadius: const BorderRadius.vertical(
+                        top: Radius.circular(3),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ToggleSetting extends StatelessWidget {
+  const _ToggleSetting({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+    this.switchKey,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final Key? switchKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0,
+                ),
+              ),
+              const SizedBox(height: 3),
+              Text(
+                subtitle,
+                style: const TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 12,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 12),
+        Switch(key: switchKey, value: value, onChanged: onChanged),
       ],
     );
   }
@@ -174,97 +464,75 @@ class ComparisonMetadataSection extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const _SectionLabel('元数据'),
-        const SizedBox(height: 8),
-        TextFormField(
-          controller: pilgrimNameController,
-          decoration: const InputDecoration(
-            labelText: '巡礼者名字',
-            prefixIcon: Icon(Icons.person_outline),
+        const SizedBox(height: 12),
+        _ToggleSetting(
+          title: '显示巡礼者名字',
+          subtitle: '在图片上显示巡礼者名字',
+          value: config.showPilgrimName,
+          switchKey: const ValueKey('comparison-show-pilgrim-name'),
+          onChanged: (value) =>
+              onChanged(config.copyWith(showPilgrimName: value)),
+        ),
+        const SizedBox(height: 10),
+        AnimatedOpacity(
+          duration: const Duration(milliseconds: 160),
+          opacity: config.showPilgrimName ? 1 : 0.45,
+          child: TextFormField(
+            key: const ValueKey('comparison-pilgrim-name'),
+            controller: pilgrimNameController,
+            enabled: config.showPilgrimName,
+            decoration: _comparisonTextFieldDecoration(
+              hintText: '请输入巡礼者名字',
+              enabled: config.showPilgrimName,
+            ),
+            textInputAction: TextInputAction.done,
+            onChanged: (value) =>
+                onChanged(config.copyWith(pilgrimName: value)),
           ),
-          textInputAction: TextInputAction.done,
-          onChanged: (value) => onChanged(config.copyWith(pilgrimName: value)),
         ),
-        const SizedBox(height: 8),
-        Row(
-          children: [
-            const Expanded(
-              child: Text(
-                '在右侧显示巡礼者',
-                style: TextStyle(fontSize: 14, letterSpacing: 0),
-              ),
-            ),
-            Switch(
-              value: config.showPilgrimName,
-              onChanged: (v) => onChanged(config.copyWith(showPilgrimName: v)),
-            ),
-          ],
+        const SizedBox(height: 20),
+        const _SectionDivider(),
+        const SizedBox(height: 10),
+        _ToggleSetting(
+          title: '显示调色参数',
+          subtitle: '在图片底部显示调色相关参数',
+          value: config.showColorGradingParams,
+          onChanged: (value) =>
+              onChanged(config.copyWith(showColorGradingParams: value)),
         ),
-        const SizedBox(height: 8),
-        Row(
-          children: [
-            const Expanded(
-              child: Text(
-                '底部显示调色参数',
-                style: TextStyle(fontSize: 14, letterSpacing: 0),
-              ),
-            ),
-            Switch(
-              value: config.showColorGradingParams,
-              onChanged: (v) =>
-                  onChanged(config.copyWith(showColorGradingParams: v)),
-            ),
-          ],
-        ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 20),
+        const _SectionDivider(),
+        const SizedBox(height: 18),
+        const _SectionLabel('显示内容'),
+        const SizedBox(height: 10),
         LayoutBuilder(
           builder: (context, constraints) {
-            final itemWidth = constraints.maxWidth >= 360
-                ? (constraints.maxWidth - 8) / 2
-                : constraints.maxWidth;
-
+            const spacing = 8.0;
+            final itemWidth = (constraints.maxWidth - spacing * 2) / 3;
             return Wrap(
-              spacing: 8,
-              runSpacing: 2,
-              children: ComparisonMetadataField.values
-                  .map((field) {
-                    final selected = config.metadataFields.contains(field);
-                    return SizedBox(
-                      width: itemWidth,
-                      child: Row(
-                        children: [
-                          Checkbox(
-                            value: selected,
-                            onChanged: (_) {
-                              final updated = Set<ComparisonMetadataField>.from(
-                                config.metadataFields,
-                              );
-                              if (selected) {
-                                updated.remove(field);
-                              } else {
-                                updated.add(field);
-                              }
-                              onChanged(
-                                config.copyWith(metadataFields: updated),
-                              );
-                            },
-                            materialTapTargetSize:
-                                MaterialTapTargetSize.shrinkWrap,
-                            visualDensity: VisualDensity.compact,
-                          ),
-                          Expanded(
-                            child: Text(
-                              field.label,
-                              style: const TextStyle(
-                                fontSize: 14,
-                                letterSpacing: 0,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  })
-                  .toList(growable: false),
+              spacing: spacing,
+              runSpacing: 8,
+              children: [
+                for (final field in _metadataFieldOrder)
+                  SizedBox(
+                    width: itemWidth,
+                    child: _MetadataFilterChip(
+                      field: field,
+                      selected: config.metadataFields.contains(field),
+                      onSelected: () {
+                        final updated = Set<ComparisonMetadataField>.from(
+                          config.metadataFields,
+                        );
+                        if (updated.contains(field)) {
+                          updated.remove(field);
+                        } else {
+                          updated.add(field);
+                        }
+                        onChanged(config.copyWith(metadataFields: updated));
+                      },
+                    ),
+                  ),
+              ],
             );
           },
         ),
@@ -273,37 +541,101 @@ class ComparisonMetadataSection extends StatelessWidget {
   }
 }
 
-class _OptionChip extends StatelessWidget {
-  const _OptionChip({
-    required this.label,
+const _metadataFieldOrder = [
+  ComparisonMetadataField.capturedAt,
+  ComparisonMetadataField.pointName,
+  ComparisonMetadataField.workTitle,
+  ComparisonMetadataField.episodeLabel,
+  ComparisonMetadataField.coordinates,
+  ComparisonMetadataField.anitabiId,
+];
+
+class _MetadataFilterChip extends StatelessWidget {
+  const _MetadataFilterChip({
+    required this.field,
     required this.selected,
     required this.onSelected,
   });
 
-  final String label;
+  final ComparisonMetadataField field;
   final bool selected;
   final VoidCallback onSelected;
 
   @override
   Widget build(BuildContext context) {
-    return ChoiceChip(
-      label: Text(
-        label,
-        style: TextStyle(
-          color: selected ? Colors.white : AppColors.textPrimary,
-          fontSize: 13,
-          fontWeight: FontWeight.w700,
-          letterSpacing: 0,
+    final foreground = selected
+        ? AppColors.accentDark
+        : AppColors.textSecondary;
+    return FilterChip(
+      key: ValueKey('comparison-metadata-${field.name}'),
+      avatar: Icon(_metadataFieldIcon(field), size: 16, color: foreground),
+      label: SizedBox(
+        width: double.infinity,
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerLeft,
+          child: Text(
+            field.label,
+            style: TextStyle(
+              color: foreground,
+              fontSize: 12,
+              fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+              letterSpacing: 0,
+            ),
+          ),
         ),
       ),
       selected: selected,
-      selectedColor: AppColors.accent,
-      backgroundColor: AppColors.surfaceMuted,
+      showCheckmark: false,
+      selectedColor: AppColors.accent.withValues(alpha: 0.08),
+      backgroundColor: AppColors.surface,
       side: BorderSide(color: selected ? AppColors.accent : AppColors.border),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      visualDensity: VisualDensity.compact,
       onSelected: (_) => onSelected(),
     );
   }
+}
+
+IconData _metadataFieldIcon(ComparisonMetadataField field) {
+  return switch (field) {
+    ComparisonMetadataField.capturedAt => Icons.access_time_rounded,
+    ComparisonMetadataField.pointName => Icons.place_rounded,
+    ComparisonMetadataField.workTitle => Icons.article_rounded,
+    ComparisonMetadataField.episodeLabel => Icons.landscape_outlined,
+    ComparisonMetadataField.coordinates => Icons.my_location_rounded,
+    ComparisonMetadataField.anitabiId => Icons.badge_outlined,
+  };
+}
+
+InputDecoration _comparisonTextFieldDecoration({
+  required String hintText,
+  required bool enabled,
+}) {
+  return InputDecoration(
+    hintText: hintText,
+    hintStyle: TextStyle(
+      color: AppColors.textSecondary.withValues(alpha: 0.42),
+      fontSize: 14,
+      letterSpacing: 0,
+    ),
+    filled: true,
+    fillColor: enabled ? AppColors.surface : AppColors.surfaceMuted,
+    contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
+    enabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: const BorderSide(color: AppColors.border),
+    ),
+    disabledBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: BorderSide(color: AppColors.border.withValues(alpha: 0.65)),
+    ),
+    focusedBorder: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(8),
+      borderSide: BorderSide(color: AppColors.accent, width: 1.4),
+    ),
+  );
 }
 
 class _ColorOption extends StatelessWidget {
@@ -322,57 +654,79 @@ class _ColorOption extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      borderRadius: BorderRadius.circular(18),
+      borderRadius: BorderRadius.circular(8),
       onTap: onTap,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Container(
-            width: 36,
-            height: 36,
-            decoration: BoxDecoration(
-              color: color,
-              shape: BoxShape.circle,
-              border: Border.all(
-                color: selected
-                    ? (color == AppColors.accent
-                          ? AppColors.textPrimary
-                          : AppColors.accent)
-                    : color == Colors.white
-                    ? AppColors.border
-                    : Colors.transparent,
-                width: selected ? 3 : 1,
+      child: AnimatedScale(
+        scale: selected ? 1.03 : 1,
+        duration: const Duration(milliseconds: 160),
+        curve: Curves.easeOutBack,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          curve: Curves.easeOut,
+          constraints: const BoxConstraints(minWidth: 76, minHeight: 40),
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          decoration: BoxDecoration(
+            color: selected
+                ? AppColors.accent.withValues(alpha: 0.08)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: selected ? AppColors.accent : AppColors.border,
+              width: selected ? 1.4 : 1,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 20,
+                height: 20,
+                decoration: BoxDecoration(
+                  color: color,
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: color == Colors.white
+                        ? AppColors.border
+                        : Colors.transparent,
+                  ),
+                ),
+                child: AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 140),
+                  transitionBuilder: (child, animation) => ScaleTransition(
+                    scale: animation,
+                    child: FadeTransition(opacity: animation, child: child),
+                  ),
+                  child: selected
+                      ? Icon(
+                          Icons.check,
+                          key: const ValueKey('selected'),
+                          size: 14,
+                          color: color.computeLuminance() > 0.55
+                              ? AppColors.textPrimary
+                              : Colors.white,
+                        )
+                      : const SizedBox(
+                          key: ValueKey('unselected'),
+                          width: 14,
+                          height: 14,
+                        ),
+                ),
               ),
-              boxShadow: selected
-                  ? const [
-                      BoxShadow(
-                        color: Color(0x33000000),
-                        blurRadius: 4,
-                        offset: Offset(0, 1),
-                      ),
-                    ]
-                  : null,
-            ),
-            child: selected
-                ? Icon(
-                    Icons.check,
-                    size: 18,
-                    color: color.computeLuminance() > 0.55
-                        ? AppColors.textPrimary
-                        : Colors.white,
-                  )
-                : null,
+              const SizedBox(width: 7),
+              Text(
+                label,
+                style: TextStyle(
+                  color: selected
+                      ? AppColors.accentDark
+                      : AppColors.textPrimary,
+                  fontSize: 13,
+                  fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
           ),
-          const SizedBox(width: 4),
-          Text(
-            label,
-            style: const TextStyle(
-              fontSize: 12,
-              color: AppColors.textSecondary,
-              letterSpacing: 0,
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }
@@ -388,10 +742,23 @@ class _SectionLabel extends StatelessWidget {
     return Text(
       label,
       style: const TextStyle(
-        fontSize: 16,
-        fontWeight: FontWeight.w800,
+        fontSize: 18,
+        fontWeight: FontWeight.w900,
         letterSpacing: 0,
       ),
+    );
+  }
+}
+
+class _SectionDivider extends StatelessWidget {
+  const _SectionDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Divider(
+      height: 1,
+      thickness: 1,
+      color: AppColors.surfaceMuted,
     );
   }
 }
@@ -406,8 +773,8 @@ class _FieldLabel extends StatelessWidget {
     return Text(
       label,
       style: const TextStyle(
-        color: AppColors.textSecondary,
-        fontSize: 13,
+        color: AppColors.textPrimary,
+        fontSize: 14,
         fontWeight: FontWeight.w700,
         letterSpacing: 0,
       ),

--- a/lib/records/point_visit_records_screen.dart
+++ b/lib/records/point_visit_records_screen.dart
@@ -21,34 +21,48 @@ class PointVisitRecordsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: controller,
-      builder: (context, _) {
-        final resolvedPoint = controller.pointById(point.id) ?? point;
-        final records = controller.recordsForPoint(point.id);
+    return MediaQuery(
+      data: MediaQuery.of(
+        context,
+      ).copyWith(textScaler: appTextScaler(settings.fontScale)),
+      child: AppUiScaleView(
+        scale: settings.uiScale,
+        child: AnimatedBuilder(
+          animation: controller,
+          builder: (context, _) {
+            final resolvedPoint = controller.pointById(point.id) ?? point;
+            final records = controller.recordsForPoint(point.id);
 
-        return Scaffold(
-          appBar: AppBar(title: const Text('点位拍摄记录')),
-          body: ListView(
-            padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
-            children: [
-              _PointRecordsHeader(point: resolvedPoint, count: records.length),
-              const SizedBox(height: 16),
-              if (records.isEmpty)
-                const _EmptyPointRecords()
-              else
-                for (final record in records) ...[
-                  _PointVisitRecordCard(
-                    record: record,
-                    onTap: () =>
-                        _openRecordDetail(context, record, resolvedPoint),
+            return Scaffold(
+              appBar: AppBar(title: const Text('点位拍摄记录')),
+              body: ListView(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                children: [
+                  _PointRecordsHeader(
+                    point: resolvedPoint,
+                    count: records.length,
                   ),
-                  const SizedBox(height: 10),
+                  const SizedBox(height: 16),
+                  if (records.isEmpty)
+                    const _EmptyPointRecords()
+                  else ...[
+                    const _PointRecordsListLabel(),
+                    const SizedBox(height: 8),
+                    for (final record in records) ...[
+                      _PointVisitRecordCard(
+                        record: record,
+                        onTap: () =>
+                            _openRecordDetail(context, record, resolvedPoint),
+                      ),
+                      const SizedBox(height: 10),
+                    ],
+                  ],
                 ],
-            ],
-          ),
-        );
-      },
+              ),
+            );
+          },
+        ),
+      ),
     );
   }
 
@@ -130,14 +144,31 @@ class _PointRecordsHeader extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 12),
-          Text(
-            '$count 条',
-            style: TextStyle(
-              color: AppColors.accentDark,
-              fontSize: 15,
-              fontWeight: FontWeight.w800,
-              letterSpacing: 0,
-            ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text(
+                '$count',
+                style: TextStyle(
+                  color: AppColors.accentDark,
+                  fontSize: 26,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                ),
+              ),
+              const SizedBox(width: 2),
+              Text(
+                '条',
+                style: TextStyle(
+                  color: AppColors.accentDark,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -179,6 +210,80 @@ class _EmptyPointRecords extends StatelessWidget {
   }
 }
 
+class _PointRecordsListLabel extends StatelessWidget {
+  const _PointRecordsListLabel();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.zero,
+      child: Row(
+        children: [
+          Icon(Icons.schedule, color: AppColors.accent, size: 15),
+          const SizedBox(width: 6),
+          const Text(
+            '拍摄记录',
+            style: TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 13,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RecordCapturedAt {
+  const _RecordCapturedAt({required this.date, required this.time});
+
+  final String date;
+  final String time;
+}
+
+class _RecordCapturedAtText extends StatelessWidget {
+  const _RecordCapturedAtText({required this.capturedAt});
+
+  final DateTime capturedAt;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = _formatCapturedAt(capturedAt);
+    return SizedBox(
+      width: 82,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            value.time,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 22,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value.date,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _PointVisitRecordCard extends StatelessWidget {
   const _PointVisitRecordCard({required this.record, required this.onTap});
 
@@ -197,54 +302,47 @@ class _PointVisitRecordCard extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
-        child: Row(
-          children: [
-            SizedBox(
-              width: 104,
-              height: 104,
-              child: VisitRecordPhoto(path: photoPath),
-            ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      _formatCapturedAt(record.capturedAt),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Wrap(
-                      spacing: 6,
-                      runSpacing: 6,
-                      children: [
-                        _RecordMetaChip(
-                          icon: Icons.layers_outlined,
-                          label: record.referenceMode,
-                        ),
-                        if (record.hasColorGrading)
-                          const _RecordMetaChip(
-                            icon: Icons.auto_fix_high_outlined,
-                            label: '已调色',
+        child: IntrinsicHeight(
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              SizedBox(width: 104, child: VisitRecordPhoto(path: photoPath)),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _RecordCapturedAtText(capturedAt: record.capturedAt),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
+                        children: [
+                          _RecordMetaChip(
+                            icon: Icons.layers_outlined,
+                            label: record.referenceMode,
                           ),
-                      ],
-                    ),
-                  ],
+                          if (record.hasColorGrading)
+                            const _RecordMetaChip(
+                              icon: Icons.auto_fix_high_outlined,
+                              label: '已调色',
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            const Padding(
-              padding: EdgeInsets.only(right: 10),
-              child: Icon(Icons.chevron_right, color: AppColors.textSecondary),
-            ),
-          ],
+              const Padding(
+                padding: EdgeInsets.only(right: 10),
+                child: Icon(
+                  Icons.chevron_right,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -260,13 +358,15 @@ class _RecordMetaChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+      height: 28,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
       decoration: BoxDecoration(
         color: AppColors.surfaceMuted,
         borderRadius: BorderRadius.circular(6),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Icon(icon, size: 14, color: AppColors.textSecondary),
           const SizedBox(width: 4),
@@ -276,6 +376,7 @@ class _RecordMetaChip extends StatelessWidget {
               color: AppColors.textSecondary,
               fontSize: 12,
               fontWeight: FontWeight.w700,
+              height: 1,
               letterSpacing: 0,
             ),
           ),
@@ -285,8 +386,10 @@ class _RecordMetaChip extends StatelessWidget {
   }
 }
 
-String _formatCapturedAt(DateTime value) {
+_RecordCapturedAt _formatCapturedAt(DateTime value) {
   String twoDigits(int number) => number.toString().padLeft(2, '0');
-  return '${value.year}-${twoDigits(value.month)}-${twoDigits(value.day)} '
-      '${twoDigits(value.hour)}:${twoDigits(value.minute)}';
+  return _RecordCapturedAt(
+    date: '${value.year}-${twoDigits(value.month)}-${twoDigits(value.day)}',
+    time: '${twoDigits(value.hour)}:${twoDigits(value.minute)}',
+  );
 }

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -963,10 +963,6 @@ class _VisitRecordCard extends StatelessWidget {
                       runSpacing: 6,
                       children: [
                         _RecordChip(
-                          icon: Icons.grid_view_outlined,
-                          label: groupName,
-                        ),
-                        _RecordChip(
                           icon: Icons.schedule,
                           label: _formatCapturedAt(record.capturedAt),
                         ),

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -796,6 +796,7 @@ class _CameraSettingsPageState extends State<_CameraSettingsPage> {
       children: [
         _SettingsSection(
           title: '\u62cd\u6444\u56fe\u7247\u6bd4\u4f8b',
+          titleSpacing: 6,
           children: [
             const Text(
               '\u81ea\u52a8\u4f1a\u4f18\u5148\u8ddf\u968f\u53c2\u8003\u56fe\u6bd4\u4f8b\uff1b\u9009\u62e9\u56fa\u5b9a\u6bd4\u4f8b\u540e\u4f1a\u6309\u8be5\u6bd4\u4f8b\u62cd\u6444\u3002',
@@ -830,6 +831,7 @@ class _CameraSettingsPageState extends State<_CameraSettingsPage> {
         const SizedBox(height: 12),
         _SettingsSection(
           title: '\u65e0\u53c2\u8003\u56fe\u65f6\u6bd4\u4f8b',
+          titleSpacing: 6,
           children: [
             const Text(
               '\u62cd\u6444\u56fe\u7247\u6bd4\u4f8b\u4e3a\u81ea\u52a8\u3001\u4e14\u6ca1\u6709\u53c2\u8003\u56fe\u53ef\u5bf9\u9f50\u65f6\u4f7f\u7528\u3002',
@@ -1044,17 +1046,13 @@ class _ComparisonStyleSettingsPageState
       fontScale: _settings.fontScale,
       children: [
         _SettingsSection(
-          title: '默认配置',
+          title: '',
+          showTitle: false,
           children: [
-            Text(
-              comparisonExportConfigSummary(_config),
-              style: _secondaryTextStyle,
-            ),
             if (_loading) ...[
-              const SizedBox(height: 12),
               const LinearProgressIndicator(minHeight: 2),
+              const SizedBox(height: 14),
             ],
-            const SizedBox(height: 14),
             ComparisonExportConfigEditor(
               config: _config,
               pilgrimNameController: _pilgrimNameController,
@@ -1545,9 +1543,31 @@ class _AboutSettingsPage extends StatelessWidget {
         const _SettingsSection(
           title: '数据与版权',
           children: [
-            Text(
-              '地图可使用 OpenFreeMap、OpenStreetMap 或自定义服务；作品搜索使用 Bangumi；巡礼点位与参考图来自 Anitabi。图片源设置只影响访问域名，远端链接会统一保留 Anitabi 默认格式。第三方数据、截图和图片版权归原平台、贡献者或权利方所有。',
-              style: _secondaryParagraphTextStyle,
+            _AboutDataItem(
+              icon: Icons.map_outlined,
+              label: '地图',
+              description: '可使用 OpenFreeMap、OpenStreetMap 或自定义地图服务。',
+            ),
+            _AboutDataItem(
+              icon: Icons.search_outlined,
+              label: '作品',
+              description: '作品搜索数据来自 Bangumi。',
+            ),
+            _AboutDataItem(
+              icon: Icons.place_outlined,
+              label: '巡礼内容',
+              description: '巡礼点位与参考图来自 Anitabi。',
+            ),
+            _AboutDataItem(
+              icon: Icons.image_outlined,
+              label: '图片源',
+              description: '图片源设置只影响访问域名，远端链接统一保留 Anitabi 默认格式。',
+            ),
+            _AboutDataItem(
+              icon: Icons.copyright_outlined,
+              label: '版权归属',
+              description: '第三方数据、截图和图片版权归原平台、贡献者或权利方所有。',
+              bottomSpacing: 0,
             ),
           ],
         ),
@@ -1841,10 +1861,17 @@ class _SummarySwitchTile extends StatelessWidget {
 }
 
 class _SettingsSection extends StatelessWidget {
-  const _SettingsSection({required this.title, required this.children});
+  const _SettingsSection({
+    required this.title,
+    required this.children,
+    this.titleSpacing = 12,
+    this.showTitle = true,
+  });
 
   final String title;
   final List<Widget> children;
+  final double titleSpacing;
+  final bool showTitle;
 
   @override
   Widget build(BuildContext context) {
@@ -1858,16 +1885,18 @@ class _SettingsSection extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            title,
-            style: const TextStyle(
-              color: AppColors.textPrimary,
-              fontSize: 15,
-              fontWeight: FontWeight.w900,
-              letterSpacing: 0,
+          if (showTitle) ...[
+            Text(
+              title,
+              style: const TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 15,
+                fontWeight: FontWeight.w900,
+                letterSpacing: 0,
+              ),
             ),
-          ),
-          const SizedBox(height: 12),
+            SizedBox(height: titleSpacing),
+          ],
           ...children,
         ],
       ),
@@ -3484,6 +3513,44 @@ class _AboutInfoTile extends StatelessWidget {
                   copyLabel: value,
                   style: const TextStyle(fontSize: 14, letterSpacing: 0),
                 ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AboutDataItem extends StatelessWidget {
+  const _AboutDataItem({
+    required this.icon,
+    required this.label,
+    required this.description,
+    this.bottomSpacing = 12,
+  });
+
+  final IconData icon;
+  final String label;
+  final String description;
+  final double bottomSpacing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottomSpacing),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: AppColors.textSecondary, size: 20),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: _captionTextStyle),
+                const SizedBox(height: 2),
+                Text(description, style: _secondaryParagraphTextStyle),
               ],
             ),
           ),

--- a/lib/widgets/app_scaled_route.dart
+++ b/lib/widgets/app_scaled_route.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+
+import '../app_theme.dart';
+import '../data/anitabi_image_source_scope.dart';
+import '../plan/pilgrimage_models.dart';
+
+MaterialPageRoute<T> appScaledMaterialPageRoute<T>({
+  required AppSettings settings,
+  required WidgetBuilder builder,
+}) {
+  return MaterialPageRoute<T>(
+    builder: (context) => _AppScaledRouteView(
+      settings: settings,
+      child: Builder(builder: builder),
+    ),
+  );
+}
+
+double appScaledOverlayExtent(AppSettings settings, double extent) {
+  return extent * appUiScaler(settings.uiScale);
+}
+
+class AppScaledOverlayContent extends StatelessWidget {
+  const AppScaledOverlayContent({
+    required this.settings,
+    required this.child,
+    super.key,
+  });
+
+  final AppSettings settings;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final uiScale = appUiScaler(settings.uiScale);
+    return MediaQuery(
+      data: MediaQuery.of(
+        context,
+      ).copyWith(textScaler: appTextScaler(settings.fontScale)),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final expandedWidth = constraints.hasBoundedWidth
+              ? constraints.maxWidth / uiScale
+              : null;
+          final expandedHeight = constraints.hasBoundedHeight
+              ? constraints.maxHeight / uiScale
+              : null;
+          return OverflowBox(
+            alignment: Alignment.centerLeft,
+            minWidth: expandedWidth,
+            maxWidth: expandedWidth,
+            minHeight: expandedHeight,
+            maxHeight: expandedHeight,
+            child: Transform.scale(
+              scale: uiScale,
+              alignment: Alignment.centerLeft,
+              child: SizedBox(
+                width: expandedWidth,
+                height: expandedHeight,
+                child: child,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AppScaledRouteView extends StatelessWidget {
+  const _AppScaledRouteView({required this.settings, required this.child});
+
+  final AppSettings settings;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    AppColors.palette = settings.themePalette;
+    AppColors.customAccentValue = settings.customThemeColorValue;
+
+    return MediaQuery(
+      data: MediaQuery.of(
+        context,
+      ).copyWith(textScaler: appTextScaler(settings.fontScale)),
+      child: AnitabiImageSourceScope(
+        source: settings.anitabiImageSource,
+        child: AppUiScaleView(
+          scale: settings.uiScale,
+          child: Theme(
+            data: AppTheme.light(
+              palette: settings.themePalette,
+              customAccentValue: settings.customThemeColorValue,
+            ),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/copyable_text.dart
+++ b/lib/widgets/copyable_text.dart
@@ -14,6 +14,7 @@ class CopyableText extends StatefulWidget {
     this.style,
     this.maxLines,
     this.overflow,
+    this.onTap,
     super.key,
   });
 
@@ -23,6 +24,7 @@ class CopyableText extends StatefulWidget {
   final TextStyle? style;
   final int? maxLines;
   final TextOverflow? overflow;
+  final VoidCallback? onTap;
 
   @override
   State<CopyableText> createState() => _CopyableTextState();
@@ -40,6 +42,7 @@ class _CopyableTextState extends State<CopyableText> {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTapDown: (_) => hideActiveCopyOverlay(),
+      onTap: widget.onTap,
       onLongPress: _showCopyOverlay,
       child: Text(
         widget.text,

--- a/test/app_scaled_route_test.dart
+++ b/test/app_scaled_route_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:miriago/app_theme.dart';
+import 'package:miriago/plan/pilgrimage_models.dart';
+import 'package:miriago/widgets/app_scaled_route.dart';
+
+void main() {
+  testWidgets('scaled route applies app UI, font, and theme settings', (
+    tester,
+  ) async {
+    const settings = AppSettings(
+      uiScale: 0.8,
+      fontScale: 1.2,
+      themePalette: AppThemePalette.deepBlue,
+    );
+    late double scaledFontSize;
+    late Color primaryColor;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        onGenerateRoute: (_) => appScaledMaterialPageRoute<void>(
+          settings: settings,
+          builder: (context) {
+            scaledFontSize = MediaQuery.textScalerOf(context).scale(16);
+            primaryColor = Theme.of(context).colorScheme.primary;
+            return const Scaffold(body: Text('缩放页面'));
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final scaleView = tester.widget<AppUiScaleView>(
+      find.byType(AppUiScaleView),
+    );
+    expect(scaleView.scale, settings.uiScale);
+    expect(scaledFontSize, greaterThan(16));
+    expect(primaryColor, AppColors.deepBlue);
+  });
+
+  testWidgets('scaled overlay content matches page UI and font scale', (
+    tester,
+  ) async {
+    const settings = AppSettings(uiScale: 0.8, fontScale: 1.2);
+    const overlayWidth = 240.0;
+    const baseHeight = 48.0;
+    const contentKey = ValueKey('overlay-content');
+    late double scaledFontSize;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: overlayWidth,
+            height: appScaledOverlayExtent(settings, baseHeight),
+            child: AppScaledOverlayContent(
+              settings: settings,
+              child: Builder(
+                builder: (context) {
+                  scaledFontSize = MediaQuery.textScalerOf(context).scale(16);
+                  return const SizedBox.expand(key: contentKey);
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final effectiveUiScale = appUiScaler(settings.uiScale);
+    final contentSize = tester.getSize(find.byKey(contentKey));
+    expect(contentSize.width, closeTo(overlayWidth / effectiveUiScale, 0.01));
+    expect(contentSize.height, closeTo(baseHeight, 0.01));
+    expect(scaledFontSize, greaterThan(16));
+  });
+}

--- a/test/comparison_export_config_test.dart
+++ b/test/comparison_export_config_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:miriago/app_theme.dart';
 import 'package:miriago/plan/pilgrimage_models.dart';
 import 'package:miriago/records/comparison_export_config.dart';
 import 'package:miriago/records/comparison_export_config_editor.dart';
@@ -58,5 +59,99 @@ void main() {
     );
 
     expect(comparisonExportConfigSummary(config), '宽度 1920px / 边框 1.0% / 显示标签');
+  });
+
+  testWidgets('comparison editor exposes the redesigned interactions', (
+    tester,
+  ) async {
+    var config = const ComparisonExportConfig();
+    final pilgrimNameController = TextEditingController();
+    addTearDown(pilgrimNameController.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: StatefulBuilder(
+              builder: (context, setState) {
+                return ComparisonExportConfigEditor(
+                  config: config,
+                  pilgrimNameController: pilgrimNameController,
+                  onChanged: (updated) {
+                    setState(() => config = updated);
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('自动宽度'), findsOneWidget);
+    expect(find.text('1080px'), findsNothing);
+    expect(
+      tester
+          .widget<TextFormField>(
+            find.byKey(const ValueKey('comparison-pilgrim-name')),
+          )
+          .enabled,
+      isFalse,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('comparison-output-auto')));
+    await tester.pumpAndSettle();
+    expect(config.outputWidth, ComparisonOutputWidth.w1920);
+    expect(find.text('1080px'), findsOneWidget);
+    expect(find.text('自定义'), findsNothing);
+    expect(find.text('外观'), findsOneWidget);
+    expect(find.text('元数据'), findsOneWidget);
+    expect(find.text('显示内容'), findsOneWidget);
+    expect(find.text('巡礼者信息'), findsNothing);
+    expect(find.text('调色参数'), findsNothing);
+
+    final pilgrimSwitch = find.byKey(
+      const ValueKey('comparison-show-pilgrim-name'),
+    );
+    await tester.ensureVisible(pilgrimSwitch);
+    await tester.pumpAndSettle();
+    await tester.tap(pilgrimSwitch);
+    await tester.pumpAndSettle();
+    expect(config.showPilgrimName, isTrue);
+    expect(
+      tester
+          .widget<TextFormField>(
+            find.byKey(const ValueKey('comparison-pilgrim-name')),
+          )
+          .enabled,
+      isTrue,
+    );
+
+    final episodeChip = find.byKey(
+      const ValueKey('comparison-metadata-episodeLabel'),
+    );
+    await tester.ensureVisible(episodeChip);
+    await tester.pumpAndSettle();
+    final firstRowTops = ['capturedAt', 'pointName', 'workTitle'].map(
+      (name) => tester
+          .getTopLeft(find.byKey(ValueKey('comparison-metadata-$name')))
+          .dy,
+    );
+    expect(firstRowTops.toSet(), hasLength(1));
+    expect(
+      tester
+          .getTopLeft(
+            find.byKey(const ValueKey('comparison-metadata-episodeLabel')),
+          )
+          .dy,
+      greaterThan(firstRowTops.first),
+    );
+    await tester.tap(episodeChip);
+    await tester.pumpAndSettle();
+    expect(
+      config.metadataFields.contains(ComparisonMetadataField.episodeLabel),
+      isTrue,
+    );
   });
 }

--- a/test/pilgrimage_work_dropdown_test.dart
+++ b/test/pilgrimage_work_dropdown_test.dart
@@ -1,0 +1,129 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:miriago/plan/pilgrimage_models.dart';
+import 'package:miriago/plan/pilgrimage_work_dropdown.dart';
+
+void main() {
+  const works = [
+    PilgrimageWork(
+      id: 'work-1',
+      title: 'Sound! Euphonium',
+      subtitle: '',
+      city: '',
+      source: WorkSource.bangumi,
+      bangumiSubjectType: BangumiSubjectType.anime,
+    ),
+    PilgrimageWork(
+      id: 'work-2',
+      title: 'BanG Dream!',
+      subtitle: '',
+      city: '',
+      source: WorkSource.bangumi,
+      bangumiSubjectType: BangumiSubjectType.anime,
+    ),
+  ];
+
+  Future<void> pumpDropdown(
+    WidgetTester tester, {
+    List<PilgrimageWork> options = works,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 360,
+              child: PilgrimageWorkDropdown(
+                works: options,
+                value: options.first,
+                onChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(DropdownButtonFormField<PilgrimageWork>));
+    await tester.pumpAndSettle();
+  }
+
+  Future<TestGesture> hoverTitle(WidgetTester tester, Finder title) async {
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(title));
+    await tester.pump();
+    return mouse;
+  }
+
+  testWidgets('unselected menu item content slides right while hovered', (
+    tester,
+  ) async {
+    await pumpDropdown(tester);
+
+    final title = find.text('BanG Dream!');
+    final startX = tester.getTopLeft(title).dx;
+    final mouse = await hoverTitle(tester, title);
+
+    await tester.pump(const Duration(milliseconds: 80));
+    final middleX = tester.getTopLeft(title).dx;
+    expect(middleX, greaterThan(startX));
+    expect(middleX, lessThan(startX + 12));
+
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(title).dx, closeTo(startX + 12, 0.01));
+
+    await mouse.moveTo(Offset.zero);
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(title).dx, closeTo(startX, 0.01));
+  });
+
+  testWidgets('selected menu item stays still while hovered', (tester) async {
+    await pumpDropdown(tester);
+
+    final title = find.text('Sound! Euphonium').last;
+    final startX = tester.getTopLeft(title).dx;
+    final mouse = await hoverTitle(tester, title);
+
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(title).dx, closeTo(startX, 0.01));
+
+    await mouse.moveTo(Offset.zero);
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(title).dx, closeTo(startX, 0.01));
+  });
+
+  testWidgets('long menu keeps selected content clear of the scrollbar', (
+    tester,
+  ) async {
+    final manyWorks = List.generate(
+      12,
+      (index) => PilgrimageWork(
+        id: 'work-$index',
+        title: 'Work $index',
+        subtitle: '',
+        city: '',
+        source: WorkSource.bangumi,
+        bangumiSubjectType: BangumiSubjectType.anime,
+      ),
+    );
+
+    await pumpDropdown(tester, options: manyWorks);
+
+    expect(find.byType(Scrollbar), findsOneWidget);
+    final scrollbarRect = tester.getRect(find.byType(Scrollbar));
+    final selectedIconRect = tester.getRect(find.byIcon(Icons.check_circle));
+    expect(selectedIconRect.right, lessThanOrEqualTo(scrollbarRect.right - 10));
+
+    final backgrounds = find.byType(AnimatedContainer);
+    expect(backgrounds, findsWidgets);
+    for (final element in backgrounds.evaluate()) {
+      final backgroundRect = tester.getRect(
+        find.byElementPredicate((candidate) => identical(candidate, element)),
+      );
+      expect(backgroundRect.right, lessThanOrEqualTo(scrollbarRect.right - 6));
+    }
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -131,7 +131,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('计划备忘录'), findsOneWidget);
-    expect(find.text('还没有写计划备忘'), findsOneWidget);
+    expect(find.text('还没有计划备忘'), findsOneWidget);
+    expect(find.text('开始记录'), findsOneWidget);
 
     await tester.tap(find.byTooltip('编辑'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## 修改概要

### 原有 PR 内容

- 重构“添加内容”页面，优化已关联作品、快速导入、作品添加与点位添加入口。
- 优化 Bangumi 搜索结果、作品类型筛选、作品管理卡片和手动作品表单。
- 优化 Anitabi 链接导入、作品下拉框、空状态及相关交互反馈。

### 本次补充提交（22a2a3e）

- 将“关于”页的数据与版权说明拆分为结构化列表，并收紧拍摄比例标题与注释的间距。
- 重构两个入口共用的对比图配置编辑器：更新分区、边框宽度滑块、颜色动画、自动宽度开关、巡礼者输入状态和三列元数据 FilterChip。
- 保持边框默认白色，补充“参考/巡礼”标签说明，并保留现有对比图配置和渲染数据结构。
- 新增统一缩放路由，使“添加内容”及作品管理、Bangumi 搜索、Anitabi 导入、手动点位、坐标选择和分组页面继承 UI、字体、主题与图片源设置。
- 修复两种下拉菜单 Overlay 的文字、badge、选中图标和背景缩放及垂直居中；恢复原生菜单宽度，并收窄悬停/选中背景高度。
- 新增缩放路由、Overlay 布局和对比图设置交互测试。

## 待对接数据功能
- 接入 Bangumi 作品封面数据并替换当前封面占位框。
- 接入手动添加作品的作品类型储存及后端数据同步。
- 接入从 Anitabi 链接导入的剪贴板粘贴功能。

## 功能与数据影响

- 未修改数据库、Repository、Tauri 后端、API 客户端或依赖版本。
- 未修改 `AppSettings` 数据结构、对比图配置序列化结构或对比图渲染器。
- 仅调整界面、导航包装和现有配置字段的交互；关闭自动输出宽度时使用现有的 1920px 选项。

## 验证

- 针对性 Dart 静态分析通过。
- `flutter test --no-pub test/app_scaled_route_test.dart test/comparison_export_config_test.dart`：6 项非鼠标测试通过。
- `flutter build web --release --no-pub` 构建成功，Wasm dry run 通过。
- Web 预览与 Anitabi 同源静态数据代理均返回 HTTP 200。
- 按项目约定未进行鼠标测试。

## 依赖关系

- 本 PR 延续原有分支提交，并基于 #5 的前端优化工作。