### PR TITLE
feat: refine plan management and record filtering UI

### DIFF
--- a/lib/data/local/app_database.dart
+++ b/lib/data/local/app_database.dart
@@ -150,6 +150,8 @@ class AppSettingsEntries extends Table {
       integer().withDefault(const Constant(40))();
   IntColumn get mapThumbnailConcurrentLoads =>
       integer().withDefault(const Constant(10))();
+  BoolColumn get showPlanGroupProgress =>
+      boolean().withDefault(const Constant(true))();
   BoolColumn get mapMarkerClusteringEnabled =>
       boolean().withDefault(const Constant(true))();
   IntColumn get mapMarkerClusterRadius =>
@@ -172,7 +174,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 34;
+  int get schemaVersion => 35;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -530,6 +532,15 @@ class AppDatabase extends _$AppDatabase {
           SET map_marker_cluster_max_zoom = 21
           WHERE map_marker_cluster_max_zoom = 18
         ''');
+      }
+      if (from < 35) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'show_plan_group_progress',
+          appSettingsEntries,
+          appSettingsEntries.showPlanGroupProgress,
+        );
       }
     },
   );

--- a/lib/data/local/app_database.g.dart
+++ b/lib/data/local/app_database.g.dart
@@ -4460,6 +4460,21 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         requiredDuringInsert: false,
         defaultValue: const Constant(10),
       );
+  static const VerificationMeta _showPlanGroupProgressMeta =
+      const VerificationMeta('showPlanGroupProgress');
+  @override
+  late final GeneratedColumn<bool> showPlanGroupProgress =
+      GeneratedColumn<bool>(
+        'show_plan_group_progress',
+        aliasedName,
+        false,
+        type: DriftSqlType.bool,
+        requiredDuringInsert: false,
+        defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("show_plan_group_progress" IN (0, 1))',
+        ),
+        defaultValue: const Constant(true),
+      );
   static const VerificationMeta _mapMarkerClusteringEnabledMeta =
       const VerificationMeta('mapMarkerClusteringEnabled');
   @override
@@ -4564,6 +4579,7 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
     customCameraAspectRatioHeight,
     mapThumbnailVisibleThreshold,
     mapThumbnailConcurrentLoads,
+    showPlanGroupProgress,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -4822,6 +4838,15 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
       );
     }
+    if (data.containsKey('show_plan_group_progress')) {
+      context.handle(
+        _showPlanGroupProgressMeta,
+        showPlanGroupProgress.isAcceptableOrUnknown(
+          data['show_plan_group_progress']!,
+          _showPlanGroupProgressMeta,
+        ),
+      );
+    }
     if (data.containsKey('map_marker_clustering_enabled')) {
       context.handle(
         _mapMarkerClusteringEnabledMeta,
@@ -4997,6 +5022,10 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         DriftSqlType.int,
         data['${effectivePrefix}map_thumbnail_concurrent_loads'],
       )!,
+      showPlanGroupProgress: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}show_plan_group_progress'],
+      )!,
       mapMarkerClusteringEnabled: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}map_marker_clustering_enabled'],
@@ -5060,6 +5089,7 @@ class AppSettingsEntry extends DataClass
   final double customCameraAspectRatioHeight;
   final int mapThumbnailVisibleThreshold;
   final int mapThumbnailConcurrentLoads;
+  final bool showPlanGroupProgress;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -5095,6 +5125,7 @@ class AppSettingsEntry extends DataClass
     required this.customCameraAspectRatioHeight,
     required this.mapThumbnailVisibleThreshold,
     required this.mapThumbnailConcurrentLoads,
+    required this.showPlanGroupProgress,
     required this.mapMarkerClusteringEnabled,
     required this.mapMarkerClusterRadius,
     required this.mapMarkerClusterMaxZoom,
@@ -5153,6 +5184,7 @@ class AppSettingsEntry extends DataClass
     map['map_thumbnail_concurrent_loads'] = Variable<int>(
       mapThumbnailConcurrentLoads,
     );
+    map['show_plan_group_progress'] = Variable<bool>(showPlanGroupProgress);
     map['map_marker_clustering_enabled'] = Variable<bool>(
       mapMarkerClusteringEnabled,
     );
@@ -5196,6 +5228,7 @@ class AppSettingsEntry extends DataClass
       customCameraAspectRatioHeight: Value(customCameraAspectRatioHeight),
       mapThumbnailVisibleThreshold: Value(mapThumbnailVisibleThreshold),
       mapThumbnailConcurrentLoads: Value(mapThumbnailConcurrentLoads),
+      showPlanGroupProgress: Value(showPlanGroupProgress),
       mapMarkerClusteringEnabled: Value(mapMarkerClusteringEnabled),
       mapMarkerClusterRadius: Value(mapMarkerClusterRadius),
       mapMarkerClusterMaxZoom: Value(mapMarkerClusterMaxZoom),
@@ -5271,6 +5304,9 @@ class AppSettingsEntry extends DataClass
       mapThumbnailConcurrentLoads: serializer.fromJson<int>(
         json['mapThumbnailConcurrentLoads'],
       ),
+      showPlanGroupProgress: serializer.fromJson<bool>(
+        json['showPlanGroupProgress'],
+      ),
       mapMarkerClusteringEnabled: serializer.fromJson<bool>(
         json['mapMarkerClusteringEnabled'],
       ),
@@ -5339,6 +5375,7 @@ class AppSettingsEntry extends DataClass
       'mapThumbnailConcurrentLoads': serializer.toJson<int>(
         mapThumbnailConcurrentLoads,
       ),
+      'showPlanGroupProgress': serializer.toJson<bool>(showPlanGroupProgress),
       'mapMarkerClusteringEnabled': serializer.toJson<bool>(
         mapMarkerClusteringEnabled,
       ),
@@ -5383,6 +5420,7 @@ class AppSettingsEntry extends DataClass
     double? customCameraAspectRatioHeight,
     int? mapThumbnailVisibleThreshold,
     int? mapThumbnailConcurrentLoads,
+    bool? showPlanGroupProgress,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -5428,6 +5466,7 @@ class AppSettingsEntry extends DataClass
         mapThumbnailVisibleThreshold ?? this.mapThumbnailVisibleThreshold,
     mapThumbnailConcurrentLoads:
         mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
+    showPlanGroupProgress: showPlanGroupProgress ?? this.showPlanGroupProgress,
     mapMarkerClusteringEnabled:
         mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
     mapMarkerClusterRadius:
@@ -5517,6 +5556,9 @@ class AppSettingsEntry extends DataClass
       mapThumbnailConcurrentLoads: data.mapThumbnailConcurrentLoads.present
           ? data.mapThumbnailConcurrentLoads.value
           : this.mapThumbnailConcurrentLoads,
+      showPlanGroupProgress: data.showPlanGroupProgress.present
+          ? data.showPlanGroupProgress.value
+          : this.showPlanGroupProgress,
       mapMarkerClusteringEnabled: data.mapMarkerClusteringEnabled.present
           ? data.mapMarkerClusteringEnabled.value
           : this.mapMarkerClusteringEnabled,
@@ -5575,6 +5617,7 @@ class AppSettingsEntry extends DataClass
             'mapThumbnailVisibleThreshold: $mapThumbnailVisibleThreshold, ',
           )
           ..write('mapThumbnailConcurrentLoads: $mapThumbnailConcurrentLoads, ')
+          ..write('showPlanGroupProgress: $showPlanGroupProgress, ')
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -5615,6 +5658,7 @@ class AppSettingsEntry extends DataClass
     customCameraAspectRatioHeight,
     mapThumbnailVisibleThreshold,
     mapThumbnailConcurrentLoads,
+    showPlanGroupProgress,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -5660,6 +5704,7 @@ class AppSettingsEntry extends DataClass
               this.mapThumbnailVisibleThreshold &&
           other.mapThumbnailConcurrentLoads ==
               this.mapThumbnailConcurrentLoads &&
+          other.showPlanGroupProgress == this.showPlanGroupProgress &&
           other.mapMarkerClusteringEnabled == this.mapMarkerClusteringEnabled &&
           other.mapMarkerClusterRadius == this.mapMarkerClusterRadius &&
           other.mapMarkerClusterMaxZoom == this.mapMarkerClusterMaxZoom &&
@@ -5697,6 +5742,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
   final Value<double> customCameraAspectRatioHeight;
   final Value<int> mapThumbnailVisibleThreshold;
   final Value<int> mapThumbnailConcurrentLoads;
+  final Value<bool> showPlanGroupProgress;
   final Value<bool> mapMarkerClusteringEnabled;
   final Value<int> mapMarkerClusterRadius;
   final Value<int> mapMarkerClusterMaxZoom;
@@ -5733,6 +5779,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.customCameraAspectRatioHeight = const Value.absent(),
     this.mapThumbnailVisibleThreshold = const Value.absent(),
     this.mapThumbnailConcurrentLoads = const Value.absent(),
+    this.showPlanGroupProgress = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -5770,6 +5817,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.customCameraAspectRatioHeight = const Value.absent(),
     this.mapThumbnailVisibleThreshold = const Value.absent(),
     this.mapThumbnailConcurrentLoads = const Value.absent(),
+    this.showPlanGroupProgress = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -5807,6 +5855,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Expression<double>? customCameraAspectRatioHeight,
     Expression<int>? mapThumbnailVisibleThreshold,
     Expression<int>? mapThumbnailConcurrentLoads,
+    Expression<bool>? showPlanGroupProgress,
     Expression<bool>? mapMarkerClusteringEnabled,
     Expression<int>? mapMarkerClusterRadius,
     Expression<int>? mapMarkerClusterMaxZoom,
@@ -5860,6 +5909,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         'map_thumbnail_visible_threshold': mapThumbnailVisibleThreshold,
       if (mapThumbnailConcurrentLoads != null)
         'map_thumbnail_concurrent_loads': mapThumbnailConcurrentLoads,
+      if (showPlanGroupProgress != null)
+        'show_plan_group_progress': showPlanGroupProgress,
       if (mapMarkerClusteringEnabled != null)
         'map_marker_clustering_enabled': mapMarkerClusteringEnabled,
       if (mapMarkerClusterRadius != null)
@@ -5903,6 +5954,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Value<double>? customCameraAspectRatioHeight,
     Value<int>? mapThumbnailVisibleThreshold,
     Value<int>? mapThumbnailConcurrentLoads,
+    Value<bool>? showPlanGroupProgress,
     Value<bool>? mapMarkerClusteringEnabled,
     Value<int>? mapMarkerClusterRadius,
     Value<int>? mapMarkerClusterMaxZoom,
@@ -5953,6 +6005,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           mapThumbnailVisibleThreshold ?? this.mapThumbnailVisibleThreshold,
       mapThumbnailConcurrentLoads:
           mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
+      showPlanGroupProgress:
+          showPlanGroupProgress ?? this.showPlanGroupProgress,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:
@@ -6084,6 +6138,11 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         mapThumbnailConcurrentLoads.value,
       );
     }
+    if (showPlanGroupProgress.present) {
+      map['show_plan_group_progress'] = Variable<bool>(
+        showPlanGroupProgress.value,
+      );
+    }
     if (mapMarkerClusteringEnabled.present) {
       map['map_marker_clustering_enabled'] = Variable<bool>(
         mapMarkerClusteringEnabled.value,
@@ -6153,6 +6212,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
             'mapThumbnailVisibleThreshold: $mapThumbnailVisibleThreshold, ',
           )
           ..write('mapThumbnailConcurrentLoads: $mapThumbnailConcurrentLoads, ')
+          ..write('showPlanGroupProgress: $showPlanGroupProgress, ')
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -9054,6 +9114,7 @@ typedef $$AppSettingsEntriesTableCreateCompanionBuilder =
       Value<double> customCameraAspectRatioHeight,
       Value<int> mapThumbnailVisibleThreshold,
       Value<int> mapThumbnailConcurrentLoads,
+      Value<bool> showPlanGroupProgress,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9092,6 +9153,7 @@ typedef $$AppSettingsEntriesTableUpdateCompanionBuilder =
       Value<double> customCameraAspectRatioHeight,
       Value<int> mapThumbnailVisibleThreshold,
       Value<int> mapThumbnailConcurrentLoads,
+      Value<bool> showPlanGroupProgress,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9247,6 +9309,11 @@ class $$AppSettingsEntriesTableFilterComposer
 
   ColumnFilters<int> get mapThumbnailConcurrentLoads => $composableBuilder(
     column: $table.mapThumbnailConcurrentLoads,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get showPlanGroupProgress => $composableBuilder(
+    column: $table.showPlanGroupProgress,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -9432,6 +9499,11 @@ class $$AppSettingsEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get showPlanGroupProgress => $composableBuilder(
+    column: $table.showPlanGroupProgress,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => ColumnOrderings(column),
@@ -9606,6 +9678,11 @@ class $$AppSettingsEntriesTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<bool> get showPlanGroupProgress => $composableBuilder(
+    column: $table.showPlanGroupProgress,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => column,
@@ -9708,6 +9785,7 @@ class $$AppSettingsEntriesTableTableManager
                     const Value.absent(),
                 Value<int> mapThumbnailVisibleThreshold = const Value.absent(),
                 Value<int> mapThumbnailConcurrentLoads = const Value.absent(),
+                Value<bool> showPlanGroupProgress = const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -9744,6 +9822,7 @@ class $$AppSettingsEntriesTableTableManager
                 customCameraAspectRatioHeight: customCameraAspectRatioHeight,
                 mapThumbnailVisibleThreshold: mapThumbnailVisibleThreshold,
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
+                showPlanGroupProgress: showPlanGroupProgress,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,
@@ -9785,6 +9864,7 @@ class $$AppSettingsEntriesTableTableManager
                     const Value.absent(),
                 Value<int> mapThumbnailVisibleThreshold = const Value.absent(),
                 Value<int> mapThumbnailConcurrentLoads = const Value.absent(),
+                Value<bool> showPlanGroupProgress = const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -9821,6 +9901,7 @@ class $$AppSettingsEntriesTableTableManager
                 customCameraAspectRatioHeight: customCameraAspectRatioHeight,
                 mapThumbnailVisibleThreshold: mapThumbnailVisibleThreshold,
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
+                showPlanGroupProgress: showPlanGroupProgress,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,

--- a/lib/data/local/sqlite_pilgrimage_repository.dart
+++ b/lib/data/local/sqlite_pilgrimage_repository.dart
@@ -103,6 +103,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
         200,
       ),
       mapThumbnailConcurrentLoads: row.mapThumbnailConcurrentLoads.clamp(1, 30),
+      showPlanGroupProgress: row.showPlanGroupProgress,
       mapMarkerClusteringEnabled: row.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius: row.mapMarkerClusterRadius.clamp(32, 120),
       mapMarkerClusterMaxZoom: row.mapMarkerClusterMaxZoom.clamp(10, 22),
@@ -1089,6 +1090,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
             mapThumbnailConcurrentLoads: Value(
               settings.mapThumbnailConcurrentLoads.clamp(1, 30),
             ),
+            showPlanGroupProgress: Value(settings.showPlanGroupProgress),
             mapMarkerClusteringEnabled: Value(
               settings.mapMarkerClusteringEnabled,
             ),

--- a/lib/desktop/desktop_repository_state.dart
+++ b/lib/desktop/desktop_repository_state.dart
@@ -94,6 +94,7 @@ Map<String, Object?> _settingsJson(AppSettings settings) {
     'customCameraAspectRatioHeight': settings.customCameraAspectRatioHeight,
     'mapThumbnailVisibleThreshold': settings.mapThumbnailVisibleThreshold,
     'mapThumbnailConcurrentLoads': settings.mapThumbnailConcurrentLoads,
+    'showPlanGroupProgress': settings.showPlanGroupProgress,
     'mapMarkerClusteringEnabled': settings.mapMarkerClusteringEnabled,
     'mapMarkerClusterRadius': settings.mapMarkerClusterRadius,
     'mapMarkerClusterMaxZoom': settings.mapMarkerClusterMaxZoom,
@@ -172,6 +173,7 @@ AppSettings _settingsFromJson(Map<String, Object?> json) {
         _intValue(json['mapThumbnailVisibleThreshold']) ?? 40,
     mapThumbnailConcurrentLoads:
         _intValue(json['mapThumbnailConcurrentLoads']) ?? 10,
+    showPlanGroupProgress: _boolValue(json['showPlanGroupProgress']) ?? true,
     mapMarkerClusteringEnabled:
         _boolValue(json['mapMarkerClusteringEnabled']) ?? true,
     mapMarkerClusterRadius: _intValue(json['mapMarkerClusterRadius']) ?? 40,

--- a/lib/map/pilgrimage_map_screen.dart
+++ b/lib/map/pilgrimage_map_screen.dart
@@ -838,6 +838,7 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
       context: context,
       groups: groups,
       selectedGroupId: groups[_selectedGroupIndex].id,
+      showProgressRing: widget.settings.showPlanGroupProgress,
       onSelectGroup: (selectedGroup) {
         final index = groups.indexWhere(
           (group) => group.id == selectedGroup.id,
@@ -1047,7 +1048,11 @@ class _PointCard extends StatelessWidget {
               onPrevious: onPreviousOverlapPoint!,
               onNext: onNextOverlapPoint!,
             ),
-            const Divider(height: 1),
+            const Divider(
+              key: ValueKey('map-overlap-point-divider'),
+              height: 1,
+              color: AppColors.border,
+            ),
             const SizedBox(height: 6),
           ],
           Row(

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -432,7 +432,24 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
   final Set<String> _addedWorkIds = {};
 
   @override
+  void initState() {
+    super.initState();
+    _queryController.addListener(_handleQueryChanged);
+  }
+
+  void _handleQueryChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void _clearQuery() {
+    _queryController.clear();
+  }
+
+  @override
   void dispose() {
+    _queryController.removeListener(_handleQueryChanged);
     _queryController.dispose();
     super.dispose();
   }
@@ -545,10 +562,31 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
                   prominent: true,
                   child: TextField(
                     controller: _queryController,
-                    decoration: _boxedFormDecoration(
-                      hintText: '例如：轻音少女',
-                      reserveHelperSpace: false,
-                    ),
+                    decoration:
+                        _boxedFormDecoration(
+                          hintText: '例如：轻音少女',
+                          reserveHelperSpace: false,
+                        ).copyWith(
+                          suffixIcon: _queryController.text.isEmpty
+                              ? null
+                              : IconButton(
+                                  key: const ValueKey(
+                                    'bangumi-search-clear-button',
+                                  ),
+                                  tooltip: '清空搜索',
+                                  onPressed: _clearQuery,
+                                  padding: EdgeInsets.zero,
+                                  constraints: const BoxConstraints.tightFor(
+                                    width: 40,
+                                    height: 46,
+                                  ),
+                                  icon: const Icon(Icons.clear, size: 19),
+                                ),
+                          suffixIconConstraints: const BoxConstraints.tightFor(
+                            width: 40,
+                            height: 46,
+                          ),
+                        ),
                     textInputAction: TextInputAction.search,
                     onSubmitted: (_) => _search(),
                   ),
@@ -849,7 +887,25 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
   final _linkController = TextEditingController();
 
   @override
+  void initState() {
+    super.initState();
+    _linkController.addListener(_handleLinkChanged);
+  }
+
+  void _handleLinkChanged() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  void _clearLink() {
+    _linkController.clear();
+    _formKey.currentState?.reset();
+  }
+
+  @override
   void dispose() {
+    _linkController.removeListener(_handleLinkChanged);
     _linkController.dispose();
     super.dispose();
   }
@@ -923,6 +979,7 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final hasLinkText = _linkController.text.isNotEmpty;
     return Scaffold(
       appBar: AppBar(title: const Text('Anitabi 链接导入')),
       body: Form(
@@ -969,17 +1026,27 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
                         letterSpacing: 0,
                       ),
                       helperText: ' ',
-                      suffixIcon: Padding(
-                        padding: EdgeInsets.only(right: 6),
-                        child: IconButton(
-                          onPressed: _pasteLinkFromClipboard,
-                          tooltip: '粘贴',
-                          icon: Icon(Icons.content_paste_outlined, size: 20),
+                      suffixIcon: IconButton(
+                        key: const ValueKey('anitabi-link-input-action'),
+                        onPressed: hasLinkText
+                            ? _clearLink
+                            : _pasteLinkFromClipboard,
+                        tooltip: hasLinkText ? '清除搜索框' : '粘贴',
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints.tightFor(
+                          width: 40,
+                          height: 40,
+                        ),
+                        icon: Icon(
+                          hasLinkText
+                              ? Icons.clear
+                              : Icons.content_paste_outlined,
+                          size: 20,
                         ),
                       ),
-                      suffixIconConstraints: const BoxConstraints(
-                        minWidth: 46,
-                        minHeight: 40,
+                      suffixIconConstraints: const BoxConstraints.tightFor(
+                        width: 40,
+                        height: 40,
                       ),
                       contentPadding: const EdgeInsets.symmetric(
                         horizontal: 14,

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -57,6 +57,13 @@ class AnitabiMapImportScreen extends StatefulWidget {
   State<AnitabiMapImportScreen> createState() => _AnitabiMapImportScreenState();
 }
 
+class _ImportOverlapPointBrowser {
+  _ImportOverlapPointBrowser({required List<String> pointIds})
+    : pointIds = List.unmodifiable(pointIds);
+
+  final List<String> pointIds;
+}
+
 class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
   static const double _fallbackLoadedPointsZoom = 15;
   static const Duration _thumbnailBoundsDebounceDuration = Duration(
@@ -71,6 +78,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
   AnitabiBangumiLite? _lite;
   List<AnitabiPoint> _points = const [];
   AnitabiPoint? _selectedPoint;
+  _ImportOverlapPointBrowser? _overlapPointBrowser;
   Object? _error;
   bool _isLoading = false;
   bool _isImporting = false;
@@ -226,6 +234,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
         _error = null;
         _lite = null;
         _points = const [];
+        _overlapPointBrowser = null;
         _selectedPoint = null;
       });
       _showManualWorkMessage();
@@ -237,6 +246,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       _isLoading = true;
       _error = null;
       _points = const [];
+      _overlapPointBrowser = null;
       _selectedPoint = null;
     });
 
@@ -256,6 +266,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       setState(() {
         _lite = lite;
         _points = points;
+        _overlapPointBrowser = null;
         _selectedPoint = _initialSelectedPointForLoadedPoints(points, lite);
       });
       _requestMapMove(
@@ -328,6 +339,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       _isLoading = true;
       _error = null;
       _points = const [];
+      _overlapPointBrowser = null;
       _selectedPoint = null;
     });
 
@@ -350,6 +362,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
         _selectedWork = work;
         _lite = lite;
         _points = points;
+        _overlapPointBrowser = null;
         _selectedPoint = _initialSelectedPointForLoadedPoints(points, lite);
       });
       _requestMapMove(
@@ -379,6 +392,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       _isLoading = true;
       _error = null;
       _points = const [];
+      _overlapPointBrowser = null;
       _selectedPoint = null;
     });
 
@@ -403,6 +417,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
         _selectedWork = work;
         _lite = lite;
         _points = result.points;
+        _overlapPointBrowser = null;
         _selectedPoint = result.point;
       });
       _requestMapMove(result.point.position, math.max(lite.zoom, 15));
@@ -519,7 +534,11 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     return plan.works.firstOrNull;
   }
 
-  void _selectPoint(AnitabiPoint point) {
+  void _selectPoint(
+    AnitabiPoint point, {
+    bool preserveOverlapBrowser = false,
+    _ImportOverlapPointBrowser? overlapPointBrowser,
+  }) {
     if (_isImporting) {
       return;
     }
@@ -531,8 +550,66 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     messenger.removeCurrentSnackBar();
     messenger.clearSnackBars();
     setState(() {
+      if (overlapPointBrowser != null) {
+        _overlapPointBrowser = overlapPointBrowser;
+      } else if (!preserveOverlapBrowser) {
+        _overlapPointBrowser = null;
+      }
       _selectedPoint = point;
     });
+  }
+
+  void _openOverlapPointBrowser(
+    List<AnitabiPoint> points,
+    List<AnitabiPoint> visiblePoints,
+  ) {
+    if (_isImporting) {
+      return;
+    }
+    final orderedPoints = orderMapClusterItems<AnitabiPoint>(
+      items: points,
+      planOrder: visiblePoints,
+      idOf: (point) => point.id,
+    );
+    if (orderedPoints.isEmpty) {
+      return;
+    }
+    if (orderedPoints.length == 1) {
+      _selectPoint(orderedPoints.single);
+      return;
+    }
+    _selectPoint(
+      orderedPoints.first,
+      overlapPointBrowser: _ImportOverlapPointBrowser(
+        pointIds: orderedPoints.map((point) => point.id).toList(),
+      ),
+    );
+  }
+
+  void _moveOverlapPoint(int offset) {
+    final browser = _overlapPointBrowser;
+    if (browser == null || browser.pointIds.length < 2) {
+      return;
+    }
+    final pointsById = {
+      for (final point in _pointsForWork(_selectedWork)) point.id: point,
+    };
+    final points = [
+      for (final pointId in browser.pointIds) ?pointsById[pointId],
+    ];
+    if (points.length < 2) {
+      setState(() => _overlapPointBrowser = null);
+      return;
+    }
+    final selectedIndex = points.indexWhere(
+      (point) => point.id == _selectedPoint?.id,
+    );
+    final nextIndex = nextMapOverlapIndex(
+      currentIndex: selectedIndex < 0 ? 0 : selectedIndex,
+      offset: offset,
+      total: points.length,
+    );
+    _selectPoint(points[nextIndex], preserveOverlapBrowser: true);
   }
 
   PilgrimagePoint? _importedPointFor(AnitabiPoint point) {
@@ -1082,6 +1159,9 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
   }
 
   void _handleMapEvent(MapEvent event) {
+    if (_overlapPointBrowser != null && !isAtMaximumMapZoom(event.camera)) {
+      setState(() => _overlapPointBrowser = null);
+    }
     if (!_showThumbnailMarkers) {
       return;
     }
@@ -1236,6 +1316,16 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       visiblePoints,
       isSelected: (point) => point.id == selectedPoint?.id,
     );
+    final pointsById = {for (final point in visiblePoints) point.id: point};
+    final overlapPoints = [
+      for (final pointId in _overlapPointBrowser?.pointIds ?? const <String>[])
+        ?pointsById[pointId],
+    ];
+    final overlapPointIndex = overlapPoints.indexWhere(
+      (point) => point.id == selectedPoint?.id,
+    );
+    final hasActiveOverlapBrowser =
+        overlapPoints.length > 1 && overlapPointIndex >= 0;
 
     return PopScope(
       canPop: !_isImporting,
@@ -1360,28 +1450,74 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                                   visiblePoints,
                                   visibleBounds,
                                 );
-                            final clusteringEnabled =
+                            final atMaximumZoom = isAtMaximumMapZoom(camera);
+                            final normalClusteringEnabled =
                                 _settings.mapMarkerClusteringEnabled &&
                                 camera.zoom <=
                                     _settings.mapMarkerClusterMaxZoom;
+                            final overlapClusteringEnabled =
+                                _settings.mapMarkerClusteringEnabled &&
+                                camera.zoom > _settings.mapMarkerClusterMaxZoom;
+                            final clusteringEnabled =
+                                normalClusteringEnabled ||
+                                overlapClusteringEnabled;
+                            final activeOverlapPointIds =
+                                hasActiveOverlapBrowser && atMaximumZoom
+                                ? overlapPoints.map((point) => point.id).toSet()
+                                : const <String>{};
+                            final clusterItems = activeOverlapPointIds.isEmpty
+                                ? mapPoints
+                                : mapPoints
+                                      .where(
+                                        (point) => !activeOverlapPointIds
+                                            .contains(point.id),
+                                      )
+                                      .toList(growable: false);
+                            final terminalRadiusLimit =
+                                scaledMapMarkerDimension(
+                                  _showThumbnailMarkers ? 52 : 44,
+                                  _settings.mapMarkerScale,
+                                );
+                            final clusterRadius = normalClusteringEnabled
+                                ? _settings.mapMarkerClusterRadius.toDouble()
+                                : _settings.mapMarkerClusterRadius
+                                      .toDouble()
+                                      .clamp(1, terminalRadiusLimit)
+                                      .toDouble();
                             final markerClusters = clusteringEnabled
                                 ? clusterMapMarkers<AnitabiPoint>(
-                                    items: mapPoints,
+                                    items: clusterItems,
                                     positionOf: (point) => point.position,
                                     camera: camera,
-                                    radiusPixels: _settings
-                                        .mapMarkerClusterRadius
-                                        .toDouble(),
+                                    radiusPixels: clusterRadius,
                                     keepSeparate: (point) =>
+                                        activeOverlapPointIds.isEmpty &&
+                                        normalClusteringEnabled &&
                                         point.id == selectedPoint?.id,
                                   )
                                 : [
-                                    for (final point in mapPoints)
+                                    for (final point in clusterItems)
                                       MapMarkerCluster(
                                         items: [point],
                                         position: point.position,
                                       ),
+                                    if (activeOverlapPointIds.isNotEmpty &&
+                                        selectedPoint != null)
+                                      MapMarkerCluster(
+                                        items: [selectedPoint],
+                                        position: selectedPoint.position,
+                                      ),
                                   ];
+                            if (clusteringEnabled &&
+                                activeOverlapPointIds.isNotEmpty &&
+                                selectedPoint != null) {
+                              markerClusters.add(
+                                MapMarkerCluster(
+                                  items: [selectedPoint],
+                                  position: selectedPoint.position,
+                                ),
+                              );
+                            }
                             return MarkerLayer(
                               markers: [
                                 for (final cluster in markerClusters)
@@ -1406,14 +1542,25 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                                         child: Center(
                                           child: MapMarkerClusterBadge(
                                             count: cluster.items.length,
-                                            onTap: () => _mapController.move(
-                                              cluster.position,
-                                              nextClusterZoom(
-                                                camera,
-                                                _settings
-                                                    .mapMarkerClusterMaxZoom,
-                                              ),
-                                            ),
+                                            opensPointBrowser: atMaximumZoom,
+                                            onTap: atMaximumZoom
+                                                ? () =>
+                                                      _openOverlapPointBrowser(
+                                                        cluster.items,
+                                                        visiblePoints,
+                                                      )
+                                                : () => _mapController.move(
+                                                    cluster.position,
+                                                    normalClusteringEnabled
+                                                        ? nextClusterZoom(
+                                                            camera,
+                                                            _settings
+                                                                .mapMarkerClusterMaxZoom,
+                                                          )
+                                                        : nextOverlapClusterZoom(
+                                                            camera,
+                                                          ),
+                                                  ),
                                           ),
                                         ),
                                       ),
@@ -1510,6 +1657,18 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                               ),
                               isImporting: _isImporting,
                               onImport: _importSelectedPoint,
+                              overlapPointIndex: hasActiveOverlapBrowser
+                                  ? overlapPointIndex
+                                  : null,
+                              overlapPointCount: hasActiveOverlapBrowser
+                                  ? overlapPoints.length
+                                  : null,
+                              onPreviousOverlapPoint: hasActiveOverlapBrowser
+                                  ? () => _moveOverlapPoint(-1)
+                                  : null,
+                              onNextOverlapPoint: hasActiveOverlapBrowser
+                                  ? () => _moveOverlapPoint(1)
+                                  : null,
                             ),
                     ),
                   ],
@@ -1872,6 +2031,10 @@ class _AnitabiPointCard extends StatelessWidget {
     required this.imported,
     required this.isImporting,
     required this.onImport,
+    this.overlapPointIndex,
+    this.overlapPointCount,
+    this.onPreviousOverlapPoint,
+    this.onNextOverlapPoint,
   });
 
   final AnitabiPoint point;
@@ -1884,6 +2047,10 @@ class _AnitabiPointCard extends StatelessWidget {
   final bool imported;
   final bool isImporting;
   final VoidCallback onImport;
+  final int? overlapPointIndex;
+  final int? overlapPointCount;
+  final VoidCallback? onPreviousOverlapPoint;
+  final VoidCallback? onNextOverlapPoint;
 
   @override
   Widget build(BuildContext context) {
@@ -1892,6 +2059,11 @@ class _AnitabiPointCard extends StatelessWidget {
     final fullImageUrl = anitabiFullResolutionImageUrl(point.referenceImageUrl);
     final localThumbnailPath = importedPoint?.referenceThumbnailPath;
     final localFullPath = importedPoint?.referenceFullImagePath;
+    final showOverlapPager =
+        overlapPointIndex != null &&
+        overlapPointCount != null &&
+        onPreviousOverlapPoint != null &&
+        onNextOverlapPoint != null;
     void openFullImage() {
       if (fullImageUrl == null) {
         return;
@@ -1938,135 +2110,162 @@ class _AnitabiPointCard extends StatelessWidget {
           side: const BorderSide(color: AppColors.border),
         ),
         clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          key: ValueKey('anitabi-point-card-${point.id}'),
-          onTap: openDetail,
-          child: Padding(
-            padding: const EdgeInsets.all(14),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: Material(
-                    color: AppColors.surfaceMuted,
-                    child: InkWell(
-                      onTap: fullImageUrl == null ? null : openFullImage,
-                      child: SizedBox(
-                        width: 86,
-                        height: 86,
-                        child: importedPoint == null
-                            ? ReferenceThumbnail(
-                                localPath: localThumbnailPath,
-                                imageUrl: imageUrl,
-                                placeholder: const Icon(Icons.image_outlined),
-                              )
-                            : AutoCachingReferenceThumbnail(
-                                planId: planId,
-                                point: importedPoint!,
-                                repository: repository,
-                                onPlanUpdated: onPlanUpdated,
-                                placeholder: const Icon(Icons.image_outlined),
-                              ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (showOverlapPager) ...[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(4, 4, 4, 0),
+                child: MapOverlapPointPager(
+                  currentIndex: overlapPointIndex!,
+                  total: overlapPointCount!,
+                  onPrevious: onPreviousOverlapPoint!,
+                  onNext: onNextOverlapPoint!,
+                ),
+              ),
+              const Divider(
+                key: ValueKey('anitabi-import-overlap-point-divider'),
+                height: 1,
+                indent: 14,
+                endIndent: 14,
+                color: AppColors.border,
+              ),
+            ],
+            InkWell(
+              key: ValueKey('anitabi-point-card-${point.id}'),
+              onTap: openDetail,
+              child: Padding(
+                padding: const EdgeInsets.all(14),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Material(
+                        color: AppColors.surfaceMuted,
+                        child: InkWell(
+                          onTap: fullImageUrl == null ? null : openFullImage,
+                          child: SizedBox(
+                            width: 86,
+                            height: 86,
+                            child: importedPoint == null
+                                ? ReferenceThumbnail(
+                                    localPath: localThumbnailPath,
+                                    imageUrl: imageUrl,
+                                    placeholder: const Icon(
+                                      Icons.image_outlined,
+                                    ),
+                                  )
+                                : AutoCachingReferenceThumbnail(
+                                    planId: planId,
+                                    point: importedPoint!,
+                                    repository: repository,
+                                    onPlanUpdated: onPlanUpdated,
+                                    placeholder: const Icon(
+                                      Icons.image_outlined,
+                                    ),
+                                  ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      CopyableText(
-                        text: point.name,
-                        copyLabel: '点位名称',
-                        onTap: openDetail,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w800,
-                          letterSpacing: 0,
-                        ),
-                      ),
-                      const SizedBox(height: 3),
-                      CopyableText(
-                        text: '${point.subtitle} / ${point.episodeLabel}',
-                        copyText: _copySummary,
-                        copyLabel: '点位信息',
-                        onTap: openDetail,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          color: AppColors.textSecondary,
-                          fontSize: 12,
-                          letterSpacing: 0,
-                        ),
-                      ),
-                      const SizedBox(height: 3),
-                      CopyableText(
-                        text: point.origin,
-                        copyLabel: '来源',
-                        onTap: openDetail,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          color: AppColors.textSecondary,
-                          fontSize: 12,
-                          letterSpacing: 0,
-                        ),
-                      ),
-                      const SizedBox(height: 10),
-                      Row(
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          SizedBox(
-                            height: 40,
-                            child: OutlinedButton.icon(
-                              onPressed: openNavigation,
-                              icon: const Icon(
-                                Icons.navigation_outlined,
-                                size: 17,
-                              ),
-                              label: const Text('导航'),
-                              style: OutlinedButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 10,
-                                ),
-                              ),
+                          CopyableText(
+                            text: point.name,
+                            copyLabel: '点位名称',
+                            onTap: openDetail,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: 0,
                             ),
                           ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: SizedBox(
-                              height: 40,
-                              child: FilledButton.icon(
-                                onPressed: imported || isImporting
-                                    ? null
-                                    : onImport,
-                                icon: Icon(
-                                  imported
-                                      ? Icons.check
-                                      : Icons.add_location_alt_outlined,
-                                  size: 18,
-                                ),
-                                label: Text(imported ? '已加入' : '加入计划'),
-                                style: FilledButton.styleFrom(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 10,
+                          const SizedBox(height: 3),
+                          CopyableText(
+                            text: '${point.subtitle} / ${point.episodeLabel}',
+                            copyText: _copySummary,
+                            copyLabel: '点位信息',
+                            onTap: openDetail,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: AppColors.textSecondary,
+                              fontSize: 12,
+                              letterSpacing: 0,
+                            ),
+                          ),
+                          const SizedBox(height: 3),
+                          CopyableText(
+                            text: point.origin,
+                            copyLabel: '来源',
+                            onTap: openDetail,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: AppColors.textSecondary,
+                              fontSize: 12,
+                              letterSpacing: 0,
+                            ),
+                          ),
+                          const SizedBox(height: 10),
+                          Row(
+                            children: [
+                              SizedBox(
+                                height: 40,
+                                child: OutlinedButton.icon(
+                                  onPressed: openNavigation,
+                                  icon: const Icon(
+                                    Icons.navigation_outlined,
+                                    size: 17,
+                                  ),
+                                  label: const Text('导航'),
+                                  style: OutlinedButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 10,
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: SizedBox(
+                                  height: 40,
+                                  child: FilledButton.icon(
+                                    onPressed: imported || isImporting
+                                        ? null
+                                        : onImport,
+                                    icon: Icon(
+                                      imported
+                                          ? Icons.check
+                                          : Icons.add_location_alt_outlined,
+                                      size: 18,
+                                    ),
+                                    label: Text(imported ? '已加入' : '加入计划'),
+                                    style: FilledButton.styleFrom(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 10,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ],
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/plan/pilgrimage_models.dart
+++ b/lib/plan/pilgrimage_models.dart
@@ -171,6 +171,7 @@ class AppSettings {
     this.customCameraAspectRatioHeight = 1,
     this.mapThumbnailVisibleThreshold = 40,
     this.mapThumbnailConcurrentLoads = 10,
+    this.showPlanGroupProgress = true,
     this.mapMarkerClusteringEnabled = true,
     this.mapMarkerClusterRadius = 40,
     this.mapMarkerClusterMaxZoom = 21,
@@ -206,6 +207,7 @@ class AppSettings {
   final double customCameraAspectRatioHeight;
   final int mapThumbnailVisibleThreshold;
   final int mapThumbnailConcurrentLoads;
+  final bool showPlanGroupProgress;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -241,6 +243,7 @@ class AppSettings {
     double? customCameraAspectRatioHeight,
     int? mapThumbnailVisibleThreshold,
     int? mapThumbnailConcurrentLoads,
+    bool? showPlanGroupProgress,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -289,6 +292,8 @@ class AppSettings {
           mapThumbnailVisibleThreshold ?? this.mapThumbnailVisibleThreshold,
       mapThumbnailConcurrentLoads:
           mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
+      showPlanGroupProgress:
+          showPlanGroupProgress ?? this.showPlanGroupProgress,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:

--- a/lib/plan/plan_group_picker_sheet.dart
+++ b/lib/plan/plan_group_picker_sheet.dart
@@ -144,6 +144,8 @@ class _PlanGroupPickerTile extends StatelessWidget {
         : (group.completedCount / group.points.length)
               .clamp(0.0, 1.0)
               .toDouble();
+    final completed =
+        group.points.isNotEmpty && group.completedCount >= group.points.length;
     return Padding(
       padding: const EdgeInsets.only(bottom: 4),
       child: Material(
@@ -159,6 +161,25 @@ class _PlanGroupPickerTile extends StatelessWidget {
             height: 68,
             child: Stack(
               children: [
+                if (showProgressRing && !completed)
+                  Positioned.fill(
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: FractionallySizedBox(
+                        key: ValueKey('plan-group-picker-progress-${group.id}'),
+                        widthFactor: progress,
+                        heightFactor: 1,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: accentColor.withValues(
+                              alpha: selected ? 0.18 : 0.08,
+                            ),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
                 if (selected)
                   Positioned(
                     key: const ValueKey('plan-group-picker-selected-accent'),
@@ -179,15 +200,49 @@ class _PlanGroupPickerTile extends StatelessWidget {
                   padding: const EdgeInsets.fromLTRB(16, 8, 12, 8),
                   child: Row(
                     children: [
-                      Icon(
-                        group.isUngrouped
-                            ? (selected
-                                  ? Icons.inventory_2
-                                  : Icons.inventory_2_outlined)
-                            : (selected ? Icons.folder : Icons.folder_outlined),
-                        color: selected ? accentColor : AppColors.textSecondary,
-                        size: 24,
-                      ),
+                      if (completed)
+                        SizedBox(
+                          key: ValueKey(
+                            'plan-group-picker-completed-icon-${group.id}',
+                          ),
+                          width: 28,
+                          height: 26,
+                          child: Stack(
+                            alignment: Alignment.center,
+                            children: [
+                              Icon(
+                                Icons.folder,
+                                color: AppColors.accentDark,
+                                size: 28,
+                              ),
+                              const Padding(
+                                padding: EdgeInsets.only(top: 2),
+                                child: Icon(
+                                  Icons.check,
+                                  color: Colors.white,
+                                  size: 14,
+                                ),
+                              ),
+                            ],
+                          ),
+                        )
+                      else
+                        SizedBox(
+                          width: 28,
+                          child: Icon(
+                            group.isUngrouped
+                                ? (selected
+                                      ? Icons.inventory_2
+                                      : Icons.inventory_2_outlined)
+                                : (selected
+                                      ? Icons.folder
+                                      : Icons.folder_outlined),
+                            color: selected
+                                ? accentColor
+                                : AppColors.textSecondary,
+                            size: 24,
+                          ),
+                        ),
                       const SizedBox(width: 14),
                       Expanded(
                         child: Column(
@@ -220,57 +275,40 @@ class _PlanGroupPickerTile extends StatelessWidget {
                         ),
                       ),
                       const SizedBox(width: 8),
-                      SizedBox.square(
-                        dimension: 44,
-                        key: ValueKey('plan-group-picker-progress-${group.id}'),
-                        child: Stack(
-                          alignment: Alignment.center,
-                          children: [
-                            if (showProgressRing)
-                              CircularProgressIndicator(
-                                value: progress,
-                                strokeWidth: 3,
-                                backgroundColor: AppColors.border,
-                                color: selected
-                                    ? accentColor
-                                    : AppColors.textSecondary,
-                              ),
-                            Text.rich(
-                              key: ValueKey(
-                                'plan-group-picker-count-${group.id}',
+                      SizedBox(
+                        width: 44,
+                        child: Text.rich(
+                          key: ValueKey('plan-group-picker-count-${group.id}'),
+                          TextSpan(
+                            text: '${group.completedCount}',
+                            children: [
+                              TextSpan(
+                                text: '/',
+                                style: const TextStyle(
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.w700,
+                                  letterSpacing: 0,
+                                ),
                               ),
                               TextSpan(
-                                text: '${group.completedCount}',
-                                children: [
-                                  TextSpan(
-                                    text: '/',
-                                    style: const TextStyle(
-                                      fontSize: 10,
-                                      fontWeight: FontWeight.w700,
-                                      letterSpacing: 0,
-                                    ),
-                                  ),
-                                  TextSpan(
-                                    text: '${group.points.length}',
-                                    style: TextStyle(
-                                      fontSize: emphasizeTotalCount ? 17 : 10,
-                                      fontWeight: FontWeight.w700,
-                                      letterSpacing: 0,
-                                    ),
-                                  ),
-                                ],
+                                text: '${group.points.length}',
+                                style: TextStyle(
+                                  fontSize: emphasizeTotalCount ? 17 : 10,
+                                  fontWeight: FontWeight.w700,
+                                  letterSpacing: 0,
+                                ),
                               ),
-                              textAlign: TextAlign.center,
-                              style: TextStyle(
-                                color: selected
-                                    ? accentColor
-                                    : AppColors.textSecondary,
-                                fontSize: emphasizeTotalCount ? 10 : 17,
-                                fontWeight: FontWeight.w800,
-                                letterSpacing: 0,
-                              ),
-                            ),
-                          ],
+                            ],
+                          ),
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            color: selected
+                                ? AppColors.accentDark
+                                : AppColors.textSecondary,
+                            fontSize: emphasizeTotalCount ? 10 : 17,
+                            fontWeight: FontWeight.w800,
+                            letterSpacing: 0,
+                          ),
                         ),
                       ),
                     ],

--- a/lib/plan/plan_manager_screen.dart
+++ b/lib/plan/plan_manager_screen.dart
@@ -8,6 +8,28 @@ import '../widgets/copyable_text.dart';
 import '../widgets/snackbar_helper.dart';
 import 'pilgrimage_models.dart';
 
+Widget _cleanPlanReorderProxy(
+  Widget child,
+  int index,
+  Animation<double> animation,
+) {
+  return AnimatedBuilder(
+    animation: animation,
+    builder: (context, child) {
+      final elevation = Curves.easeOut.transform(animation.value) * 10;
+      return Material(
+        key: const ValueKey('plan-reorder-proxy'),
+        color: Colors.transparent,
+        shadowColor: Colors.black.withValues(alpha: 0.18),
+        elevation: elevation,
+        borderRadius: BorderRadius.circular(8),
+        child: child,
+      );
+    },
+    child: child,
+  );
+}
+
 class PlanManagerScreen extends StatefulWidget {
   const PlanManagerScreen({required this.repository, super.key});
 
@@ -332,6 +354,7 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
                   buildDefaultDragHandles: false,
+                  proxyDecorator: _cleanPlanReorderProxy,
                   onReorderItem: _savingOrder ? (_, _) {} : _reorderPlans,
                   itemCount: plans.length,
                   itemBuilder: (context, index) {

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -349,6 +349,7 @@ class _PlanScreenState extends State<PlanScreen> {
             _GroupSwitcher(
               groups: groups,
               selectedIndex: _selectedGroupIndex,
+              showProgressRing: widget.settings.showPlanGroupProgress,
               onSelectGroup: (group) {
                 final currentGroups = planGroupBuckets(
                   controller.plan,
@@ -734,12 +735,14 @@ class _GroupSwitcher extends StatelessWidget {
   const _GroupSwitcher({
     required this.groups,
     required this.selectedIndex,
+    required this.showProgressRing,
     required this.onSelectGroup,
     required this.onCreateGroup,
   });
 
   final List<PlanGroupBucket> groups;
   final int selectedIndex;
+  final bool showProgressRing;
   final ValueChanged<PlanGroupBucket> onSelectGroup;
   final Future<PilgrimagePlanGroup?> Function() onCreateGroup;
 
@@ -790,6 +793,7 @@ class _GroupSwitcher extends StatelessWidget {
       context: context,
       groups: groups,
       selectedGroupId: groups[selectedIndex].id,
+      showProgressRing: showProgressRing,
       onSelectGroup: onSelectGroup,
       onCreateGroup: onCreateGroup,
     );

--- a/lib/plan/point_manager_screen.dart
+++ b/lib/plan/point_manager_screen.dart
@@ -744,41 +744,30 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
   Future<String?> _pickTargetGroup({String? currentGroupId}) async {
     final groups = _plan.groups.toList(growable: false)
       ..sort((a, b) => a.orderIndex.compareTo(b.orderIndex));
-    return showModalBottomSheet<String>(
+    final selectedGroupId = await showPlanGroupSelectionSheet(
       context: context,
-      showDragHandle: true,
-      builder: (context) {
-        return SafeArea(
-          top: false,
-          child: ListView(
-            shrinkWrap: true,
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-            children: [
-              const _SheetTitle(title: '移动到片区'),
-              _MoveTargetTile(
-                title: '未分配点位',
-                selected: currentGroupId == null,
-                onTap: () => Navigator.of(context).pop(_ungroupedGroupMove),
-              ),
-              for (final group in groups)
-                _MoveTargetTile(
-                  title: group.name,
-                  selected: currentGroupId == group.id,
-                  onTap: () => Navigator.of(context).pop(group.id),
-                ),
-            ],
-          ),
-        );
+      title: '移动到片区',
+      subtitle: '选择一个片区作为当前点位所属片区',
+      selectedOptionId: currentGroupId ?? _ungroupedGroupMove,
+      options: [
+        const PlanGroupSelectionOption(id: _ungroupedGroupMove, title: '未分入片区'),
+        for (final group in groups)
+          PlanGroupSelectionOption(id: group.id, title: group.name),
+      ],
+      onCreateOption: () async {
+        final created = await _createGroupFromPicker();
+        return created == null
+            ? null
+            : PlanGroupSelectionOption(id: created.id, title: created.name);
       },
-    ).then((value) {
-      if (value == null) {
-        return _cancelGroupMove;
-      }
-      if (value == _ungroupedGroupMove) {
-        return null;
-      }
-      return value;
-    });
+    );
+    if (selectedGroupId == null) {
+      return _cancelGroupMove;
+    }
+    if (selectedGroupId == _ungroupedGroupMove) {
+      return null;
+    }
+    return selectedGroupId;
   }
 
   Future<void> _openNearestAssign() async {
@@ -1753,34 +1742,6 @@ class _SheetTitle extends StatelessWidget {
 
 class _OrderModeTile extends StatelessWidget {
   const _OrderModeTile({
-    required this.title,
-    required this.selected,
-    required this.onTap,
-  });
-
-  final String title;
-  final bool selected;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      child: ListTile(
-        contentPadding: EdgeInsets.zero,
-        leading: Icon(
-          selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
-          color: selected ? AppColors.accent : AppColors.textSecondary,
-        ),
-        title: Text(title),
-        onTap: onTap,
-      ),
-    );
-  }
-}
-
-class _MoveTargetTile extends StatelessWidget {
-  const _MoveTargetTile({
     required this.title,
     required this.selected,
     required this.onTap,

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -29,8 +29,8 @@ class RecordsScreen extends StatefulWidget {
 }
 
 class _RecordsScreenState extends State<RecordsScreen> {
-  String? _selectedWorkId;
-  String? _selectedGroupFilterId;
+  Set<String>? _selectedWorkIds;
+  Set<String>? _selectedGroupFilterIds;
   String _searchQuery = '';
   _RecordStatusFilter _statusFilter = _RecordStatusFilter.all;
   var _expandedSectionsInitialized = false;
@@ -93,8 +93,8 @@ class _RecordsScreenState extends State<RecordsScreen> {
                   statusFilter: _statusFilter,
                   searchQuery: _searchQuery,
                   activeScopeFilterCount:
-                      (_selectedWorkId == null ? 0 : 1) +
-                      (_selectedGroupFilterId == null ? 0 : 1),
+                      (_selectedWorkIds == null ? 0 : 1) +
+                      (_selectedGroupFilterIds == null ? 0 : 1),
                   onSearchChanged: (query) {
                     setState(() {
                       _searchQuery = query;
@@ -194,7 +194,8 @@ class _RecordsScreenState extends State<RecordsScreen> {
     return controller.visitRecords
         .where((record) {
           final point = controller.pointById(record.pointId);
-          if (_selectedWorkId != null && record.workId != _selectedWorkId) {
+          final workIds = _selectedWorkIds;
+          if (workIds != null && !workIds.contains(record.workId)) {
             return false;
           }
           if (!_matchesGroupFilter(point)) {
@@ -286,36 +287,38 @@ class _RecordsScreenState extends State<RecordsScreen> {
   }
 
   bool _matchesGroupFilter(PilgrimagePoint? point) {
-    final filterId = _selectedGroupFilterId;
-    if (filterId == null) {
+    final filterIds = _selectedGroupFilterIds;
+    if (filterIds == null) {
       return true;
     }
-    if (filterId == _orphanRecordFilterId) {
-      return point == null;
+    if (point == null) {
+      return filterIds.contains(_orphanRecordFilterId);
     }
-    if (filterId == _ungroupedRecordFilterId) {
-      return point != null && point.groupId == null;
+    final groupId = point.groupId;
+    if (groupId == null) {
+      return filterIds.contains(_ungroupedRecordFilterId);
     }
-    return point != null && point.groupId == filterId;
+    return filterIds.contains(groupId);
   }
 
   Future<void> _openScopeFilters() async {
     final result = await showModalBottomSheet<_RecordScopeSelection>(
       context: context,
       isScrollControlled: true,
+      showDragHandle: true,
       builder: (context) => _RecordScopeFilterSheet(
         works: widget.controller.plan.works,
         groups: widget.controller.plan.groups,
-        selectedWorkId: _selectedWorkId,
-        selectedGroupFilterId: _selectedGroupFilterId,
+        selectedWorkIds: _selectedWorkIds,
+        selectedGroupFilterIds: _selectedGroupFilterIds,
       ),
     );
     if (result == null || !mounted) {
       return;
     }
     setState(() {
-      _selectedWorkId = result.workId;
-      _selectedGroupFilterId = result.groupId;
+      _selectedWorkIds = result.workIds;
+      _selectedGroupFilterIds = result.groupIds;
       _resetExpandedSections();
     });
   }
@@ -435,6 +438,10 @@ class _RecordFilters extends StatelessWidget {
               key: const ValueKey('records-scope-filter-button'),
               tooltip: '按作品和片区筛选',
               onPressed: onOpenScopeFilters,
+              style: IconButton.styleFrom(
+                backgroundColor: AppColors.surface,
+                side: const BorderSide(color: AppColors.border),
+              ),
               icon: const Icon(Icons.tune),
             ),
           ),
@@ -445,24 +452,24 @@ class _RecordFilters extends StatelessWidget {
 }
 
 class _RecordScopeSelection {
-  const _RecordScopeSelection({required this.workId, required this.groupId});
+  const _RecordScopeSelection({required this.workIds, required this.groupIds});
 
-  final String? workId;
-  final String? groupId;
+  final Set<String>? workIds;
+  final Set<String>? groupIds;
 }
 
 class _RecordScopeFilterSheet extends StatefulWidget {
   const _RecordScopeFilterSheet({
     required this.works,
     required this.groups,
-    required this.selectedWorkId,
-    required this.selectedGroupFilterId,
+    required this.selectedWorkIds,
+    required this.selectedGroupFilterIds,
   });
 
   final List<PilgrimageWork> works;
   final List<PilgrimagePlanGroup> groups;
-  final String? selectedWorkId;
-  final String? selectedGroupFilterId;
+  final Set<String>? selectedWorkIds;
+  final Set<String>? selectedGroupFilterIds;
 
   @override
   State<_RecordScopeFilterSheet> createState() =>
@@ -470,24 +477,75 @@ class _RecordScopeFilterSheet extends StatefulWidget {
 }
 
 class _RecordScopeFilterSheetState extends State<_RecordScopeFilterSheet> {
-  late String? _workId = widget.selectedWorkId;
-  late String? _groupId = widget.selectedGroupFilterId;
+  late Set<String>? _workIds = _copyFilter(widget.selectedWorkIds);
+  late Set<String>? _groupIds = _copyFilter(widget.selectedGroupFilterIds);
+
+  static Set<String>? _copyFilter(Set<String>? value) {
+    return value == null ? null : {...value};
+  }
+
+  Future<void> _openWorkFilters() async {
+    final selectedIds = await showModalBottomSheet<Set<String>>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      backgroundColor: AppColors.surface,
+      builder: (context) => _RecordScopeOptionSheet(
+        kind: 'work',
+        title: '作品',
+        options: [
+          for (final work in widget.works)
+            _RecordScopeOption(id: work.id, label: work.title),
+        ],
+        selectedIds: _workIds ?? const {},
+      ),
+    );
+    if (selectedIds == null || !mounted) {
+      return;
+    }
+    setState(() => _workIds = selectedIds.isEmpty ? null : selectedIds);
+  }
+
+  Future<void> _openGroupFilters() async {
+    final groups = sortGroupsByPlanOrder(widget.groups);
+    final selectedIds = await showModalBottomSheet<Set<String>>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      backgroundColor: AppColors.surface,
+      builder: (context) => _RecordScopeOptionSheet(
+        kind: 'group',
+        title: '片区',
+        options: [
+          for (final group in groups)
+            _RecordScopeOption(id: group.id, label: group.name),
+          const _RecordScopeOption(id: _ungroupedRecordFilterId, label: '未分组'),
+          const _RecordScopeOption(id: _orphanRecordFilterId, label: '孤立记录'),
+        ],
+        selectedIds: _groupIds ?? const {},
+      ),
+    );
+    if (selectedIds == null || !mounted) {
+      return;
+    }
+    setState(() => _groupIds = selectedIds.isEmpty ? null : selectedIds);
+  }
 
   @override
   Widget build(BuildContext context) {
-    final groups = sortGroupsByPlanOrder(widget.groups);
     return SafeArea(
+      top: false,
       child: ConstrainedBox(
         constraints: BoxConstraints(
-          maxHeight: MediaQuery.sizeOf(context).height * 0.75,
+          maxHeight: MediaQuery.sizeOf(context).height * 0.72,
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 18, 12, 8),
-              child: Row(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
                 children: [
                   const Expanded(
                     child: Text(
@@ -500,107 +558,450 @@ class _RecordScopeFilterSheetState extends State<_RecordScopeFilterSheet> {
                     ),
                   ),
                   TextButton(
+                    key: const ValueKey('records-scope-clear'),
                     onPressed: () => setState(() {
-                      _workId = null;
-                      _groupId = null;
+                      _workIds = null;
+                      _groupIds = null;
                     }),
                     child: const Text('清除'),
                   ),
                 ],
               ),
+              Text(
+                '已选：作品 ${_workIds?.length ?? 0} · 片区 ${_groupIds?.length ?? 0}',
+                key: const ValueKey('records-scope-summary'),
+                style: const TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  letterSpacing: 0,
+                ),
+              ),
+              const SizedBox(height: 18),
+              const Text('作品', style: TextStyle(fontWeight: FontWeight.w800)),
+              const SizedBox(height: 8),
+              _RecordScopeEntry(
+                key: const ValueKey('records-scope-work-entry'),
+                label: _scopeLabel(_workIds, allLabel: '全部作品', noun: '作品'),
+                onTap: _openWorkFilters,
+              ),
+              const SizedBox(height: 16),
+              const Text('片区', style: TextStyle(fontWeight: FontWeight.w800)),
+              const SizedBox(height: 8),
+              _RecordScopeEntry(
+                key: const ValueKey('records-scope-group-entry'),
+                label: _scopeLabel(_groupIds, allLabel: '全部片区', noun: '片区'),
+                onTap: _openGroupFilters,
+              ),
+              const SizedBox(height: 28),
+              FilledButton(
+                key: const ValueKey('records-scope-apply'),
+                onPressed: () => Navigator.of(context).pop(
+                  _RecordScopeSelection(
+                    workIds: _copyFilter(_workIds),
+                    groupIds: _copyFilter(_groupIds),
+                  ),
+                ),
+                child: Text(
+                  '应用筛选（${_workIds == null && _groupIds == null ? '全部点位' : '已选择'}）',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _scopeLabel(
+    Set<String>? ids, {
+    required String allLabel,
+    required String noun,
+  }) {
+    return ids == null ? allLabel : '已选 ${ids.length} 个$noun';
+  }
+}
+
+class _RecordScopeEntry extends StatelessWidget {
+  const _RecordScopeEntry({
+    required this.label,
+    required this.onTap,
+    super.key,
+  });
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: const BorderSide(color: AppColors.border),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          height: 48,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: [
+                Icon(Icons.check_circle, color: AppColors.accent, size: 20),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+                const Icon(Icons.chevron_right, color: AppColors.textSecondary),
+              ],
             ),
-            Flexible(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RecordScopeOption {
+  const _RecordScopeOption({required this.id, required this.label});
+
+  final String id;
+  final String label;
+}
+
+class _RecordScopeOptionSheet extends StatefulWidget {
+  const _RecordScopeOptionSheet({
+    required this.kind,
+    required this.title,
+    required this.options,
+    required this.selectedIds,
+  });
+
+  final String kind;
+  final String title;
+  final List<_RecordScopeOption> options;
+  final Set<String> selectedIds;
+
+  @override
+  State<_RecordScopeOptionSheet> createState() =>
+      _RecordScopeOptionSheetState();
+}
+
+class _RecordScopeOptionSheetState extends State<_RecordScopeOptionSheet> {
+  late final Set<String> _selectedIds = {...widget.selectedIds};
+  var _scrolling = false;
+
+  void _toggleOption(String id, bool selected) {
+    setState(() {
+      if (selected) {
+        _selectedIds.add(id);
+      } else {
+        _selectedIds.remove(id);
+      }
+    });
+  }
+
+  void _confirm() {
+    Navigator.of(context).pop({..._selectedIds});
+  }
+
+  bool _handleScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollStartNotification && !_scrolling) {
+      setState(() => _scrolling = true);
+    } else if (notification is ScrollEndNotification && _scrolling) {
+      setState(() => _scrolling = false);
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final maxHeight = MediaQuery.sizeOf(context).height * 0.82;
+    final desiredHeight = 52.0 + 40.0 + widget.options.length * 48.0 + 78.0;
+    final sheetHeight = desiredHeight
+        .clamp(190.0, maxHeight > 560 ? 560.0 : maxHeight)
+        .toDouble();
+    final noun = widget.kind == 'work' ? '作品' : '片区';
+    return SafeArea(
+      top: false,
+      child: SizedBox(
+        height: sheetHeight,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SizedBox(
+              height: 52,
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: 64,
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 8),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: IconButton(
+                          key: ValueKey('records-scope-back-${widget.kind}'),
+                          tooltip: '返回筛选记录',
+                          onPressed: () => Navigator.of(context).pop(),
+                          icon: const Icon(Icons.chevron_left),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      '选择${widget.title}',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 64),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 8),
+              child: Text(
+                '全部${widget.title}',
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+            Expanded(
+              child: widget.options.isEmpty
+                  ? const Center(
+                      child: Text(
+                        '暂无可筛选项',
+                        style: TextStyle(color: AppColors.textSecondary),
+                      ),
+                    )
+                  : NotificationListener<ScrollNotification>(
+                      onNotification: _handleScrollNotification,
+                      child: ListView.builder(
+                        padding: EdgeInsets.zero,
+                        itemCount: widget.options.length,
+                        itemBuilder: (context, index) {
+                          final option = widget.options[index];
+                          final selected = _selectedIds.contains(option.id);
+                          return _RecordScopeOptionTile(
+                            key: ValueKey(
+                              'records-scope-option-${widget.kind}-${option.id}',
+                            ),
+                            decorationKey: ValueKey(
+                              'records-scope-option-decoration-${widget.kind}-${option.id}',
+                            ),
+                            option: option,
+                            badgeLabel: noun,
+                            selected: selected,
+                            hoverEnabled: !_scrolling,
+                            onChanged: (value) =>
+                                _toggleOption(option.id, value),
+                          );
+                        },
+                      ),
+                    ),
+            ),
+            ColoredBox(
+              color: AppColors.background,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 10, 16, 16),
+                child: Row(
                   children: [
-                    const Text(
-                      '作品',
-                      style: TextStyle(fontWeight: FontWeight.w800),
+                    Expanded(
+                      child: Text(
+                        '已选择 ${_selectedIds.length} 个$noun',
+                        key: ValueKey(
+                          'records-scope-secondary-count-${widget.kind}',
+                        ),
+                        style: const TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0,
+                        ),
+                      ),
                     ),
-                    const SizedBox(height: 8),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: [
-                        ChoiceChip(
-                          label: const Text('全部作品'),
-                          selected: _workId == null,
-                          onSelected: (_) => setState(() => _workId = null),
+                    SizedBox(
+                      width: 176,
+                      child: FilledButton(
+                        key: ValueKey(
+                          'records-scope-secondary-confirm-${widget.kind}',
                         ),
-                        for (final work in widget.works)
-                          ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 280),
-                            child: ChoiceChip(
-                              label: Text(
-                                work.title,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                              selected: _workId == work.id,
-                              onSelected: (_) =>
-                                  setState(() => _workId = work.id),
-                            ),
-                          ),
-                      ],
-                    ),
-                    const SizedBox(height: 18),
-                    const Text(
-                      '片区',
-                      style: TextStyle(fontWeight: FontWeight.w800),
-                    ),
-                    const SizedBox(height: 8),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: [
-                        ChoiceChip(
-                          label: const Text('全部片区'),
-                          selected: _groupId == null,
-                          onSelected: (_) => setState(() => _groupId = null),
+                        onPressed: _confirm,
+                        child: Text(
+                          _selectedIds.isEmpty
+                              ? '确定'
+                              : '确定（${_selectedIds.length}）',
                         ),
-                        for (final group in groups)
-                          ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 280),
-                            child: ChoiceChip(
-                              label: Text(
-                                group.name,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                              selected: _groupId == group.id,
-                              onSelected: (_) =>
-                                  setState(() => _groupId = group.id),
-                            ),
-                          ),
-                        ChoiceChip(
-                          label: const Text('未分组'),
-                          selected: _groupId == _ungroupedRecordFilterId,
-                          onSelected: (_) => setState(
-                            () => _groupId = _ungroupedRecordFilterId,
-                          ),
-                        ),
-                        ChoiceChip(
-                          label: const Text('孤立记录'),
-                          selected: _groupId == _orphanRecordFilterId,
-                          onSelected: (_) =>
-                              setState(() => _groupId = _orphanRecordFilterId),
-                        ),
-                      ],
+                      ),
                     ),
                   ],
                 ),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
-              child: FilledButton(
-                onPressed: () => Navigator.of(context).pop(
-                  _RecordScopeSelection(workId: _workId, groupId: _groupId),
-                ),
-                child: const Text('应用筛选'),
-              ),
-            ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RecordScopeOptionTile extends StatefulWidget {
+  const _RecordScopeOptionTile({
+    required this.decorationKey,
+    required this.option,
+    required this.badgeLabel,
+    required this.selected,
+    required this.hoverEnabled,
+    required this.onChanged,
+    super.key,
+  });
+
+  final Key decorationKey;
+  final _RecordScopeOption option;
+  final String badgeLabel;
+  final bool selected;
+  final bool hoverEnabled;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  State<_RecordScopeOptionTile> createState() => _RecordScopeOptionTileState();
+}
+
+class _RecordScopeOptionTileState extends State<_RecordScopeOptionTile> {
+  var _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final showHover = widget.hoverEnabled && _hovered;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: MouseRegion(
+        onEnter: (_) {
+          if (!_hovered) {
+            setState(() => _hovered = true);
+          }
+        },
+        onExit: (_) {
+          if (_hovered) {
+            setState(() => _hovered = false);
+          }
+        },
+        child: SizedBox(
+          height: 48,
+          child: Stack(
+            clipBehavior: Clip.none,
+            fit: StackFit.expand,
+            children: [
+              Positioned(
+                left: 0,
+                top: 6,
+                right: 0,
+                bottom: 6,
+                child: AnimatedContainer(
+                  key: widget.decorationKey,
+                  duration: const Duration(milliseconds: 200),
+                  curve: Curves.easeOutCubic,
+                  decoration: BoxDecoration(
+                    color: AppColors.accent.withValues(
+                      alpha: widget.selected ? 0.10 : (showHover ? 0.05 : 0),
+                    ),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                ),
+              ),
+              Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  onTap: () => widget.onChanged(!widget.selected),
+                  hoverColor: Colors.transparent,
+                  splashColor: Colors.transparent,
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    curve: Curves.easeOutCubic,
+                    transform: Matrix4.translationValues(
+                      showHover && !widget.selected ? 12 : 0,
+                      0,
+                      0,
+                    ),
+                    transformAlignment: Alignment.centerLeft,
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: AppColors.accent.withValues(alpha: 0.08),
+                            border: Border.all(
+                              color: AppColors.accent.withValues(alpha: 0.42),
+                            ),
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Text(
+                            widget.badgeLabel,
+                            style: TextStyle(
+                              color: AppColors.accent,
+                              fontSize: 11,
+                              fontWeight: FontWeight.w700,
+                              height: 1.15,
+                              letterSpacing: 0,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: Text(
+                            widget.option.label,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: AppColors.textPrimary,
+                              fontSize: 14,
+                              letterSpacing: 0,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Checkbox(
+                          value: widget.selected,
+                          onChanged: (value) =>
+                              widget.onChanged(value ?? false),
+                          shape: const CircleBorder(),
+                          side: const BorderSide(
+                            color: AppColors.border,
+                            width: 1.5,
+                          ),
+                          visualDensity: VisualDensity.compact,
+                          materialTapTargetSize:
+                              MaterialTapTargetSize.shrinkWrap,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -869,8 +1270,13 @@ class _ExpandedRecordFiltersState extends State<_ExpandedRecordFilters> {
             child: _searchController.text.isEmpty
                 ? const SizedBox.shrink()
                 : IconButton(
+                    key: const ValueKey('records-search-clear-button'),
                     tooltip: '清空搜索',
                     padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints.tightFor(
+                      width: 40,
+                      height: 42,
+                    ),
                     onPressed: () {
                       _searchController.clear();
                       widget.onSearchChanged('');

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -713,6 +713,29 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
               ],
             ),
           ),
+          const SizedBox(height: 14),
+          _AppearancePanel(
+            child: Material(
+              color: Colors.transparent,
+              child: SwitchListTile(
+                key: const ValueKey('plan-group-progress-toggle'),
+                contentPadding: EdgeInsets.zero,
+                secondary: const Icon(
+                  Icons.linear_scale_outlined,
+                  color: AppColors.textSecondary,
+                ),
+                title: const Text('显示片区进度条', style: _titleTextStyle),
+                subtitle: const Text(
+                  '在片区选择弹窗中显示未完成片区的进度背景；完成后仅显示对勾。',
+                  style: _secondaryTextStyle,
+                ),
+                value: settings.showPlanGroupProgress,
+                onChanged: (value) {
+                  _update(settings.copyWith(showPlanGroupProgress: value));
+                },
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/test/desktop_repository_state_test.dart
+++ b/test/desktop_repository_state_test.dart
@@ -22,6 +22,7 @@ void main() {
         comparisonPilgrimName: 'BilyHurington',
         mapThumbnailVisibleThreshold: 55,
         mapThumbnailConcurrentLoads: 12,
+        showPlanGroupProgress: false,
         mapMarkerClusteringEnabled: false,
         mapMarkerClusterRadius: 88,
         mapMarkerClusterMaxZoom: 20,
@@ -84,6 +85,7 @@ void main() {
     expect(decoded.settings.comparisonPilgrimName, 'BilyHurington');
     expect(decoded.settings.mapThumbnailVisibleThreshold, 55);
     expect(decoded.settings.mapThumbnailConcurrentLoads, 12);
+    expect(decoded.settings.showPlanGroupProgress, isFalse);
     expect(decoded.settings.mapMarkerClusteringEnabled, isFalse);
     expect(decoded.settings.mapMarkerClusterRadius, 88);
     expect(decoded.settings.mapMarkerClusterMaxZoom, 20);

--- a/test/map_marker_clustering_test.dart
+++ b/test/map_marker_clustering_test.dart
@@ -292,6 +292,14 @@ void main() {
       expect(controller.currentPoint?.id, 'point-c');
       expect(find.text('重合点位  1 / 3'), findsOneWidget);
       expect(
+        tester
+            .widget<Divider>(
+              find.byKey(const ValueKey('map-overlap-point-divider')),
+            )
+            .color,
+        AppColors.border,
+      );
+      expect(
         tester.widget<MarkerLayer>(find.byType(MarkerLayer)).markers.last.key,
         const ValueKey('plan-map-marker-point-a'),
       );

--- a/test/sqlite_pilgrimage_repository_test.dart
+++ b/test/sqlite_pilgrimage_repository_test.dart
@@ -1375,6 +1375,7 @@ void main() {
         customCameraAspectRatioHeight: 9,
         mapThumbnailVisibleThreshold: 55,
         mapThumbnailConcurrentLoads: 12,
+        showPlanGroupProgress: false,
         mapMarkerClusteringEnabled: false,
         mapMarkerClusterRadius: 88,
         mapMarkerClusterMaxZoom: 20,
@@ -1417,6 +1418,7 @@ void main() {
     expect(settings.customCameraAspectRatioHeight, 9);
     expect(settings.mapThumbnailVisibleThreshold, 55);
     expect(settings.mapThumbnailConcurrentLoads, 12);
+    expect(settings.showPlanGroupProgress, isFalse);
     expect(settings.mapMarkerClusteringEnabled, isFalse);
     expect(settings.mapMarkerClusterRadius, 88);
     expect(settings.mapMarkerClusterMaxZoom, 20);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,8 +9,11 @@ import 'package:latlong2/latlong.dart';
 import 'package:miriago/app_theme.dart';
 import 'package:miriago/main.dart';
 import 'package:miriago/data/anitabi_client.dart';
+import 'package:miriago/data/bangumi_api_client.dart';
 import 'package:miriago/data/sample_pilgrimage_repository.dart';
+import 'package:miriago/map/map_marker_clustering.dart';
 import 'package:miriago/point_detail/point_detail_sheet.dart';
+import 'package:miriago/plan/add_points_screen.dart';
 import 'package:miriago/plan/anitabi_map_import_screen.dart';
 import 'package:miriago/plan/nearest_group_assign_screen.dart';
 import 'package:miriago/plan/plan_group_manager_screen.dart';
@@ -207,7 +210,19 @@ void main() {
         of: planGroupOption,
         matching: find.byType(CircularProgressIndicator),
       ),
-      findsOneWidget,
+      findsNothing,
+    );
+    expect(
+      tester
+          .getSize(
+            find.byKey(
+              const ValueKey(
+                'plan-group-picker-progress-sample-group-uji-station',
+              ),
+            ),
+          )
+          .height,
+      68,
     );
     final planCount = tester.widget<Text>(
       find.byKey(
@@ -220,6 +235,43 @@ void main() {
     expect((planCountSpan.children![1] as TextSpan).style?.fontSize, 10);
     expect(find.textContaining('关键点：'), findsWidgets);
     expect(find.textContaining('关键点：关键点：'), findsNothing);
+  });
+
+  testWidgets('completed plan group uses a checked filled folder', (
+    tester,
+  ) async {
+    final group = samplePilgrimagePlan.groups.first;
+    final completedPointIds = samplePilgrimagePlan.points
+        .where((point) => point.groupId == group.id)
+        .map((point) => point.id)
+        .toSet();
+    final plan = samplePilgrimagePlan.copyWith(
+      completedPointIds: completedPointIds,
+    );
+    await tester.pumpWidget(
+      MiriaGoApp(repository: SamplePilgrimageRepository(plans: [plan])),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, group.name));
+    await tester.pumpAndSettle();
+
+    final completedIcon = find.byKey(
+      ValueKey('plan-group-picker-completed-icon-${group.id}'),
+    );
+    expect(completedIcon, findsOneWidget);
+    expect(
+      find.descendant(of: completedIcon, matching: find.byIcon(Icons.folder)),
+      findsOneWidget,
+    );
+    final checkIcon = tester.widget<Icon>(
+      find.descendant(of: completedIcon, matching: find.byIcon(Icons.check)),
+    );
+    expect(checkIcon.color, Colors.white);
+    expect(
+      find.byKey(ValueKey('plan-group-picker-progress-${group.id}')),
+      findsNothing,
+    );
   });
 
   testWidgets('box assign uses the integrated region picker', (tester) async {
@@ -399,6 +451,14 @@ void main() {
     expect(statusFilterShape.side.color, AppColors.border);
     expect(statusFilterShape.side.style, BorderStyle.solid);
     expect(statusFilterShape.side.width, 1);
+    final scopeFilterButton = tester.widget<IconButton>(
+      find.byKey(const ValueKey('records-scope-filter-button')),
+    );
+    expect(
+      scopeFilterButton.style?.backgroundColor?.resolve({}),
+      AppColors.surface,
+    );
+    expect(scopeFilterButton.style?.side?.resolve({})?.color, AppColors.border);
     expect(
       tester
           .widgetList<NavigationDestination>(find.byType(NavigationDestination))
@@ -638,6 +698,17 @@ void main() {
     );
     expect(
       tester
+          .getRect(find.byKey(const ValueKey('records-search-clear-button')))
+          .right,
+      closeTo(
+        tester
+            .getRect(find.byKey(const ValueKey('records-search-shell')))
+            .right,
+        0.1,
+      ),
+    );
+    expect(
+      tester
           .widget<TextField>(find.byKey(const ValueKey('records-search-field')))
           .controller
           ?.text,
@@ -653,11 +724,101 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('records-scope-filter-button')));
     await tester.pumpAndSettle();
 
+    expect(
+      tester.widget<BottomSheet>(find.byType(BottomSheet)).showDragHandle,
+      isTrue,
+    );
     expect(find.text('筛选记录'), findsOneWidget);
     expect(find.text('作品'), findsOneWidget);
     expect(find.text('片区'), findsOneWidget);
-    await tester.tap(find.widgetWithText(ChoiceChip, '大吉山'));
-    await tester.tap(find.widgetWithText(FilledButton, '应用筛选'));
+    expect(find.text('已选：作品 0 · 片区 0'), findsOneWidget);
+    expect(find.text('全部作品'), findsOneWidget);
+    expect(find.text('全部片区'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('records-scope-work-entry')));
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<BottomSheet>(find.byType(BottomSheet).last).showDragHandle,
+      isTrue,
+    );
+    expect(
+      find.byKey(const ValueKey('records-scope-secondary-confirm-work')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('records-scope-secondary-top-confirm-work')),
+      findsNothing,
+    );
+    expect(
+      tester
+          .getSize(
+            find.byKey(const ValueKey('records-scope-secondary-confirm-work')),
+          )
+          .width,
+      176,
+    );
+    final workOptionDecoration = tester.widget<AnimatedContainer>(
+      find.byKey(
+        const ValueKey('records-scope-option-decoration-work-hibike-euphonium'),
+      ),
+    );
+    final unselectedDecoration =
+        workOptionDecoration.decoration! as BoxDecoration;
+    expect(unselectedDecoration.border, isNull);
+    expect(unselectedDecoration.borderRadius, BorderRadius.circular(6));
+    expect(unselectedDecoration.color!.a, 0);
+    expect(
+      find.descendant(
+        of: find.byKey(
+          const ValueKey('records-scope-option-work-hibike-euphonium'),
+        ),
+        matching: find.text('作品'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byType(Checkbox), findsWidgets);
+    await tester.tap(find.byKey(const ValueKey('records-scope-back-work')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('records-scope-group-entry')));
+    await tester.pumpAndSettle();
+    final daikichiyamaOption = find.byKey(
+      const ValueKey('records-scope-option-group-sample-group-daikichiyama'),
+    );
+    expect(daikichiyamaOption, findsOneWidget);
+    await tester.tap(daikichiyamaOption);
+    await tester.pump();
+    expect(
+      tester
+          .widget<Checkbox>(
+            find.descendant(
+              of: daikichiyamaOption,
+              matching: find.byType(Checkbox),
+            ),
+          )
+          .value,
+      isTrue,
+    );
+    final selectedDecoration =
+        tester
+                .widget<AnimatedContainer>(
+                  find.byKey(
+                    const ValueKey(
+                      'records-scope-option-decoration-group-sample-group-daikichiyama',
+                    ),
+                  ),
+                )
+                .decoration!
+            as BoxDecoration;
+    expect(selectedDecoration.border, isNull);
+    expect(selectedDecoration.color!.a, greaterThan(0));
+    await tester.tap(
+      find.byKey(const ValueKey('records-scope-secondary-confirm-group')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('已选：作品 0 · 片区 1'), findsOneWidget);
+    expect(find.text('已选 1 个片区'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('records-scope-apply')));
     await tester.pumpAndSettle();
 
     expect(
@@ -1097,6 +1258,12 @@ void main() {
       ),
       findsNothing,
     );
+    expect(
+      find.byKey(
+        const ValueKey('plan-group-picker-progress-sample-group-uji-station'),
+      ),
+      findsNothing,
+    );
     final managerCount = tester.widget<Text>(
       find.byKey(
         const ValueKey('plan-group-picker-count-sample-group-uji-station'),
@@ -1120,6 +1287,55 @@ void main() {
     expect(find.text('选择一个片区作为当前点位所属片区'), findsOneWidget);
     expect(
       find.byKey(const ValueKey('plan-point-group-selection-宇治站附近')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-point-group-create-entry')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('ungrouped manager point uses the shared move region sheet', (
+    tester,
+  ) async {
+    final sourceRepository = SamplePilgrimageRepository();
+    final sourcePlan = await sourceRepository.loadActivePlan();
+    final point = sourcePlan.points.first.copyWith(
+      groupId: null,
+      groupOrderIndex: null,
+    );
+    final plan = sourcePlan.copyWith(
+      groups: const [],
+      points: [point],
+      currentPointId: null,
+      currentGroupId: null,
+    );
+    final repository = SamplePilgrimageRepository(plans: [plan]);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: PointManagerScreen(
+          plan: plan,
+          repository: repository,
+          settings: const AppSettings(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    tester
+        .widget<PopupMenuButton<String>>(find.byType(PopupMenuButton))
+        .onSelected!('move');
+    await tester.pumpAndSettle();
+
+    expect(find.text('移动到片区'), findsOneWidget);
+    expect(find.text('选择一个片区作为当前点位所属片区'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('plan-point-group-option-未分入片区')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-point-group-selection-未分入片区')),
       findsOneWidget,
     );
     expect(
@@ -1174,7 +1390,7 @@ void main() {
     expect(find.textContaining('桌面启动器'), findsNothing);
   });
 
-  testWidgets('separates map display settings from data sources', (
+  testWidgets('separates appearance, map display, and data source settings', (
     tester,
   ) async {
     await _pumpApp(tester);
@@ -1182,6 +1398,21 @@ void main() {
     await tester.tap(find.text('设置').last);
     await tester.pumpAndSettle();
 
+    await tester.tap(find.text('外观设置'));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('显示片区进度条'),
+      280,
+      scrollable: find.byType(Scrollable).last,
+    );
+    expect(find.text('显示片区进度条'), findsOneWidget);
+    final progressToggle = tester.widget<SwitchListTile>(
+      find.byKey(const ValueKey('plan-group-progress-toggle')),
+    );
+    expect(progressToggle.value, isTrue);
+
+    Navigator.of(tester.element(find.text('外观设置').first)).pop();
+    await tester.pumpAndSettle();
     await tester.scrollUntilVisible(
       find.text('数据源设置'),
       280,
@@ -1196,14 +1427,20 @@ void main() {
     expect(find.text('最大缩放倍率'), findsOneWidget);
     expect(find.text('地图标记大小'), findsOneWidget);
     expect(find.text('片区范围半径'), findsOneWidget);
-    expect(find.text('自动聚合密集点位'), findsOneWidget);
+    expect(find.text('显示片区进度条'), findsNothing);
     expect(find.text('90%'), findsOneWidget);
-    expect(find.text('40 px'), findsOneWidget);
     final maxZoomSlider = tester.widget<Slider>(
       find.byKey(const ValueKey('map-max-zoom-slider')),
     );
     expect(maxZoomSlider.value, 22);
     expect(maxZoomSlider.max, 24);
+    await tester.scrollUntilVisible(
+      find.text('自动聚合密集点位'),
+      280,
+      scrollable: find.byType(Scrollable).last,
+    );
+    expect(find.text('自动聚合密集点位'), findsOneWidget);
+    expect(find.text('40 px'), findsOneWidget);
     await tester.scrollUntilVisible(
       find.text('缩略图显示阈值'),
       280,
@@ -1603,6 +1840,36 @@ void main() {
     expect((await repository.loadActivePlan()).id, 'sample-uji-hibike');
   });
 
+  testWidgets('plan reorder proxy keeps item spacing transparent', (
+    tester,
+  ) async {
+    final repository = SamplePilgrimageRepository();
+    await repository.createPlan(name: '第二计划', area: '京都');
+    await tester.pumpWidget(
+      MaterialApp(home: PlanManagerScreen(repository: repository)),
+    );
+    await tester.pumpAndSettle();
+
+    final reorderable = tester.widget<ReorderableListView>(
+      find.byKey(const ValueKey('reorderable-plan-list')),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: reorderable.proxyDecorator!(
+          const SizedBox(key: ValueKey('proxy-child')),
+          0,
+          const AlwaysStoppedAnimation(1),
+        ),
+      ),
+    );
+
+    final reorderProxy = tester.widget<Material>(
+      find.byKey(const ValueKey('plan-reorder-proxy')),
+    );
+    expect(reorderProxy.color, Colors.transparent);
+    expect(find.byKey(const ValueKey('proxy-child')), findsOneWidget);
+  });
+
   testWidgets('restores plan order when persistence fails', (tester) async {
     final repository = _FailingPlanOrderRepository();
     await repository.createPlan(name: '第二计划', area: '京都');
@@ -1672,6 +1939,43 @@ void main() {
     expect(mapImportInkWell.onTap, isNotNull);
     expect(find.text('在作品地图上选择并导入点位'), findsOneWidget);
     expect(find.text('请先通过 Bangumi 搜索添加作品'), findsNothing);
+  });
+
+  testWidgets('Bangumi search shows a trailing clear button after input', (
+    tester,
+  ) async {
+    final repository = SamplePilgrimageRepository(plans: const []);
+    final plan = await repository.createPlan(name: '搜索测试', area: '东京');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: BangumiWorkSearchScreen(
+          plan: plan,
+          repository: repository,
+          bangumiApiClient: BangumiApiClient(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final searchField = find.byType(TextField);
+    expect(
+      find.byKey(const ValueKey('bangumi-search-clear-button')),
+      findsNothing,
+    );
+    await tester.enterText(searchField, '轻音少女');
+    await tester.pump();
+    final clearButton = find.byKey(
+      const ValueKey('bangumi-search-clear-button'),
+    );
+    expect(clearButton, findsOneWidget);
+    expect(
+      tester.getRect(clearButton).right,
+      closeTo(tester.getRect(searchField).right, 0.1),
+    );
+    await tester.tap(clearButton);
+    await tester.pump();
+    expect(tester.widget<TextField>(searchField).controller?.text, isEmpty);
+    expect(clearButton, findsNothing);
   });
 
   testWidgets('adds a manual work to an empty plan', (tester) async {
@@ -2247,6 +2551,21 @@ void main() {
 
     final field = tester.widget<TextFormField>(find.byType(TextFormField));
     expect(field.controller?.text, link);
+    expect(find.byTooltip('清除搜索框'), findsOneWidget);
+    expect(find.byTooltip('粘贴'), findsNothing);
+    expect(
+      tester
+          .getRect(find.byKey(const ValueKey('anitabi-link-input-action')))
+          .right,
+      closeTo(tester.getRect(find.byType(TextFormField)).right, 0.1),
+    );
+    await tester.tap(find.byTooltip('清除搜索框'));
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<TextFormField>(find.byType(TextFormField)).controller?.text,
+      isEmpty,
+    );
+    expect(find.byTooltip('粘贴'), findsOneWidget);
     expect(find.text('Anitabi 地图导入'), findsNothing);
   });
 
@@ -2386,6 +2705,74 @@ void main() {
     expect(find.text('1002 场景 / EP 1002'), findsOneWidget);
     expect(find.text('1001 点位'), findsNothing);
     expect(find.text('1001 场景 / EP 1001'), findsNothing);
+  });
+
+  testWidgets('Anitabi import map browses overlapping points at maximum zoom', (
+    tester,
+  ) async {
+    const settings = AppSettings(mapMarkerClusterMaxZoom: 18, mapMaxZoom: 24);
+    final repository = SamplePilgrimageRepository(
+      plans: const [],
+      settings: settings,
+    );
+    final plan = await repository.createPlan(name: '重合点位测试', area: '京都');
+    final planWithWork = await repository.addWorkToPlan(
+      planId: plan.id,
+      work: const PilgrimageWork(
+        id: 'overlap-work',
+        bangumiId: 3001,
+        title: '重合点位作品',
+        subtitle: '',
+        city: '京都',
+        source: WorkSource.bangumi,
+      ),
+    );
+    const position = LatLng(35, 135);
+    final points = [
+      for (var index = 0; index < 3; index += 1)
+        AnitabiPoint(
+          bangumiId: 3001,
+          id: 'overlap-$index',
+          name: '重合点位 ${index + 1}',
+          subtitle: '场景 ${index + 1}',
+          position: position,
+          episodeLabel: 'EP ${index + 1}',
+          referenceImageUrl: null,
+          origin: 'Anitabi',
+          originUrl: 'https://anitabi.cn/',
+        ),
+    ];
+    final anitabiClient = _FakeAnitabiClient(pointsByBangumi: {3001: points});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AnitabiMapImportScreen(
+          plan: planWithWork,
+          repository: repository,
+          initialSettings: settings,
+          anitabiClient: anitabiClient,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final map = tester.widget<FlutterMap>(find.byType(FlutterMap));
+    map.mapController!.move(position, 24);
+    await tester.pumpAndSettle();
+    final cluster = tester.widget<MapMarkerClusterBadge>(
+      find.byType(MapMarkerClusterBadge),
+    );
+    expect(cluster.opensPointBrowser, isTrue);
+    cluster.onTap();
+    await tester.pump();
+
+    expect(find.text('重合点位  1 / 3'), findsOneWidget);
+    tester
+        .widget<IconButton>(find.byKey(const ValueKey('map-overlap-next')))
+        .onPressed!();
+    await tester.pump();
+    expect(find.text('重合点位  2 / 3'), findsOneWidget);
+    expect(find.text('重合点位 2'), findsOneWidget);
   });
 
   testWidgets('Anitabi initial Bangumi load failure does not add work', (


### PR DESCRIPTION
## 概述

- 优化计划管理、片区选择与重合点位切换的交互和视觉效果。
- 重做记录页作品、片区筛选为两级多选弹窗，保留底部确认操作。
- 改进作品地图与 Anitabi 导入页面的重合点位控制和搜索清除交互。
- 增加片区进度显示：完成片区仅显示对勾，未完成片区可显示进度背景。
- 在外观设置中提供“显示片区进度条”开关，并完成本地与桌面状态持久化。

## 测试

- 运行 Flutter 静态分析。
- 运行计划片区完成状态、记录筛选和设置页归属相关组件测试。
- 运行桌面状态序列化与 SQLite 设置持久化测试。