### PR TITLE
feat: hide completed map points and polish plan, record, and settings UI

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -162,6 +162,62 @@ class AppTheme {
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
       ),
+      popupMenuTheme: PopupMenuThemeData(
+        color: AppColors.surface,
+        surfaceTintColor: Colors.transparent,
+        elevation: 8,
+        shadowColor: Colors.black.withValues(alpha: 0.16),
+        menuPadding: const EdgeInsets.symmetric(vertical: 4),
+        position: PopupMenuPosition.under,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+          side: const BorderSide(color: AppColors.border),
+        ),
+        textStyle: const TextStyle(
+          color: AppColors.textPrimary,
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+      ),
+      menuTheme: MenuThemeData(
+        style: MenuStyle(
+          backgroundColor: WidgetStatePropertyAll(AppColors.surface),
+          surfaceTintColor: const WidgetStatePropertyAll(Colors.transparent),
+          elevation: const WidgetStatePropertyAll(8),
+          shadowColor: WidgetStatePropertyAll(
+            Colors.black.withValues(alpha: 0.16),
+          ),
+          padding: const WidgetStatePropertyAll(
+            EdgeInsets.symmetric(vertical: 4),
+          ),
+          side: const WidgetStatePropertyAll(
+            BorderSide(color: AppColors.border),
+          ),
+          shape: WidgetStatePropertyAll(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          ),
+        ),
+      ),
+      menuButtonTheme: MenuButtonThemeData(
+        style: ButtonStyle(
+          foregroundColor: const WidgetStatePropertyAll(AppColors.textPrimary),
+          minimumSize: const WidgetStatePropertyAll(Size(0, 44)),
+          padding: const WidgetStatePropertyAll(
+            EdgeInsets.symmetric(horizontal: 12),
+          ),
+          textStyle: const WidgetStatePropertyAll(
+            TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0,
+            ),
+          ),
+          shape: WidgetStatePropertyAll(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
+          ),
+        ),
+      ),
       sliderTheme: base.sliderTheme.copyWith(
         activeTrackColor: AppColors.accent,
         inactiveTrackColor: AppColors.border,

--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -84,6 +84,8 @@ class AppColors {
 class AppTheme {
   const AppTheme._();
 
+  static const double appBarHeight = kToolbarHeight;
+
   static ThemeData light({
     AppThemePalette palette = AppThemePalette.classicGreen,
     int customAccentValue = 0xFF16C6A8,
@@ -115,6 +117,7 @@ class AppTheme {
         backgroundColor: AppColors.background,
         foregroundColor: AppColors.textPrimary,
         elevation: 0,
+        toolbarHeight: AppTheme.appBarHeight,
         centerTitle: false,
         titleTextStyle: TextStyle(
           color: AppColors.textPrimary,

--- a/lib/camera_reference/camerawesome_reference_screen.dart
+++ b/lib/camera_reference/camerawesome_reference_screen.dart
@@ -1444,7 +1444,8 @@ class _NativeCameraTopBar extends StatelessWidget {
       child: Row(
         children: [
           _CameraCircleButton(
-            tooltip: '返回',
+            tooltip: null,
+            semanticLabel: '返回',
             icon: Icons.arrow_back,
             onPressed: () => Navigator.of(context).maybePop(),
           ),
@@ -1675,7 +1676,8 @@ class _NativeLandscapeLeftRail extends StatelessWidget {
               _CameraCircleButton(
                 size: metrics.controlButtonSize,
                 iconSize: metrics.controlIconSize,
-                tooltip: '返回',
+                tooltip: null,
+                semanticLabel: '返回',
                 icon: Icons.arrow_back,
                 onPressed: onBack,
               ),
@@ -2454,7 +2456,8 @@ class _CameraTopBar extends StatelessWidget {
       child: Row(
         children: [
           _CameraCircleButton(
-            tooltip: '返回',
+            tooltip: null,
+            semanticLabel: '返回',
             icon: Icons.arrow_back,
             onPressed: () => Navigator.of(context).maybePop(),
           ),
@@ -2655,6 +2658,7 @@ class _CameraCircleButton extends StatelessWidget {
     required this.icon,
     required this.onPressed,
     this.text,
+    this.semanticLabel,
     this.size = 44,
     this.iconSize = 21,
   });
@@ -2663,6 +2667,7 @@ class _CameraCircleButton extends StatelessWidget {
   final IconData icon;
   final VoidCallback onPressed;
   final String? text;
+  final String? semanticLabel;
   final double size;
   final double iconSize;
 
@@ -2681,7 +2686,18 @@ class _CameraCircleButton extends StatelessWidget {
         shape: const CircleBorder(),
       ),
       onPressed: onPressed,
-      icon: _CameraButtonIcon(icon: icon, iconSize: iconSize, text: text),
+      icon: semanticLabel == null
+          ? _CameraButtonIcon(icon: icon, iconSize: iconSize, text: text)
+          : Semantics(
+              label: semanticLabel,
+              child: ExcludeSemantics(
+                child: _CameraButtonIcon(
+                  icon: icon,
+                  iconSize: iconSize,
+                  text: text,
+                ),
+              ),
+            ),
     );
     return SizedBox.square(dimension: size, child: button);
   }
@@ -3727,9 +3743,8 @@ class _FallbackTopBar extends StatelessWidget {
       child: Row(
         children: [
           IconButton(
-            tooltip: '返回',
             onPressed: () => Navigator.of(context).maybePop(),
-            icon: const Icon(Icons.arrow_back),
+            icon: const Icon(Icons.arrow_back, semanticLabel: '返回'),
           ),
           Expanded(
             child: Text(

--- a/lib/camera_reference/visit_record_confirmation_screen.dart
+++ b/lib/camera_reference/visit_record_confirmation_screen.dart
@@ -13,6 +13,7 @@ import '../records/visit_record_photo_stub.dart'
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/anitabi_network_image.dart';
 import '../widgets/reference_image_placeholder.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/reference_image_source_stub.dart'
     if (dart.library.io) '../widgets/reference_image_source_io.dart';
 import '../widgets/reference_thumbnail_stub.dart'
@@ -234,7 +235,10 @@ class _VisitRecordConfirmationScreenState
         }
       },
       child: Scaffold(
-        appBar: AppBar(title: const Text('确认记录')),
+        appBar: AppBar(
+          leading: appBackButtonIfCanPop(context),
+          title: const Text('确认记录'),
+        ),
         body: ListView(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
           children: [

--- a/lib/color_grading/color_grading_screen.dart
+++ b/lib/color_grading/color_grading_screen.dart
@@ -11,6 +11,7 @@ import '../plan/pilgrimage_plan_controller.dart';
 import '../records/visit_record_photo_stub.dart'
     if (dart.library.io) '../records/visit_record_photo_io.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'color_adjustment.dart';
 import 'color_grading_params.dart';
 import 'graded_photo_storage_stub.dart'
@@ -271,6 +272,7 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: const Text('自动调色'),
         actions: [TextButton(onPressed: _reset, child: const Text('重置'))],
       ),

--- a/lib/data/local/app_database.dart
+++ b/lib/data/local/app_database.dart
@@ -172,6 +172,8 @@ class AppSettingsEntries extends Table {
       boolean().withDefault(const Constant(true))();
   BoolColumn get dismissPlanActionsOnOutsideTap =>
       boolean().withDefault(const Constant(true))();
+  BoolColumn get hideCompletedPointsOnMap =>
+      boolean().withDefault(const Constant(true))();
   BoolColumn get mapMarkerClusteringEnabled =>
       boolean().withDefault(const Constant(true))();
   IntColumn get mapMarkerClusterRadius =>
@@ -194,7 +196,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 39;
+  int get schemaVersion => 40;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -635,6 +637,15 @@ class AppDatabase extends _$AppDatabase {
           'dismiss_plan_actions_on_outside_tap',
           appSettingsEntries,
           appSettingsEntries.dismissPlanActionsOnOutsideTap,
+        );
+      }
+      if (from < 40) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'hide_completed_points_on_map',
+          appSettingsEntries,
+          appSettingsEntries.hideCompletedPointsOnMap,
         );
       }
     },

--- a/lib/data/local/app_database.dart
+++ b/lib/data/local/app_database.dart
@@ -170,6 +170,8 @@ class AppSettingsEntries extends Table {
       integer().withDefault(const Constant(10))();
   BoolColumn get showPlanGroupProgress =>
       boolean().withDefault(const Constant(true))();
+  BoolColumn get dismissPlanActionsOnOutsideTap =>
+      boolean().withDefault(const Constant(true))();
   BoolColumn get mapMarkerClusteringEnabled =>
       boolean().withDefault(const Constant(true))();
   IntColumn get mapMarkerClusterRadius =>
@@ -192,7 +194,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 38;
+  int get schemaVersion => 39;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -624,6 +626,15 @@ class AppDatabase extends _$AppDatabase {
           'photo_location_strategy',
           appSettingsEntries,
           appSettingsEntries.photoLocationStrategy,
+        );
+      }
+      if (from < 39) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'dismiss_plan_actions_on_outside_tap',
+          appSettingsEntries,
+          appSettingsEntries.dismissPlanActionsOnOutsideTap,
         );
       }
     },

--- a/lib/data/local/app_database.g.dart
+++ b/lib/data/local/app_database.g.dart
@@ -4590,6 +4590,21 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
         defaultValue: const Constant(true),
       );
+  static const VerificationMeta _hideCompletedPointsOnMapMeta =
+      const VerificationMeta('hideCompletedPointsOnMap');
+  @override
+  late final GeneratedColumn<bool> hideCompletedPointsOnMap =
+      GeneratedColumn<bool>(
+        'hide_completed_points_on_map',
+        aliasedName,
+        false,
+        type: DriftSqlType.bool,
+        requiredDuringInsert: false,
+        defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("hide_completed_points_on_map" IN (0, 1))',
+        ),
+        defaultValue: const Constant(true),
+      );
   static const VerificationMeta _mapMarkerClusteringEnabledMeta =
       const VerificationMeta('mapMarkerClusteringEnabled');
   @override
@@ -4704,6 +4719,7 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
     mapThumbnailConcurrentLoads,
     showPlanGroupProgress,
     dismissPlanActionsOnOutsideTap,
+    hideCompletedPointsOnMap,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -5052,6 +5068,15 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
       );
     }
+    if (data.containsKey('hide_completed_points_on_map')) {
+      context.handle(
+        _hideCompletedPointsOnMapMeta,
+        hideCompletedPointsOnMap.isAcceptableOrUnknown(
+          data['hide_completed_points_on_map']!,
+          _hideCompletedPointsOnMapMeta,
+        ),
+      );
+    }
     if (data.containsKey('map_marker_clustering_enabled')) {
       context.handle(
         _mapMarkerClusteringEnabledMeta,
@@ -5267,6 +5292,10 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         DriftSqlType.bool,
         data['${effectivePrefix}dismiss_plan_actions_on_outside_tap'],
       )!,
+      hideCompletedPointsOnMap: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}hide_completed_points_on_map'],
+      )!,
       mapMarkerClusteringEnabled: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}map_marker_clustering_enabled'],
@@ -5340,6 +5369,7 @@ class AppSettingsEntry extends DataClass
   final int mapThumbnailConcurrentLoads;
   final bool showPlanGroupProgress;
   final bool dismissPlanActionsOnOutsideTap;
+  final bool hideCompletedPointsOnMap;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -5385,6 +5415,7 @@ class AppSettingsEntry extends DataClass
     required this.mapThumbnailConcurrentLoads,
     required this.showPlanGroupProgress,
     required this.dismissPlanActionsOnOutsideTap,
+    required this.hideCompletedPointsOnMap,
     required this.mapMarkerClusteringEnabled,
     required this.mapMarkerClusterRadius,
     required this.mapMarkerClusterMaxZoom,
@@ -5465,6 +5496,9 @@ class AppSettingsEntry extends DataClass
     map['dismiss_plan_actions_on_outside_tap'] = Variable<bool>(
       dismissPlanActionsOnOutsideTap,
     );
+    map['hide_completed_points_on_map'] = Variable<bool>(
+      hideCompletedPointsOnMap,
+    );
     map['map_marker_clustering_enabled'] = Variable<bool>(
       mapMarkerClusteringEnabled,
     );
@@ -5518,6 +5552,7 @@ class AppSettingsEntry extends DataClass
       mapThumbnailConcurrentLoads: Value(mapThumbnailConcurrentLoads),
       showPlanGroupProgress: Value(showPlanGroupProgress),
       dismissPlanActionsOnOutsideTap: Value(dismissPlanActionsOnOutsideTap),
+      hideCompletedPointsOnMap: Value(hideCompletedPointsOnMap),
       mapMarkerClusteringEnabled: Value(mapMarkerClusteringEnabled),
       mapMarkerClusterRadius: Value(mapMarkerClusterRadius),
       mapMarkerClusterMaxZoom: Value(mapMarkerClusterMaxZoom),
@@ -5621,6 +5656,9 @@ class AppSettingsEntry extends DataClass
       dismissPlanActionsOnOutsideTap: serializer.fromJson<bool>(
         json['dismissPlanActionsOnOutsideTap'],
       ),
+      hideCompletedPointsOnMap: serializer.fromJson<bool>(
+        json['hideCompletedPointsOnMap'],
+      ),
       mapMarkerClusteringEnabled: serializer.fromJson<bool>(
         json['mapMarkerClusteringEnabled'],
       ),
@@ -5711,6 +5749,9 @@ class AppSettingsEntry extends DataClass
       'dismissPlanActionsOnOutsideTap': serializer.toJson<bool>(
         dismissPlanActionsOnOutsideTap,
       ),
+      'hideCompletedPointsOnMap': serializer.toJson<bool>(
+        hideCompletedPointsOnMap,
+      ),
       'mapMarkerClusteringEnabled': serializer.toJson<bool>(
         mapMarkerClusteringEnabled,
       ),
@@ -5765,6 +5806,7 @@ class AppSettingsEntry extends DataClass
     int? mapThumbnailConcurrentLoads,
     bool? showPlanGroupProgress,
     bool? dismissPlanActionsOnOutsideTap,
+    bool? hideCompletedPointsOnMap,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -5826,6 +5868,8 @@ class AppSettingsEntry extends DataClass
     showPlanGroupProgress: showPlanGroupProgress ?? this.showPlanGroupProgress,
     dismissPlanActionsOnOutsideTap:
         dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
+    hideCompletedPointsOnMap:
+        hideCompletedPointsOnMap ?? this.hideCompletedPointsOnMap,
     mapMarkerClusteringEnabled:
         mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
     mapMarkerClusterRadius:
@@ -5947,6 +5991,9 @@ class AppSettingsEntry extends DataClass
           data.dismissPlanActionsOnOutsideTap.present
           ? data.dismissPlanActionsOnOutsideTap.value
           : this.dismissPlanActionsOnOutsideTap,
+      hideCompletedPointsOnMap: data.hideCompletedPointsOnMap.present
+          ? data.hideCompletedPointsOnMap.value
+          : this.hideCompletedPointsOnMap,
       mapMarkerClusteringEnabled: data.mapMarkerClusteringEnabled.present
           ? data.mapMarkerClusteringEnabled.value
           : this.mapMarkerClusteringEnabled,
@@ -6019,6 +6066,7 @@ class AppSettingsEntry extends DataClass
           ..write(
             'dismissPlanActionsOnOutsideTap: $dismissPlanActionsOnOutsideTap, ',
           )
+          ..write('hideCompletedPointsOnMap: $hideCompletedPointsOnMap, ')
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -6069,6 +6117,7 @@ class AppSettingsEntry extends DataClass
     mapThumbnailConcurrentLoads,
     showPlanGroupProgress,
     dismissPlanActionsOnOutsideTap,
+    hideCompletedPointsOnMap,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -6127,6 +6176,7 @@ class AppSettingsEntry extends DataClass
           other.showPlanGroupProgress == this.showPlanGroupProgress &&
           other.dismissPlanActionsOnOutsideTap ==
               this.dismissPlanActionsOnOutsideTap &&
+          other.hideCompletedPointsOnMap == this.hideCompletedPointsOnMap &&
           other.mapMarkerClusteringEnabled == this.mapMarkerClusteringEnabled &&
           other.mapMarkerClusterRadius == this.mapMarkerClusterRadius &&
           other.mapMarkerClusterMaxZoom == this.mapMarkerClusterMaxZoom &&
@@ -6174,6 +6224,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
   final Value<int> mapThumbnailConcurrentLoads;
   final Value<bool> showPlanGroupProgress;
   final Value<bool> dismissPlanActionsOnOutsideTap;
+  final Value<bool> hideCompletedPointsOnMap;
   final Value<bool> mapMarkerClusteringEnabled;
   final Value<int> mapMarkerClusterRadius;
   final Value<int> mapMarkerClusterMaxZoom;
@@ -6220,6 +6271,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.mapThumbnailConcurrentLoads = const Value.absent(),
     this.showPlanGroupProgress = const Value.absent(),
     this.dismissPlanActionsOnOutsideTap = const Value.absent(),
+    this.hideCompletedPointsOnMap = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -6267,6 +6319,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.mapThumbnailConcurrentLoads = const Value.absent(),
     this.showPlanGroupProgress = const Value.absent(),
     this.dismissPlanActionsOnOutsideTap = const Value.absent(),
+    this.hideCompletedPointsOnMap = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -6314,6 +6367,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Expression<int>? mapThumbnailConcurrentLoads,
     Expression<bool>? showPlanGroupProgress,
     Expression<bool>? dismissPlanActionsOnOutsideTap,
+    Expression<bool>? hideCompletedPointsOnMap,
     Expression<bool>? mapMarkerClusteringEnabled,
     Expression<int>? mapMarkerClusterRadius,
     Expression<int>? mapMarkerClusterMaxZoom,
@@ -6386,6 +6440,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         'show_plan_group_progress': showPlanGroupProgress,
       if (dismissPlanActionsOnOutsideTap != null)
         'dismiss_plan_actions_on_outside_tap': dismissPlanActionsOnOutsideTap,
+      if (hideCompletedPointsOnMap != null)
+        'hide_completed_points_on_map': hideCompletedPointsOnMap,
       if (mapMarkerClusteringEnabled != null)
         'map_marker_clustering_enabled': mapMarkerClusteringEnabled,
       if (mapMarkerClusterRadius != null)
@@ -6439,6 +6495,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Value<int>? mapThumbnailConcurrentLoads,
     Value<bool>? showPlanGroupProgress,
     Value<bool>? dismissPlanActionsOnOutsideTap,
+    Value<bool>? hideCompletedPointsOnMap,
     Value<bool>? mapMarkerClusteringEnabled,
     Value<int>? mapMarkerClusterRadius,
     Value<int>? mapMarkerClusterMaxZoom,
@@ -6507,6 +6564,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           showPlanGroupProgress ?? this.showPlanGroupProgress,
       dismissPlanActionsOnOutsideTap:
           dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
+      hideCompletedPointsOnMap:
+          hideCompletedPointsOnMap ?? this.hideCompletedPointsOnMap,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:
@@ -6684,6 +6743,11 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         dismissPlanActionsOnOutsideTap.value,
       );
     }
+    if (hideCompletedPointsOnMap.present) {
+      map['hide_completed_points_on_map'] = Variable<bool>(
+        hideCompletedPointsOnMap.value,
+      );
+    }
     if (mapMarkerClusteringEnabled.present) {
       map['map_marker_clustering_enabled'] = Variable<bool>(
         mapMarkerClusteringEnabled.value,
@@ -6767,6 +6831,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           ..write(
             'dismissPlanActionsOnOutsideTap: $dismissPlanActionsOnOutsideTap, ',
           )
+          ..write('hideCompletedPointsOnMap: $hideCompletedPointsOnMap, ')
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -9678,6 +9743,7 @@ typedef $$AppSettingsEntriesTableCreateCompanionBuilder =
       Value<int> mapThumbnailConcurrentLoads,
       Value<bool> showPlanGroupProgress,
       Value<bool> dismissPlanActionsOnOutsideTap,
+      Value<bool> hideCompletedPointsOnMap,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9726,6 +9792,7 @@ typedef $$AppSettingsEntriesTableUpdateCompanionBuilder =
       Value<int> mapThumbnailConcurrentLoads,
       Value<bool> showPlanGroupProgress,
       Value<bool> dismissPlanActionsOnOutsideTap,
+      Value<bool> hideCompletedPointsOnMap,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9931,6 +9998,11 @@ class $$AppSettingsEntriesTableFilterComposer
 
   ColumnFilters<bool> get dismissPlanActionsOnOutsideTap => $composableBuilder(
     column: $table.dismissPlanActionsOnOutsideTap,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get hideCompletedPointsOnMap => $composableBuilder(
+    column: $table.hideCompletedPointsOnMap,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -10168,6 +10240,11 @@ class $$AppSettingsEntriesTableOrderingComposer
         builder: (column) => ColumnOrderings(column),
       );
 
+  ColumnOrderings<bool> get hideCompletedPointsOnMap => $composableBuilder(
+    column: $table.hideCompletedPointsOnMap,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => ColumnOrderings(column),
@@ -10394,6 +10471,11 @@ class $$AppSettingsEntriesTableAnnotationComposer
         builder: (column) => column,
       );
 
+  GeneratedColumn<bool> get hideCompletedPointsOnMap => $composableBuilder(
+    column: $table.hideCompletedPointsOnMap,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => column,
@@ -10509,6 +10591,7 @@ class $$AppSettingsEntriesTableTableManager
                 Value<bool> showPlanGroupProgress = const Value.absent(),
                 Value<bool> dismissPlanActionsOnOutsideTap =
                     const Value.absent(),
+                Value<bool> hideCompletedPointsOnMap = const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -10555,6 +10638,7 @@ class $$AppSettingsEntriesTableTableManager
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
                 showPlanGroupProgress: showPlanGroupProgress,
                 dismissPlanActionsOnOutsideTap: dismissPlanActionsOnOutsideTap,
+                hideCompletedPointsOnMap: hideCompletedPointsOnMap,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,
@@ -10609,6 +10693,7 @@ class $$AppSettingsEntriesTableTableManager
                 Value<bool> showPlanGroupProgress = const Value.absent(),
                 Value<bool> dismissPlanActionsOnOutsideTap =
                     const Value.absent(),
+                Value<bool> hideCompletedPointsOnMap = const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -10655,6 +10740,7 @@ class $$AppSettingsEntriesTableTableManager
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
                 showPlanGroupProgress: showPlanGroupProgress,
                 dismissPlanActionsOnOutsideTap: dismissPlanActionsOnOutsideTap,
+                hideCompletedPointsOnMap: hideCompletedPointsOnMap,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,

--- a/lib/data/local/app_database.g.dart
+++ b/lib/data/local/app_database.g.dart
@@ -4575,6 +4575,21 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
         defaultValue: const Constant(true),
       );
+  static const VerificationMeta _dismissPlanActionsOnOutsideTapMeta =
+      const VerificationMeta('dismissPlanActionsOnOutsideTap');
+  @override
+  late final GeneratedColumn<bool> dismissPlanActionsOnOutsideTap =
+      GeneratedColumn<bool>(
+        'dismiss_plan_actions_on_outside_tap',
+        aliasedName,
+        false,
+        type: DriftSqlType.bool,
+        requiredDuringInsert: false,
+        defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("dismiss_plan_actions_on_outside_tap" IN (0, 1))',
+        ),
+        defaultValue: const Constant(true),
+      );
   static const VerificationMeta _mapMarkerClusteringEnabledMeta =
       const VerificationMeta('mapMarkerClusteringEnabled');
   @override
@@ -4688,6 +4703,7 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
     mapThumbnailVisibleThreshold,
     mapThumbnailConcurrentLoads,
     showPlanGroupProgress,
+    dismissPlanActionsOnOutsideTap,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -5027,6 +5043,15 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
       );
     }
+    if (data.containsKey('dismiss_plan_actions_on_outside_tap')) {
+      context.handle(
+        _dismissPlanActionsOnOutsideTapMeta,
+        dismissPlanActionsOnOutsideTap.isAcceptableOrUnknown(
+          data['dismiss_plan_actions_on_outside_tap']!,
+          _dismissPlanActionsOnOutsideTapMeta,
+        ),
+      );
+    }
     if (data.containsKey('map_marker_clustering_enabled')) {
       context.handle(
         _mapMarkerClusteringEnabledMeta,
@@ -5238,6 +5263,10 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         DriftSqlType.bool,
         data['${effectivePrefix}show_plan_group_progress'],
       )!,
+      dismissPlanActionsOnOutsideTap: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}dismiss_plan_actions_on_outside_tap'],
+      )!,
       mapMarkerClusteringEnabled: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}map_marker_clustering_enabled'],
@@ -5310,6 +5339,7 @@ class AppSettingsEntry extends DataClass
   final int mapThumbnailVisibleThreshold;
   final int mapThumbnailConcurrentLoads;
   final bool showPlanGroupProgress;
+  final bool dismissPlanActionsOnOutsideTap;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -5354,6 +5384,7 @@ class AppSettingsEntry extends DataClass
     required this.mapThumbnailVisibleThreshold,
     required this.mapThumbnailConcurrentLoads,
     required this.showPlanGroupProgress,
+    required this.dismissPlanActionsOnOutsideTap,
     required this.mapMarkerClusteringEnabled,
     required this.mapMarkerClusterRadius,
     required this.mapMarkerClusterMaxZoom,
@@ -5431,6 +5462,9 @@ class AppSettingsEntry extends DataClass
       mapThumbnailConcurrentLoads,
     );
     map['show_plan_group_progress'] = Variable<bool>(showPlanGroupProgress);
+    map['dismiss_plan_actions_on_outside_tap'] = Variable<bool>(
+      dismissPlanActionsOnOutsideTap,
+    );
     map['map_marker_clustering_enabled'] = Variable<bool>(
       mapMarkerClusteringEnabled,
     );
@@ -5483,6 +5517,7 @@ class AppSettingsEntry extends DataClass
       mapThumbnailVisibleThreshold: Value(mapThumbnailVisibleThreshold),
       mapThumbnailConcurrentLoads: Value(mapThumbnailConcurrentLoads),
       showPlanGroupProgress: Value(showPlanGroupProgress),
+      dismissPlanActionsOnOutsideTap: Value(dismissPlanActionsOnOutsideTap),
       mapMarkerClusteringEnabled: Value(mapMarkerClusteringEnabled),
       mapMarkerClusterRadius: Value(mapMarkerClusterRadius),
       mapMarkerClusterMaxZoom: Value(mapMarkerClusterMaxZoom),
@@ -5583,6 +5618,9 @@ class AppSettingsEntry extends DataClass
       showPlanGroupProgress: serializer.fromJson<bool>(
         json['showPlanGroupProgress'],
       ),
+      dismissPlanActionsOnOutsideTap: serializer.fromJson<bool>(
+        json['dismissPlanActionsOnOutsideTap'],
+      ),
       mapMarkerClusteringEnabled: serializer.fromJson<bool>(
         json['mapMarkerClusteringEnabled'],
       ),
@@ -5670,6 +5708,9 @@ class AppSettingsEntry extends DataClass
         mapThumbnailConcurrentLoads,
       ),
       'showPlanGroupProgress': serializer.toJson<bool>(showPlanGroupProgress),
+      'dismissPlanActionsOnOutsideTap': serializer.toJson<bool>(
+        dismissPlanActionsOnOutsideTap,
+      ),
       'mapMarkerClusteringEnabled': serializer.toJson<bool>(
         mapMarkerClusteringEnabled,
       ),
@@ -5723,6 +5764,7 @@ class AppSettingsEntry extends DataClass
     int? mapThumbnailVisibleThreshold,
     int? mapThumbnailConcurrentLoads,
     bool? showPlanGroupProgress,
+    bool? dismissPlanActionsOnOutsideTap,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -5782,6 +5824,8 @@ class AppSettingsEntry extends DataClass
     mapThumbnailConcurrentLoads:
         mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
     showPlanGroupProgress: showPlanGroupProgress ?? this.showPlanGroupProgress,
+    dismissPlanActionsOnOutsideTap:
+        dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
     mapMarkerClusteringEnabled:
         mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
     mapMarkerClusterRadius:
@@ -5899,6 +5943,10 @@ class AppSettingsEntry extends DataClass
       showPlanGroupProgress: data.showPlanGroupProgress.present
           ? data.showPlanGroupProgress.value
           : this.showPlanGroupProgress,
+      dismissPlanActionsOnOutsideTap:
+          data.dismissPlanActionsOnOutsideTap.present
+          ? data.dismissPlanActionsOnOutsideTap.value
+          : this.dismissPlanActionsOnOutsideTap,
       mapMarkerClusteringEnabled: data.mapMarkerClusteringEnabled.present
           ? data.mapMarkerClusteringEnabled.value
           : this.mapMarkerClusteringEnabled,
@@ -5968,6 +6016,9 @@ class AppSettingsEntry extends DataClass
           )
           ..write('mapThumbnailConcurrentLoads: $mapThumbnailConcurrentLoads, ')
           ..write('showPlanGroupProgress: $showPlanGroupProgress, ')
+          ..write(
+            'dismissPlanActionsOnOutsideTap: $dismissPlanActionsOnOutsideTap, ',
+          )
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -6017,6 +6068,7 @@ class AppSettingsEntry extends DataClass
     mapThumbnailVisibleThreshold,
     mapThumbnailConcurrentLoads,
     showPlanGroupProgress,
+    dismissPlanActionsOnOutsideTap,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -6073,6 +6125,8 @@ class AppSettingsEntry extends DataClass
           other.mapThumbnailConcurrentLoads ==
               this.mapThumbnailConcurrentLoads &&
           other.showPlanGroupProgress == this.showPlanGroupProgress &&
+          other.dismissPlanActionsOnOutsideTap ==
+              this.dismissPlanActionsOnOutsideTap &&
           other.mapMarkerClusteringEnabled == this.mapMarkerClusteringEnabled &&
           other.mapMarkerClusterRadius == this.mapMarkerClusterRadius &&
           other.mapMarkerClusterMaxZoom == this.mapMarkerClusterMaxZoom &&
@@ -6119,6 +6173,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
   final Value<int> mapThumbnailVisibleThreshold;
   final Value<int> mapThumbnailConcurrentLoads;
   final Value<bool> showPlanGroupProgress;
+  final Value<bool> dismissPlanActionsOnOutsideTap;
   final Value<bool> mapMarkerClusteringEnabled;
   final Value<int> mapMarkerClusterRadius;
   final Value<int> mapMarkerClusterMaxZoom;
@@ -6164,6 +6219,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.mapThumbnailVisibleThreshold = const Value.absent(),
     this.mapThumbnailConcurrentLoads = const Value.absent(),
     this.showPlanGroupProgress = const Value.absent(),
+    this.dismissPlanActionsOnOutsideTap = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -6210,6 +6266,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.mapThumbnailVisibleThreshold = const Value.absent(),
     this.mapThumbnailConcurrentLoads = const Value.absent(),
     this.showPlanGroupProgress = const Value.absent(),
+    this.dismissPlanActionsOnOutsideTap = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -6256,6 +6313,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Expression<int>? mapThumbnailVisibleThreshold,
     Expression<int>? mapThumbnailConcurrentLoads,
     Expression<bool>? showPlanGroupProgress,
+    Expression<bool>? dismissPlanActionsOnOutsideTap,
     Expression<bool>? mapMarkerClusteringEnabled,
     Expression<int>? mapMarkerClusterRadius,
     Expression<int>? mapMarkerClusterMaxZoom,
@@ -6326,6 +6384,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         'map_thumbnail_concurrent_loads': mapThumbnailConcurrentLoads,
       if (showPlanGroupProgress != null)
         'show_plan_group_progress': showPlanGroupProgress,
+      if (dismissPlanActionsOnOutsideTap != null)
+        'dismiss_plan_actions_on_outside_tap': dismissPlanActionsOnOutsideTap,
       if (mapMarkerClusteringEnabled != null)
         'map_marker_clustering_enabled': mapMarkerClusteringEnabled,
       if (mapMarkerClusterRadius != null)
@@ -6378,6 +6438,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Value<int>? mapThumbnailVisibleThreshold,
     Value<int>? mapThumbnailConcurrentLoads,
     Value<bool>? showPlanGroupProgress,
+    Value<bool>? dismissPlanActionsOnOutsideTap,
     Value<bool>? mapMarkerClusteringEnabled,
     Value<int>? mapMarkerClusterRadius,
     Value<int>? mapMarkerClusterMaxZoom,
@@ -6444,6 +6505,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
       showPlanGroupProgress:
           showPlanGroupProgress ?? this.showPlanGroupProgress,
+      dismissPlanActionsOnOutsideTap:
+          dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:
@@ -6616,6 +6679,11 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         showPlanGroupProgress.value,
       );
     }
+    if (dismissPlanActionsOnOutsideTap.present) {
+      map['dismiss_plan_actions_on_outside_tap'] = Variable<bool>(
+        dismissPlanActionsOnOutsideTap.value,
+      );
+    }
     if (mapMarkerClusteringEnabled.present) {
       map['map_marker_clustering_enabled'] = Variable<bool>(
         mapMarkerClusteringEnabled.value,
@@ -6696,6 +6764,9 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           )
           ..write('mapThumbnailConcurrentLoads: $mapThumbnailConcurrentLoads, ')
           ..write('showPlanGroupProgress: $showPlanGroupProgress, ')
+          ..write(
+            'dismissPlanActionsOnOutsideTap: $dismissPlanActionsOnOutsideTap, ',
+          )
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -9606,6 +9677,7 @@ typedef $$AppSettingsEntriesTableCreateCompanionBuilder =
       Value<int> mapThumbnailVisibleThreshold,
       Value<int> mapThumbnailConcurrentLoads,
       Value<bool> showPlanGroupProgress,
+      Value<bool> dismissPlanActionsOnOutsideTap,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9653,6 +9725,7 @@ typedef $$AppSettingsEntriesTableUpdateCompanionBuilder =
       Value<int> mapThumbnailVisibleThreshold,
       Value<int> mapThumbnailConcurrentLoads,
       Value<bool> showPlanGroupProgress,
+      Value<bool> dismissPlanActionsOnOutsideTap,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9853,6 +9926,11 @@ class $$AppSettingsEntriesTableFilterComposer
 
   ColumnFilters<bool> get showPlanGroupProgress => $composableBuilder(
     column: $table.showPlanGroupProgress,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get dismissPlanActionsOnOutsideTap => $composableBuilder(
+    column: $table.dismissPlanActionsOnOutsideTap,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -10084,6 +10162,12 @@ class $$AppSettingsEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get dismissPlanActionsOnOutsideTap =>
+      $composableBuilder(
+        column: $table.dismissPlanActionsOnOutsideTap,
+        builder: (column) => ColumnOrderings(column),
+      );
+
   ColumnOrderings<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => ColumnOrderings(column),
@@ -10304,6 +10388,12 @@ class $$AppSettingsEntriesTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<bool> get dismissPlanActionsOnOutsideTap =>
+      $composableBuilder(
+        column: $table.dismissPlanActionsOnOutsideTap,
+        builder: (column) => column,
+      );
+
   GeneratedColumn<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => column,
@@ -10417,6 +10507,8 @@ class $$AppSettingsEntriesTableTableManager
                 Value<int> mapThumbnailVisibleThreshold = const Value.absent(),
                 Value<int> mapThumbnailConcurrentLoads = const Value.absent(),
                 Value<bool> showPlanGroupProgress = const Value.absent(),
+                Value<bool> dismissPlanActionsOnOutsideTap =
+                    const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -10462,6 +10554,7 @@ class $$AppSettingsEntriesTableTableManager
                 mapThumbnailVisibleThreshold: mapThumbnailVisibleThreshold,
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
                 showPlanGroupProgress: showPlanGroupProgress,
+                dismissPlanActionsOnOutsideTap: dismissPlanActionsOnOutsideTap,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,
@@ -10514,6 +10607,8 @@ class $$AppSettingsEntriesTableTableManager
                 Value<int> mapThumbnailVisibleThreshold = const Value.absent(),
                 Value<int> mapThumbnailConcurrentLoads = const Value.absent(),
                 Value<bool> showPlanGroupProgress = const Value.absent(),
+                Value<bool> dismissPlanActionsOnOutsideTap =
+                    const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -10559,6 +10654,7 @@ class $$AppSettingsEntriesTableTableManager
                 mapThumbnailVisibleThreshold: mapThumbnailVisibleThreshold,
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
                 showPlanGroupProgress: showPlanGroupProgress,
+                dismissPlanActionsOnOutsideTap: dismissPlanActionsOnOutsideTap,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,

--- a/lib/data/local/sqlite_pilgrimage_repository.dart
+++ b/lib/data/local/sqlite_pilgrimage_repository.dart
@@ -130,6 +130,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
       ),
       mapThumbnailConcurrentLoads: row.mapThumbnailConcurrentLoads.clamp(1, 30),
       showPlanGroupProgress: row.showPlanGroupProgress,
+      dismissPlanActionsOnOutsideTap: row.dismissPlanActionsOnOutsideTap,
       mapMarkerClusteringEnabled: row.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius: row.mapMarkerClusterRadius.clamp(32, 120),
       mapMarkerClusterMaxZoom: row.mapMarkerClusterMaxZoom.clamp(10, 22),
@@ -1173,6 +1174,9 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
               settings.mapThumbnailConcurrentLoads.clamp(1, 30),
             ),
             showPlanGroupProgress: Value(settings.showPlanGroupProgress),
+            dismissPlanActionsOnOutsideTap: Value(
+              settings.dismissPlanActionsOnOutsideTap,
+            ),
             mapMarkerClusteringEnabled: Value(
               settings.mapMarkerClusteringEnabled,
             ),

--- a/lib/data/local/sqlite_pilgrimage_repository.dart
+++ b/lib/data/local/sqlite_pilgrimage_repository.dart
@@ -131,6 +131,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
       mapThumbnailConcurrentLoads: row.mapThumbnailConcurrentLoads.clamp(1, 30),
       showPlanGroupProgress: row.showPlanGroupProgress,
       dismissPlanActionsOnOutsideTap: row.dismissPlanActionsOnOutsideTap,
+      hideCompletedPointsOnMap: row.hideCompletedPointsOnMap,
       mapMarkerClusteringEnabled: row.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius: row.mapMarkerClusterRadius.clamp(32, 120),
       mapMarkerClusterMaxZoom: row.mapMarkerClusterMaxZoom.clamp(10, 22),
@@ -1177,6 +1178,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
             dismissPlanActionsOnOutsideTap: Value(
               settings.dismissPlanActionsOnOutsideTap,
             ),
+            hideCompletedPointsOnMap: Value(settings.hideCompletedPointsOnMap),
             mapMarkerClusteringEnabled: Value(
               settings.mapMarkerClusteringEnabled,
             ),

--- a/lib/desktop/desktop_repository_state.dart
+++ b/lib/desktop/desktop_repository_state.dart
@@ -104,6 +104,7 @@ Map<String, Object?> _settingsJson(AppSettings settings) {
     'mapThumbnailVisibleThreshold': settings.mapThumbnailVisibleThreshold,
     'mapThumbnailConcurrentLoads': settings.mapThumbnailConcurrentLoads,
     'showPlanGroupProgress': settings.showPlanGroupProgress,
+    'dismissPlanActionsOnOutsideTap': settings.dismissPlanActionsOnOutsideTap,
     'mapMarkerClusteringEnabled': settings.mapMarkerClusteringEnabled,
     'mapMarkerClusterRadius': settings.mapMarkerClusterRadius,
     'mapMarkerClusterMaxZoom': settings.mapMarkerClusterMaxZoom,
@@ -215,6 +216,8 @@ AppSettings _settingsFromJson(Map<String, Object?> json) {
     mapThumbnailConcurrentLoads:
         _intValue(json['mapThumbnailConcurrentLoads']) ?? 10,
     showPlanGroupProgress: _boolValue(json['showPlanGroupProgress']) ?? true,
+    dismissPlanActionsOnOutsideTap:
+        _boolValue(json['dismissPlanActionsOnOutsideTap']) ?? true,
     mapMarkerClusteringEnabled:
         _boolValue(json['mapMarkerClusteringEnabled']) ?? true,
     mapMarkerClusterRadius: _intValue(json['mapMarkerClusterRadius']) ?? 40,

--- a/lib/desktop/desktop_repository_state.dart
+++ b/lib/desktop/desktop_repository_state.dart
@@ -105,6 +105,7 @@ Map<String, Object?> _settingsJson(AppSettings settings) {
     'mapThumbnailConcurrentLoads': settings.mapThumbnailConcurrentLoads,
     'showPlanGroupProgress': settings.showPlanGroupProgress,
     'dismissPlanActionsOnOutsideTap': settings.dismissPlanActionsOnOutsideTap,
+    'hideCompletedPointsOnMap': settings.hideCompletedPointsOnMap,
     'mapMarkerClusteringEnabled': settings.mapMarkerClusteringEnabled,
     'mapMarkerClusterRadius': settings.mapMarkerClusterRadius,
     'mapMarkerClusterMaxZoom': settings.mapMarkerClusterMaxZoom,
@@ -218,6 +219,8 @@ AppSettings _settingsFromJson(Map<String, Object?> json) {
     showPlanGroupProgress: _boolValue(json['showPlanGroupProgress']) ?? true,
     dismissPlanActionsOnOutsideTap:
         _boolValue(json['dismissPlanActionsOnOutsideTap']) ?? true,
+    hideCompletedPointsOnMap:
+        _boolValue(json['hideCompletedPointsOnMap']) ?? true,
     mapMarkerClusteringEnabled:
         _boolValue(json['mapMarkerClusteringEnabled']) ?? true,
     mapMarkerClusterRadius: _intValue(json['mapMarkerClusterRadius']) ?? 40,

--- a/lib/map/pilgrimage_map_screen.dart
+++ b/lib/map/pilgrimage_map_screen.dart
@@ -319,6 +319,16 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
     return visiblePoints.map((point) => point.id).toSet();
   }
 
+  bool _shouldShowPointOnMap(PilgrimagePoint point) {
+    if (!point.hasCoordinate) {
+      return false;
+    }
+    if (!widget.settings.hideCompletedPointsOnMap) {
+      return true;
+    }
+    return _controller.statusFor(point) != VisitStatus.completed;
+  }
+
   void _moveToCurrentTarget() {
     final currentPoint = _controller.currentPoint;
     if (currentPoint == null) {
@@ -507,7 +517,7 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
         ? _controller.currentPoint
         : null;
     final positionedPoints = _controller.points
-        .where((point) => point.hasCoordinate)
+        .where(_shouldShowPointOnMap)
         .toList(growable: false);
     final initialFocusPoint = (selectedPoint?.hasCoordinate ?? false)
         ? selectedPoint
@@ -527,7 +537,7 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
     final overlapPoints = <PilgrimagePoint>[];
     for (final pointId in _overlapPointBrowser?.pointIds ?? const <String>[]) {
       final point = _controller.pointById(pointId);
-      if (point != null && point.hasCoordinate) {
+      if (point != null && _shouldShowPointOnMap(point)) {
         overlapPoints.add(point);
       }
     }
@@ -622,7 +632,8 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
                               position: point.position,
                             ),
                           if (activeOverlapPointIds.isNotEmpty &&
-                              selectedPoint != null)
+                              selectedPoint != null &&
+                              _shouldShowPointOnMap(selectedPoint))
                             MapMarkerCluster(
                               items: [selectedPoint],
                               position: selectedPoint.position,
@@ -630,7 +641,8 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
                         ];
                   if (clusteringEnabled &&
                       activeOverlapPointIds.isNotEmpty &&
-                      selectedPoint != null) {
+                      selectedPoint != null &&
+                      _shouldShowPointOnMap(selectedPoint)) {
                     markerClusters.add(
                       MapMarkerCluster(
                         items: [selectedPoint],

--- a/lib/map/pilgrimage_map_screen.dart
+++ b/lib/map/pilgrimage_map_screen.dart
@@ -1055,55 +1055,62 @@ class _PointCard extends StatelessWidget {
             ),
             const SizedBox(height: 6),
           ],
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _PointThumbnail(controller: controller, point: point),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        _StatusBadge(status: status),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: CopyableText(
-                            text: point.name,
-                            copyLabel: '点位名称',
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              fontSize: 17,
-                              fontWeight: FontWeight.w800,
-                              letterSpacing: 0,
+          GestureDetector(
+            key: ValueKey('map-point-card-content-${point.id}'),
+            behavior: HitTestBehavior.opaque,
+            onTap: onOpenDetail,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _PointThumbnail(controller: controller, point: point),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          _StatusBadge(status: status),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: CopyableText(
+                              text: point.name,
+                              copyLabel: '点位名称',
+                              onTap: onOpenDetail,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                fontSize: 17,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
+                              ),
                             ),
                           ),
-                        ),
-                        if (recordCount > 0) ...[
-                          const SizedBox(width: 8),
-                          _MapRecordBadge(count: recordCount),
+                          if (recordCount > 0) ...[
+                            const SizedBox(width: 8),
+                            _MapRecordBadge(count: recordCount),
+                          ],
                         ],
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    CopyableText(
-                      text: _metaText,
-                      copyText: _copySummary,
-                      copyLabel: '点位信息',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        color: AppColors.textSecondary,
-                        fontSize: 13,
-                        letterSpacing: 0,
                       ),
-                    ),
-                  ],
+                      const SizedBox(height: 4),
+                      CopyableText(
+                        text: _metaText,
+                        copyText: _copySummary,
+                        copyLabel: '点位信息',
+                        onTap: onOpenDetail,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 13,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
           const SizedBox(height: 12),
           Row(
@@ -1117,9 +1124,9 @@ class _PointCard extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               IconButton.outlined(
-                tooltip: '点位详情',
-                onPressed: onOpenDetail,
-                icon: const Icon(Icons.info_outline),
+                tooltip: '导航',
+                onPressed: onOpenNavigation,
+                icon: const Icon(Icons.near_me_outlined),
               ),
               const SizedBox(width: 4),
               IconButton.outlined(

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/app_scaled_route.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/input_dialog.dart';
 import 'anitabi_map_import_screen.dart';
 import 'coordinate_parser.dart';
@@ -153,7 +154,10 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
         Navigator.of(context).pop(_didUpdate);
       },
       child: Scaffold(
-        appBar: AppBar(title: const Text('添加内容')),
+        appBar: AppBar(
+          leading: appBackButtonIfCanPop(context),
+          title: const Text('添加内容'),
+        ),
         body: ListView(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
           children: [
@@ -549,7 +553,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('搜索 Bangumi'),
-          leading: BackButton(
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didAdd),
           ),
         ),
@@ -983,7 +987,10 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
   Widget build(BuildContext context) {
     final hasLinkText = _linkController.text.isNotEmpty;
     return Scaffold(
-      appBar: AppBar(title: const Text('Anitabi 链接导入')),
+      appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
+        title: const Text('Anitabi 链接导入'),
+      ),
       body: Form(
         key: _formKey,
         child: ListView(
@@ -1478,7 +1485,7 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('手动添加作品'),
-          leading: BackButton(
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didAdd),
           ),
           actions: [
@@ -2342,6 +2349,7 @@ class _QuickManualPointFormScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: const Text('快速手动添加点位'),
         actions: [
           TextButton.icon(
@@ -3105,7 +3113,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: Text(_isEditing ? '编辑点位' : '手动添加点位'),
-          leading: BackButton(
+          leading: AppBackButton(
             onPressed: () {
               if (!_didCommitPendingReference) {
                 unawaited(
@@ -3635,7 +3643,10 @@ class _ManualPointMapPickerScreenState
     final selectedPosition = _selectedPosition;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('选择点位坐标')),
+      appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
+        title: const Text('选择点位坐标'),
+      ),
       body: Stack(
         children: [
           FlutterMap(

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -28,6 +28,7 @@ import '../widgets/map_thumbnail_marker.dart';
 import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
 import '../widgets/app_scaled_route.dart';
+import '../widgets/app_back_button.dart';
 import '../utils/limited_concurrency.dart';
 import '../utils/selected_item_order.dart';
 import 'nearest_group_assign_screen.dart';
@@ -1431,6 +1432,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
+          leading: appBackButtonIfCanPop(context),
           title: const Text('从作品地图导入'),
           actions: [
             Tooltip(

--- a/lib/plan/group_anchor_picker_screen.dart
+++ b/lib/plan/group_anchor_picker_screen.dart
@@ -4,6 +4,7 @@ import 'package:latlong2/latlong.dart';
 
 import '../app_theme.dart';
 import '../widgets/input_dialog.dart';
+import '../widgets/app_back_button.dart';
 import '../map/map_tile_config.dart';
 import '../map/map_marker_scale.dart';
 import '../utils/selected_item_order.dart';
@@ -80,6 +81,7 @@ class _GroupAnchorPickerScreenState extends State<GroupAnchorPickerScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: const Text('选择关键点'),
         actions: [
           TextButton(

--- a/lib/plan/nearest_group_assign_screen.dart
+++ b/lib/plan/nearest_group_assign_screen.dart
@@ -15,6 +15,7 @@ import '../utils/selected_item_order.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'pilgrimage_models.dart';
 import 'plan_group_utils.dart';
 
@@ -93,10 +94,8 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: const Text('最近分配'),
         ),
@@ -506,10 +505,8 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: const Text('框选分配'),
         ),

--- a/lib/plan/pilgrimage_models.dart
+++ b/lib/plan/pilgrimage_models.dart
@@ -196,6 +196,7 @@ class AppSettings {
     this.mapThumbnailVisibleThreshold = 40,
     this.mapThumbnailConcurrentLoads = 10,
     this.showPlanGroupProgress = true,
+    this.dismissPlanActionsOnOutsideTap = true,
     this.mapMarkerClusteringEnabled = true,
     this.mapMarkerClusterRadius = 40,
     this.mapMarkerClusterMaxZoom = 21,
@@ -240,6 +241,7 @@ class AppSettings {
   final int mapThumbnailVisibleThreshold;
   final int mapThumbnailConcurrentLoads;
   final bool showPlanGroupProgress;
+  final bool dismissPlanActionsOnOutsideTap;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -284,6 +286,7 @@ class AppSettings {
     int? mapThumbnailVisibleThreshold,
     int? mapThumbnailConcurrentLoads,
     bool? showPlanGroupProgress,
+    bool? dismissPlanActionsOnOutsideTap,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -348,6 +351,8 @@ class AppSettings {
           mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
       showPlanGroupProgress:
           showPlanGroupProgress ?? this.showPlanGroupProgress,
+      dismissPlanActionsOnOutsideTap:
+          dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:

--- a/lib/plan/pilgrimage_models.dart
+++ b/lib/plan/pilgrimage_models.dart
@@ -197,6 +197,7 @@ class AppSettings {
     this.mapThumbnailConcurrentLoads = 10,
     this.showPlanGroupProgress = true,
     this.dismissPlanActionsOnOutsideTap = true,
+    this.hideCompletedPointsOnMap = true,
     this.mapMarkerClusteringEnabled = true,
     this.mapMarkerClusterRadius = 40,
     this.mapMarkerClusterMaxZoom = 21,
@@ -242,6 +243,7 @@ class AppSettings {
   final int mapThumbnailConcurrentLoads;
   final bool showPlanGroupProgress;
   final bool dismissPlanActionsOnOutsideTap;
+  final bool hideCompletedPointsOnMap;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -287,6 +289,7 @@ class AppSettings {
     int? mapThumbnailConcurrentLoads,
     bool? showPlanGroupProgress,
     bool? dismissPlanActionsOnOutsideTap,
+    bool? hideCompletedPointsOnMap,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -353,6 +356,8 @@ class AppSettings {
           showPlanGroupProgress ?? this.showPlanGroupProgress,
       dismissPlanActionsOnOutsideTap:
           dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
+      hideCompletedPointsOnMap:
+          hideCompletedPointsOnMap ?? this.hideCompletedPointsOnMap,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:

--- a/lib/plan/plan_group_manager_screen.dart
+++ b/lib/plan/plan_group_manager_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/app_scaled_route.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
@@ -74,10 +75,8 @@ class _PlanGroupManagerScreenState extends State<PlanGroupManagerScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: const Text('片区管理'),
           actions: [

--- a/lib/plan/plan_manager_screen.dart
+++ b/lib/plan/plan_manager_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/copyable_text.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'pilgrimage_models.dart';
 
 Widget _cleanPlanReorderProxy(
@@ -290,6 +291,7 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: Text(_sorting ? '调整计划顺序' : '切换计划'),
         actions: [
           if (plans != null && plans.length > 1)

--- a/lib/plan/plan_memo_screen.dart
+++ b/lib/plan/plan_memo_screen.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../app_theme.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'pilgrimage_plan_controller.dart';
 
 class PlanMemoScreen extends StatefulWidget {
@@ -375,11 +376,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
-            icon: const Icon(Icons.arrow_back),
-            onPressed: _handleBack,
-          ),
+          leading: AppBackButton(onPressed: _handleBack),
           title: const Text('计划备忘录'),
           actions: [
             if (_isEditing) ...[

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -308,6 +308,7 @@ class _PlanScreenState extends State<PlanScreen> {
     return Scaffold(
       appBar: AppBar(
         toolbarHeight: kToolbarHeight,
+        actionsPadding: EdgeInsets.zero,
         title: Text(
           plan.name,
           maxLines: 1,
@@ -365,7 +366,6 @@ class _PlanScreenState extends State<PlanScreen> {
                 ),
               )
             else ...[
-              if (!_showMap && !_showPlanActions) _PlanMetaStrip(plan: plan),
               _PlanActionsReveal(
                 expanded: _showPlanActions,
                 padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
@@ -402,10 +402,8 @@ class _PlanScreenState extends State<PlanScreen> {
                 onCreateGroup: () => _createGroupFromPointDetail(context),
               ),
               _PlanGroupControls(
-                plan: plan,
                 group: selectedGroup,
                 showMap: _showMap,
-                showGroupSummary: !_showPlanActions,
                 sortMode: _sortMode,
                 sortDescending: _sortDescending,
                 mapHeightRatio: _mapHeightRatio,
@@ -1017,10 +1015,8 @@ class _GroupSwitcher extends StatelessWidget {
 
 class _PlanGroupControls extends StatelessWidget {
   const _PlanGroupControls({
-    required this.plan,
     required this.group,
     required this.showMap,
-    required this.showGroupSummary,
     required this.sortMode,
     required this.sortDescending,
     required this.mapHeightRatio,
@@ -1038,10 +1034,8 @@ class _PlanGroupControls extends StatelessWidget {
     required this.onSelectPoint,
   });
 
-  final PilgrimagePlan plan;
   final PlanGroupBucket group;
   final bool showMap;
-  final bool showGroupSummary;
   final PointSortMode sortMode;
   final bool sortDescending;
   final double mapHeightRatio;
@@ -1078,10 +1072,6 @@ class _PlanGroupControls extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 2),
       child: Column(
         children: [
-          if (!showMap && showGroupSummary) ...[
-            _GroupSummary(group: group),
-            const SizedBox(height: 12),
-          ],
           Row(
             children: [
               Expanded(
@@ -1124,109 +1114,6 @@ class _PlanGroupControls extends StatelessWidget {
             ),
           ],
         ],
-      ),
-    );
-  }
-}
-
-class _GroupSummary extends StatelessWidget {
-  const _GroupSummary({required this.group});
-
-  final PlanGroupBucket group;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      key: const ValueKey('plan-group-summary'),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        border: Border.all(color: AppColors.border),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(10, 8, 10, 8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(
-                  group.isUngrouped
-                      ? Icons.inventory_2_outlined
-                      : Icons.flag_outlined,
-                  color: AppColors.accentDark,
-                  size: 20,
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    group.anchorLabel,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 6),
-            Wrap(
-              spacing: 6,
-              runSpacing: 4,
-              children: [
-                _GroupMetric(label: '点位', value: '${group.points.length}'),
-                _GroupMetric(label: '完成', value: '${group.completedCount}'),
-                _GroupMetric(label: '模式', value: group.orderModeLabel),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _GroupMetric extends StatelessWidget {
-  const _GroupMetric({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: AppColors.surfaceMuted,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              value,
-              style: const TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w800,
-                letterSpacing: 0,
-              ),
-            ),
-            const SizedBox(width: 4),
-            Text(
-              label,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0,
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }
@@ -1964,43 +1851,6 @@ class _WorkHeader extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-
-  String _workCountText(PilgrimagePlan plan) {
-    final count = plan.works.isNotEmpty
-        ? plan.works.length
-        : plan.points.map((point) => point.work.id).toSet().length;
-    return '$count 部作品';
-  }
-}
-
-class _PlanMetaStrip extends StatelessWidget {
-  const _PlanMetaStrip({required this.plan});
-
-  final PilgrimagePlan plan;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      key: const ValueKey('plan-meta-strip'),
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-      child: SizedBox(
-        width: double.infinity,
-        child: Text(
-          '${plan.area} / ${plan.points.length} 个点位 / ${_workCountText(plan)}',
-          key: const ValueKey('plan-meta-text'),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.left,
-          style: const TextStyle(
-            color: AppColors.textSecondary,
-            fontSize: 13,
-            fontWeight: FontWeight.w700,
-            letterSpacing: 0,
-          ),
-        ),
       ),
     );
   }

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -55,6 +55,7 @@ class _PlanScreenState extends State<PlanScreen> {
   PointSortMode _sortMode = PointSortMode.plan;
   bool _sortDescending = false;
   bool _showMap = false;
+  bool _showPlanActions = false;
   bool _showVirtualLocation = false;
   bool _isLocating = false;
   bool _isCachingFullReferences = false;
@@ -63,6 +64,7 @@ class _PlanScreenState extends State<PlanScreen> {
   LatLng? _currentLocation;
   final _pointListController = ScrollController();
   final _pointTileKeys = <String, GlobalKey>{};
+  final _planActionsPanelRegionKey = GlobalKey();
 
   PilgrimagePlanController get controller => widget.controller;
 
@@ -202,6 +204,42 @@ class _PlanScreenState extends State<PlanScreen> {
     });
   }
 
+  void _togglePlanActions() {
+    setState(() {
+      _showPlanActions = !_showPlanActions;
+    });
+  }
+
+  void _collapsePlanActions() {
+    if (!_showPlanActions) {
+      return;
+    }
+    setState(() {
+      _showPlanActions = false;
+    });
+  }
+
+  void _openPlanAction(VoidCallback action) {
+    _collapsePlanActions();
+    action();
+  }
+
+  void _handlePlanBodyPointerDown(PointerDownEvent event) {
+    if (!_showPlanActions || !settings.dismissPlanActionsOnOutsideTap) {
+      return;
+    }
+    final renderBox =
+        _planActionsPanelRegionKey.currentContext?.findRenderObject()
+            as RenderBox?;
+    if (renderBox == null || !renderBox.hasSize) {
+      return;
+    }
+    final panelRect = renderBox.localToGlobal(Offset.zero) & renderBox.size;
+    if (!panelRect.contains(event.position)) {
+      _collapsePlanActions();
+    }
+  }
+
   Future<void> _toggleCurrentLocation() async {
     if (_showVirtualLocation && _currentLocation != null) {
       setState(() {
@@ -269,162 +307,163 @@ class _PlanScreenState extends State<PlanScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(plan.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+        toolbarHeight: kToolbarHeight,
+        title: Text(
+          plan.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w900),
+        ),
         actions: [
-          _ReferenceCacheIconButton(
-            isCaching: _isCachingFullReferences,
-            progress: _fullReferenceCacheProgress,
-            onPressed: _handleReferenceCachePressed,
+          IconButton(
+            key: const ValueKey('plan-switch-button'),
+            tooltip: '切换计划',
+            onPressed: widget.onOpenPlanManager,
+            icon: const Icon(Icons.swap_horiz),
           ),
-          PopupMenuButton<_PlanMenuAction>(
-            tooltip: '计划操作',
-            icon: const Icon(Icons.more_horiz),
-            onSelected: (action) {
-              switch (action) {
-                case _PlanMenuAction.switchPlan:
-                  widget.onOpenPlanManager();
-                case _PlanMenuAction.addPoints:
-                  widget.onOpenAddPoints();
-                case _PlanMenuAction.managePoints:
-                  widget.onOpenPointManager();
-                case _PlanMenuAction.memo:
-                  _openPlanMemo();
-                case _PlanMenuAction.importExport:
-                  widget.onOpenImportExport();
-              }
-            },
-            itemBuilder: (context) => const [
-              PopupMenuItem(
-                value: _PlanMenuAction.switchPlan,
-                child: ListTile(
-                  leading: Icon(Icons.swap_horiz),
-                  title: Text('切换计划'),
-                ),
-              ),
-              PopupMenuItem(
-                value: _PlanMenuAction.addPoints,
-                child: ListTile(
-                  leading: Icon(Icons.add_location_alt_outlined),
-                  title: Text('添加点位'),
-                ),
-              ),
-              PopupMenuItem(
-                value: _PlanMenuAction.managePoints,
-                child: ListTile(
-                  leading: Icon(Icons.tune_outlined),
-                  title: Text('管理计划'),
-                ),
-              ),
-              PopupMenuItem(
-                value: _PlanMenuAction.memo,
-                child: ListTile(
-                  leading: Icon(Icons.sticky_note_2_outlined),
-                  title: Text('计划备忘录'),
-                ),
-              ),
-              PopupMenuItem(
-                value: _PlanMenuAction.importExport,
-                child: ListTile(
-                  leading: Icon(Icons.import_export_outlined),
-                  title: Text('导入导出'),
-                ),
-              ),
-            ],
+          IconButton(
+            key: const ValueKey('plan-actions-toggle'),
+            tooltip: _showPlanActions ? '收起计划操作' : '展开计划操作',
+            onPressed: _togglePlanActions,
+            icon: Icon(
+              _showPlanActions ? Icons.expand_less : Icons.expand_more,
+            ),
           ),
         ],
       ),
-      body: Column(
-        children: [
-          if (selectedGroup == null || controller.points.isEmpty)
-            Expanded(
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
-                children: [
-                  _WorkHeader(plan: plan),
-                  const SizedBox(height: 16),
-                  _EmptyPlanCard(onAddPoints: widget.onOpenAddPoints),
-                ],
-              ),
-            )
-          else ...[
-            if (!_showMap) _PlanMetaStrip(plan: plan),
-            _GroupSwitcher(
-              groups: groups,
-              selectedIndex: _selectedGroupIndex,
-              showProgressRing: widget.settings.showPlanGroupProgress,
-              onSelectGroup: (group) {
-                final currentGroups = planGroupBuckets(
-                  controller.plan,
-                  controller.completedPointIds,
-                );
-                final index = currentGroups.indexWhere(
-                  (candidate) => candidate.id == group.id,
-                );
-                if (index >= 0) {
-                  _selectGroup(index, currentGroups);
-                }
-              },
-              onCreateGroup: () => _createGroupFromPointDetail(context),
-            ),
-            _PlanGroupControls(
-              plan: plan,
-              group: selectedGroup,
-              showMap: _showMap,
-              sortMode: _sortMode,
-              sortDescending: _sortDescending,
-              mapHeightRatio: _mapHeightRatio,
-              settings: settings,
-              showVirtualLocation: _showVirtualLocation,
-              isLocating: _isLocating,
-              currentLocation: _currentLocation,
-              selectedPointId: controller.selectedPoint?.id,
-              onSetSortMode: (mode) {
-                setState(() {
-                  _sortMode = mode;
-                });
-              },
-              onToggleSortDirection: () {
-                setState(() {
-                  _sortDescending = !_sortDescending;
-                });
-              },
-              onToggleMap: () {
-                setState(() {
-                  _showMap = !_showMap;
-                });
-              },
-              onResizeMap: _resizeMap,
-              onToggleVirtualLocation: _toggleCurrentLocation,
-              onSelectPoint: (point) =>
-                  _handleMapPointTap(context, point, groups),
-              completedPointIds: controller.completedPointIds,
-            ),
-            Expanded(
-              child: ListView(
-                controller: _pointListController,
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-                children: [
-                  for (final point in displayPoints) ...[
-                    _PlanPointTile(
-                      key: _pointTileKey(point.id),
-                      point: point,
-                      status: controller.statusFor(point),
-                      recordCount: controller.recordsForPoint(point.id).length,
-                      onTap: () {
-                        _selectPoint(point, groups);
-                        _showPointDetail(context, point);
-                      },
-                      onOpenCamera: () => _openCamera(context, point),
-                      onComplete: () => controller.completePoint(point),
-                      onReopen: () => controller.reopenPoint(point),
+      body: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: _handlePlanBodyPointerDown,
+        child: Column(
+          children: [
+            if (selectedGroup == null || controller.points.isEmpty)
+              Expanded(
+                child: ListView(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                  children: [
+                    _WorkHeader(plan: plan),
+                    _PlanActionsReveal(
+                      expanded: _showPlanActions,
+                      child: KeyedSubtree(
+                        key: _planActionsPanelRegionKey,
+                        child: _PlanActionsPanel(
+                          isCachingReferences: _isCachingFullReferences,
+                          onCacheReferences: _handleReferenceCachePressed,
+                          onAddPoints: () =>
+                              _openPlanAction(widget.onOpenAddPoints),
+                          onManagePoints: () =>
+                              _openPlanAction(widget.onOpenPointManager),
+                          onOpenMemo: () => _openPlanAction(_openPlanMemo),
+                          onImportExport: () =>
+                              _openPlanAction(widget.onOpenImportExport),
+                        ),
+                      ),
                     ),
-                    const SizedBox(height: 8),
+                    const SizedBox(height: 16),
+                    _EmptyPlanCard(onAddPoints: widget.onOpenAddPoints),
                   ],
-                ],
+                ),
+              )
+            else ...[
+              if (!_showMap && !_showPlanActions) _PlanMetaStrip(plan: plan),
+              _PlanActionsReveal(
+                expanded: _showPlanActions,
+                padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+                child: KeyedSubtree(
+                  key: _planActionsPanelRegionKey,
+                  child: _PlanActionsPanel(
+                    isCachingReferences: _isCachingFullReferences,
+                    onCacheReferences: _handleReferenceCachePressed,
+                    onAddPoints: () => _openPlanAction(widget.onOpenAddPoints),
+                    onManagePoints: () =>
+                        _openPlanAction(widget.onOpenPointManager),
+                    onOpenMemo: () => _openPlanAction(_openPlanMemo),
+                    onImportExport: () =>
+                        _openPlanAction(widget.onOpenImportExport),
+                  ),
+                ),
               ),
-            ),
+              _GroupSwitcher(
+                groups: groups,
+                selectedIndex: _selectedGroupIndex,
+                showProgressRing: widget.settings.showPlanGroupProgress,
+                onSelectGroup: (group) {
+                  final currentGroups = planGroupBuckets(
+                    controller.plan,
+                    controller.completedPointIds,
+                  );
+                  final index = currentGroups.indexWhere(
+                    (candidate) => candidate.id == group.id,
+                  );
+                  if (index >= 0) {
+                    _selectGroup(index, currentGroups);
+                  }
+                },
+                onCreateGroup: () => _createGroupFromPointDetail(context),
+              ),
+              _PlanGroupControls(
+                plan: plan,
+                group: selectedGroup,
+                showMap: _showMap,
+                showGroupSummary: !_showPlanActions,
+                sortMode: _sortMode,
+                sortDescending: _sortDescending,
+                mapHeightRatio: _mapHeightRatio,
+                settings: settings,
+                showVirtualLocation: _showVirtualLocation,
+                isLocating: _isLocating,
+                currentLocation: _currentLocation,
+                selectedPointId: controller.selectedPoint?.id,
+                onSetSortMode: (mode) {
+                  setState(() {
+                    _sortMode = mode;
+                  });
+                },
+                onToggleSortDirection: () {
+                  setState(() {
+                    _sortDescending = !_sortDescending;
+                  });
+                },
+                onToggleMap: () {
+                  setState(() {
+                    _showMap = !_showMap;
+                  });
+                },
+                onResizeMap: _resizeMap,
+                onToggleVirtualLocation: _toggleCurrentLocation,
+                onSelectPoint: (point) =>
+                    _handleMapPointTap(context, point, groups),
+                completedPointIds: controller.completedPointIds,
+              ),
+              Expanded(
+                child: ListView(
+                  controller: _pointListController,
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                  children: [
+                    for (final point in displayPoints) ...[
+                      _PlanPointTile(
+                        key: _pointTileKey(point.id),
+                        point: point,
+                        status: controller.statusFor(point),
+                        recordCount: controller
+                            .recordsForPoint(point.id)
+                            .length,
+                        onTap: () {
+                          _selectPoint(point, groups);
+                          _showPointDetail(context, point);
+                        },
+                        onOpenCamera: () => _openCamera(context, point),
+                        onComplete: () => controller.completePoint(point),
+                        onReopen: () => controller.reopenPoint(point),
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                  ],
+                ),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }
@@ -593,6 +632,7 @@ class _PlanScreenState extends State<PlanScreen> {
     if (!confirmed || !mounted) {
       return;
     }
+    _collapsePlanActions();
     await _cacheFullReferenceImages();
   }
 
@@ -690,32 +730,217 @@ class _PlanPointCreateGroupDialogState
   }
 }
 
-enum _PlanMenuAction { switchPlan, addPoints, managePoints, memo, importExport }
-
-class _ReferenceCacheIconButton extends StatelessWidget {
-  const _ReferenceCacheIconButton({
-    required this.isCaching,
-    required this.progress,
-    required this.onPressed,
+class _PlanActionsReveal extends StatelessWidget {
+  const _PlanActionsReveal({
+    required this.expanded,
+    required this.child,
+    this.padding = EdgeInsets.zero,
   });
 
-  final bool isCaching;
-  final ReferenceFullCacheProgress? progress;
-  final VoidCallback onPressed;
+  final bool expanded;
+  final Widget child;
+  final EdgeInsetsGeometry padding;
 
   @override
   Widget build(BuildContext context) {
-    final tooltip = isCaching ? progress?.label ?? '正在缓存完整参考图' : '缓存完整参考图';
-    return IconButton(
-      tooltip: tooltip,
-      onPressed: onPressed,
-      icon: isCaching
-          ? const SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
-          : const Icon(Icons.download_for_offline_outlined),
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOutCubic,
+      alignment: Alignment.topCenter,
+      child: expanded
+          ? Padding(padding: padding, child: child)
+          : const SizedBox.shrink(),
+    );
+  }
+}
+
+class _PlanActionsPanel extends StatelessWidget {
+  const _PlanActionsPanel({
+    required this.isCachingReferences,
+    required this.onCacheReferences,
+    required this.onAddPoints,
+    required this.onManagePoints,
+    required this.onOpenMemo,
+    required this.onImportExport,
+  });
+
+  final bool isCachingReferences;
+  final VoidCallback onCacheReferences;
+  final VoidCallback onAddPoints;
+  final VoidCallback onManagePoints;
+  final VoidCallback onOpenMemo;
+  final VoidCallback onImportExport;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const ValueKey('plan-actions-panel'),
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-add-points'),
+                    icon: const Icon(Icons.add_location_alt_outlined, size: 20),
+                    title: '添加点位',
+                    subtitle: '加入巡礼场景',
+                    onTap: onAddPoints,
+                  ),
+                ),
+                const _PlanActionDivider(),
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-manage-points'),
+                    icon: const Icon(Icons.tune_outlined, size: 20),
+                    title: '管理计划',
+                    subtitle: '整理片区点位',
+                    onTap: onManagePoints,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1, thickness: 1, color: AppColors.border),
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-cache-references'),
+                    icon: isCachingReferences
+                        ? const SizedBox.square(
+                            dimension: 19,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(
+                            Icons.download_for_offline_outlined,
+                            size: 20,
+                          ),
+                    title: '缓存参考图',
+                    subtitle: '保存完整图片',
+                    onTap: onCacheReferences,
+                  ),
+                ),
+                const _PlanActionDivider(),
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-memo'),
+                    icon: const Icon(Icons.sticky_note_2_outlined, size: 20),
+                    title: '计划备忘录',
+                    subtitle: '记录行程要点',
+                    onTap: onOpenMemo,
+                  ),
+                ),
+                const _PlanActionDivider(),
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-import-export'),
+                    icon: const Icon(Icons.import_export_outlined, size: 20),
+                    title: '导入导出',
+                    subtitle: '备份迁移计划',
+                    onTap: onImportExport,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlanActionItem extends StatelessWidget {
+  const _PlanActionItem({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    super.key,
+  });
+
+  final Widget icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 64),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+            child: Row(
+              children: [
+                IconTheme(
+                  data: IconThemeData(color: AppColors.accentDark),
+                  child: icon,
+                ),
+                const SizedBox(width: 7),
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 10,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlanActionDivider extends StatelessWidget {
+  const _PlanActionDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      margin: const EdgeInsets.symmetric(vertical: 10),
+      color: AppColors.border,
     );
   }
 }
@@ -739,6 +964,7 @@ class _GroupSwitcher extends StatelessWidget {
   Widget build(BuildContext context) {
     final group = groups[selectedIndex];
     return Padding(
+      key: const ValueKey('plan-group-switcher'),
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
       child: Row(
         children: [
@@ -794,6 +1020,7 @@ class _PlanGroupControls extends StatelessWidget {
     required this.plan,
     required this.group,
     required this.showMap,
+    required this.showGroupSummary,
     required this.sortMode,
     required this.sortDescending,
     required this.mapHeightRatio,
@@ -814,6 +1041,7 @@ class _PlanGroupControls extends StatelessWidget {
   final PilgrimagePlan plan;
   final PlanGroupBucket group;
   final bool showMap;
+  final bool showGroupSummary;
   final PointSortMode sortMode;
   final bool sortDescending;
   final double mapHeightRatio;
@@ -850,7 +1078,7 @@ class _PlanGroupControls extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 2),
       child: Column(
         children: [
-          if (!showMap) ...[
+          if (!showMap && showGroupSummary) ...[
             _GroupSummary(group: group),
             const SizedBox(height: 12),
           ],
@@ -909,6 +1137,7 @@ class _GroupSummary extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DecoratedBox(
+      key: const ValueKey('plan-group-summary'),
       decoration: BoxDecoration(
         color: AppColors.surface,
         border: Border.all(color: AppColors.border),
@@ -1567,7 +1796,7 @@ class _OnboardingTimeline extends StatelessWidget {
         _OnboardingStep(
           number: 1,
           title: '加作品',
-          body: '点击右上角，选择“添加点位”，点击“作品管理”，在这里搜索你想要加入巡礼计划的作品并添加。',
+          body: '点击右上角展开计划操作，选择“添加点位”，再点击“作品管理”，搜索并添加想要加入巡礼计划的作品。',
         ),
         _OnboardingStep(
           number: 2,
@@ -1579,7 +1808,7 @@ class _OnboardingTimeline extends StatelessWidget {
           number: 3,
           title: '划片区',
           body:
-              '回到“计划”页，点击右上角，选择“管理计划”，在这里你可以对加入计划的点位进行更细致的管理。你可以创建片区，把距离接近的点位放到一起。',
+              '回到“计划”页，点击右上角展开计划操作，选择“管理计划”。在这里可以细致管理已加入计划的点位，创建片区并归纳距离接近的点位。',
           isLast: true,
         ),
       ],
@@ -1755,25 +1984,23 @@ class _PlanMetaStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 4, 16, 10),
-      child: Row(
-        children: [
-          Icon(Icons.movie_filter_outlined, color: AppColors.accentDark),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              '${plan.area} / ${plan.points.length} 个点位 / ${_workCountText(plan)}',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0,
-              ),
-            ),
+      key: const ValueKey('plan-meta-strip'),
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: SizedBox(
+        width: double.infinity,
+        child: Text(
+          '${plan.area} / ${plan.points.length} 个点位 / ${_workCountText(plan)}',
+          key: const ValueKey('plan-meta-text'),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.left,
+          style: const TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0,
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/plan/point_manager_screen.dart
+++ b/lib/plan/point_manager_screen.dart
@@ -15,6 +15,7 @@ import '../utils/selected_item_order.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'add_points_screen.dart';
 import 'nearest_group_assign_screen.dart';
 import 'pilgrimage_models.dart';
@@ -111,10 +112,8 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: Text(
             _selectionMode ? '已选 ${_selectedPointIds.length}' : '管理计划',
@@ -1831,6 +1830,7 @@ class _GroupAnchorMapPickerScreenState
 
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: const Text('选择关键点'),
         actions: [
           TextButton(

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/copyable_text.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/snackbar_helper.dart';
 import '../widgets/app_scaled_route.dart';
+import '../widgets/app_back_button.dart';
 import 'add_points_screen.dart';
 import 'pilgrimage_models.dart';
 import 'pilgrimage_work_cover.dart';
@@ -49,10 +50,8 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: const Text('作品管理'),
         ),
@@ -116,7 +115,7 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
     }
   }
 
-  Future<void> _confirmDeleteWork(PilgrimageWork work) async {
+  Future<bool> _confirmDeleteWork(PilgrimageWork work) async {
     final pointCount = _plan.points
         .where((point) => point.work.id == work.id)
         .length;
@@ -131,7 +130,7 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
       emphasizedValues: [work.title],
     );
     if (!confirmed || !mounted) {
-      return;
+      return false;
     }
 
     setState(() => _isSaving = true);
@@ -141,7 +140,7 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
         workId: work.id,
       );
       if (!mounted) {
-        return;
+        return false;
       }
 
       setState(() {
@@ -149,15 +148,17 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
         _didUpdate = true;
         _isSaving = false;
       });
+      return true;
     } catch (_) {
       if (!mounted) {
-        return;
+        return false;
       }
 
       setState(() => _isSaving = false);
       ScaffoldMessenger.of(
         context,
       ).showReplacingSnackBar(const SnackBar(content: Text('作品删除失败')));
+      return false;
     }
   }
 
@@ -338,7 +339,6 @@ class _WorkManageCardState extends State<_WorkManageCard> {
         !subtitle.startsWith('Bangumi #') &&
         subtitle != 'Manual Work' &&
         subtitle != '暂无作品原名';
-    final isBangumiWork = work.bangumiId != null;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
@@ -392,40 +392,99 @@ class _WorkManageCardState extends State<_WorkManageCard> {
                   ),
                 ),
                 const SizedBox(height: 6),
-                Wrap(
-                  spacing: 6,
-                  runSpacing: 4,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: [
-                    if (work.displayBangumiSubjectType != null)
-                      _WorkManageBadge(
-                        label: work.displayBangumiSubjectType!.label,
-                      ),
-                    _WorkManageBadge(
-                      label: isBangumiWork ? 'Bangumi' : '手动添加',
-                      emphasized: isBangumiWork,
-                    ),
-                    _WorkManageBadge(label: '$pointCount 个点位'),
-                  ],
+                _WorkBadges(
+                  key: ValueKey('work-manage-badges-${work.id}'),
+                  work: work,
+                  pointCount: pointCount,
                 ),
               ],
             ),
           ),
           const SizedBox(width: 12),
-          OutlinedButton(
-            onPressed: widget.disabled ? null : widget.onDelete,
-            style: OutlinedButton.styleFrom(
-              minimumSize: const Size(88, 40),
-              padding: const EdgeInsets.symmetric(horizontal: 14),
-              foregroundColor: Colors.redAccent,
-              side: BorderSide(
-                color: widget.disabled
-                    ? AppColors.border
-                    : Colors.redAccent.withValues(alpha: 0.65),
+          PopupMenuButton<String>(
+            key: ValueKey('work-manage-more-${work.id}'),
+            tooltip: '更多操作',
+            enabled: !widget.disabled,
+            icon: const Icon(Icons.more_horiz),
+            iconSize: 20,
+            padding: EdgeInsets.zero,
+            position: PopupMenuPosition.under,
+            offset: const Offset(0, 6),
+            elevation: 8,
+            shadowColor: Colors.black.withValues(alpha: 0.16),
+            color: AppColors.surface,
+            surfaceTintColor: Colors.transparent,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: AppColors.border),
+            ),
+            constraints: const BoxConstraints(minWidth: 148, maxWidth: 180),
+            style: IconButton.styleFrom(
+              minimumSize: const Size.square(34),
+              maximumSize: const Size.square(34),
+              padding: EdgeInsets.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(6),
               ),
             ),
-            child: const Text('删除'),
+            onSelected: (_) => widget.onDelete(),
+            itemBuilder: (context) => [
+              const PopupMenuItem<String>(
+                key: ValueKey('work-action-delete'),
+                value: 'delete',
+                height: 44,
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.delete_outline,
+                      size: 18,
+                      color: AppColors.error,
+                    ),
+                    SizedBox(width: 9),
+                    Text(
+                      '删除作品',
+                      style: TextStyle(
+                        color: AppColors.error,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkBadges extends StatelessWidget {
+  const _WorkBadges({required this.work, required this.pointCount, super.key});
+
+  final PilgrimageWork work;
+  final int pointCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final isBangumiWork = work.bangumiId != null;
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          if (work.displayBangumiSubjectType != null) ...[
+            _WorkManageBadge(label: work.displayBangumiSubjectType!.label),
+            const SizedBox(width: 6),
+          ],
+          _WorkManageBadge(
+            label: isBangumiWork ? 'Bangumi' : '手动添加',
+            emphasized: isBangumiWork,
+          ),
+          const SizedBox(width: 6),
+          _WorkManageBadge(label: '$pointCount 个点位'),
         ],
       ),
     );
@@ -455,6 +514,8 @@ class _WorkManageBadge extends StatelessWidget {
       ),
       child: Text(
         label,
+        maxLines: 1,
+        softWrap: false,
         style: TextStyle(
           color: emphasized ? AppColors.accentDark : AppColors.textSecondary,
           fontSize: 11,

--- a/lib/plan_transfer/import_export_screen.dart
+++ b/lib/plan_transfer/import_export_screen.dart
@@ -8,6 +8,7 @@ import '../platform/platform_flags_stub.dart'
 import '../plan/pilgrimage_models.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'my_maps_csv_export.dart';
 import 'plan_export_delivery.dart';
 import 'plan_export_delivery_result.dart';
@@ -68,11 +69,7 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
-            onPressed: _handleBack,
-            icon: const Icon(Icons.arrow_back),
-          ),
+          leading: AppBackButton(onPressed: _handleBack),
           title: const Text('导入导出'),
         ),
         body: ListView(

--- a/lib/plan_transfer/plan_import_preview_screen.dart
+++ b/lib/plan_transfer/plan_import_preview_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
+import '../widgets/app_back_button.dart';
 import 'plan_import_asset_restore.dart';
 import 'plan_import_package.dart';
 
@@ -32,7 +33,10 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('导入内容')),
+      appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
+        title: const Text('导入内容'),
+      ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         children: [

--- a/lib/records/point_visit_records_screen.dart
+++ b/lib/records/point_visit_records_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../app_theme.dart';
 import '../plan/pilgrimage_models.dart';
 import '../plan/pilgrimage_plan_controller.dart';
+import '../widgets/app_back_button.dart';
 import 'visit_record_detail_screen.dart';
 import 'visit_record_photo_stub.dart'
     if (dart.library.io) 'visit_record_photo_io.dart';
@@ -34,7 +35,11 @@ class PointVisitRecordsScreen extends StatelessWidget {
             final records = controller.recordsForPoint(point.id);
 
             return Scaffold(
-              appBar: AppBar(title: const Text('点位拍摄记录')),
+              appBar: AppBar(
+                toolbarHeight: 44,
+                leading: appBackButtonIfCanPop(context),
+                title: const Text('点位拍摄记录'),
+              ),
               body: ListView(
                 padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
                 children: [

--- a/lib/records/point_visit_records_screen.dart
+++ b/lib/records/point_visit_records_screen.dart
@@ -36,7 +36,6 @@ class PointVisitRecordsScreen extends StatelessWidget {
 
             return Scaffold(
               appBar: AppBar(
-                toolbarHeight: 44,
                 leading: appBackButtonIfCanPop(context),
                 title: const Text('点位拍摄记录'),
               ),

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -59,7 +59,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
     return Scaffold(
       appBar: AppBar(
         key: const ValueKey('records-app-bar'),
-        toolbarHeight: kToolbarHeight,
+        toolbarHeight: AppTheme.appBarHeight,
         title: const Text(
           '记录',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -43,6 +43,11 @@ class _RecordsScreenState extends State<RecordsScreen> {
     _synchronizeScopeFilters(controller.plan);
     final records = _filteredRecords(controller);
     final sections = _groupedRecords(controller, records);
+    final trimmedSearchQuery = _searchQuery.trim();
+    final hasActiveFilters =
+        _statusFilter != _RecordStatusFilter.all ||
+        _selectedWorkIds != null ||
+        _selectedGroupFilterIds != null;
     if (!_expandedSectionsInitialized && sections.isNotEmpty) {
       _expandedSectionIds.addAll(sections.map((section) => section.id));
       _expandedSectionsInitialized = true;
@@ -54,6 +59,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
     return Scaffold(
       appBar: AppBar(
         key: const ValueKey('records-app-bar'),
+        toolbarHeight: kToolbarHeight,
         title: const Text(
           '记录',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
@@ -79,7 +85,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
               allSectionsExpanded ? Icons.unfold_less : Icons.unfold_more,
             ),
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: 16),
         ],
       ),
       body: CustomScrollView(
@@ -121,9 +127,17 @@ class _RecordsScreenState extends State<RecordsScreen> {
             ),
           ),
           if (records.isEmpty)
-            const SliverPadding(
-              padding: EdgeInsets.fromLTRB(16, 4, 16, 0),
-              sliver: SliverToBoxAdapter(child: _EmptyRecords()),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+              sliver: SliverToBoxAdapter(
+                child: _EmptyRecords(
+                  hasAnyRecords: controller.visitRecords.isNotEmpty,
+                  searchQuery: trimmedSearchQuery,
+                  hasActiveFilters: hasActiveFilters,
+                  onClearSearch: _clearSearch,
+                  onResetFilters: _resetFilters,
+                ),
+              ),
             )
           else
             for (final section in sections)
@@ -183,6 +197,22 @@ class _RecordsScreenState extends State<RecordsScreen> {
         ),
       ),
     );
+  }
+
+  void _clearSearch() {
+    setState(() {
+      _searchQuery = '';
+      _resetExpandedSections();
+    });
+  }
+
+  void _resetFilters() {
+    setState(() {
+      _statusFilter = _RecordStatusFilter.all;
+      _selectedWorkIds = null;
+      _selectedGroupFilterIds = null;
+      _resetExpandedSections();
+    });
   }
 
   void _resetExpandedSections() {
@@ -1821,32 +1851,107 @@ class _VisitRecordCard extends StatelessWidget {
 }
 
 class _EmptyRecords extends StatelessWidget {
-  const _EmptyRecords();
+  const _EmptyRecords({
+    required this.hasAnyRecords,
+    required this.searchQuery,
+    required this.hasActiveFilters,
+    required this.onClearSearch,
+    required this.onResetFilters,
+  });
+
+  final bool hasAnyRecords;
+  final String searchQuery;
+  final bool hasActiveFilters;
+  final VoidCallback onClearSearch;
+  final VoidCallback onResetFilters;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(18),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Row(
-        children: [
-          Icon(Icons.info_outline, color: AppColors.textSecondary),
-          SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              '还没有巡礼记录。拍摄成功后会自动出现在这里。',
-              style: TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 14,
-                letterSpacing: 0,
-              ),
+    final hasSearchQuery = hasAnyRecords && searchQuery.isNotEmpty;
+    final hasFilterResult =
+        hasAnyRecords && !hasSearchQuery && hasActiveFilters;
+    final icon = hasSearchQuery
+        ? Icons.search_off_rounded
+        : hasFilterResult
+        ? Icons.filter_alt_off_rounded
+        : Icons.photo_library_outlined;
+    final title = hasSearchQuery
+        ? '没有找到相关记录'
+        : hasFilterResult
+        ? '没有符合筛选条件的记录'
+        : '还没有巡礼记录';
+    final description = hasSearchQuery
+        ? hasActiveFilters
+              ? '没有与当前关键词和筛选条件同时匹配的点位、作品或场景。试试更换关键词，或重置筛选条件。'
+              : '没有与当前关键词匹配的点位、作品或场景。试试更换关键词，或清除搜索查看全部记录。'
+        : hasFilterResult
+        ? '调整状态、作品或片区筛选条件后再试。'
+        : '完成一次点位拍摄后，记录会自动汇总到这里。';
+
+    return Semantics(
+      liveRegion: true,
+      child: Padding(
+        key: const ValueKey('records-empty-state'),
+        padding: const EdgeInsets.fromLTRB(16, 28, 16, 36),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 380),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, color: AppColors.accent, size: 42),
+                const SizedBox(height: 14),
+                Text(
+                  title,
+                  key: const ValueKey('records-empty-title'),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 7),
+                Text(
+                  description,
+                  key: const ValueKey('records-empty-description'),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 13,
+                    height: 1.5,
+                    letterSpacing: 0,
+                  ),
+                ),
+                if (hasSearchQuery || hasFilterResult) ...[
+                  const SizedBox(height: 14),
+                  Wrap(
+                    alignment: WrapAlignment.center,
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      if (hasSearchQuery)
+                        TextButton.icon(
+                          key: const ValueKey('records-empty-clear-search'),
+                          onPressed: onClearSearch,
+                          icon: const Icon(Icons.close, size: 18),
+                          label: const Text('清除搜索'),
+                        ),
+                      if (hasActiveFilters)
+                        TextButton.icon(
+                          key: const ValueKey('records-empty-reset-filters'),
+                          onPressed: onResetFilters,
+                          icon: const Icon(Icons.filter_alt_off, size: 18),
+                          label: const Text('重置筛选'),
+                        ),
+                    ],
+                  ),
+                ],
+              ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/records/visit_record_detail_screen.dart
+++ b/lib/records/visit_record_detail_screen.dart
@@ -15,6 +15,7 @@ import '../plan/reference_image_status.dart';
 import '../point_detail/point_detail_sheet.dart';
 import '../widgets/copyable_text.dart';
 import '../widgets/confirm_action_dialog.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/anitabi_network_image.dart';
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/reference_image_placeholder.dart';
@@ -61,6 +62,11 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        toolbarHeight: 44,
+        leading: AppBackButton(
+          key: const ValueKey('record-detail-back-button'),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
         title: const Text('记录详情'),
         actions: [
           IconButton(

--- a/lib/records/visit_record_detail_screen.dart
+++ b/lib/records/visit_record_detail_screen.dart
@@ -62,7 +62,6 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: 44,
         leading: AppBackButton(
           key: const ValueKey('record-detail-back-button'),
           onPressed: () => Navigator.of(context).maybePop(),

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -105,7 +105,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return Scaffold(
       appBar: AppBar(
         key: const ValueKey('settings-app-bar'),
-        toolbarHeight: kToolbarHeight,
+        toolbarHeight: AppTheme.appBarHeight,
         title: const Text(
           '设置',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
@@ -1549,10 +1549,10 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
         _SettingsSection(
           title: 'Anitabi 服务地址',
           children: [
-            _MapUrlRow(
+            _AnitabiServiceEntryRow(
               key: const ValueKey('anitabi-service-settings-entry'),
-              icon: Icons.dns_outlined,
-              label: '主站、静态数据、API 与图片服务',
+              siteUrl: settings.anitabiSiteBaseUrl,
+              usingDefaults: _usesDefaultAnitabiService(settings),
               onTap: () => Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (_) => _AnitabiServiceSettingsPage(
@@ -1750,6 +1750,27 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
         _SettingsSection(
           title: '地图标记',
           children: [
+            Material(
+              color: Colors.transparent,
+              child: SwitchListTile(
+                key: const ValueKey('hide-completed-points-on-map-toggle'),
+                contentPadding: EdgeInsets.zero,
+                secondary: const Icon(
+                  Icons.visibility_off_outlined,
+                  color: AppColors.textSecondary,
+                ),
+                title: const Text('隐藏已完成点位', style: _titleTextStyle),
+                subtitle: const Text(
+                  '在地图页不显示已标记完成的点位。关闭后仍可在地图上看到全部点位。',
+                  style: _secondaryTextStyle,
+                ),
+                value: settings.hideCompletedPointsOnMap,
+                onChanged: (value) {
+                  _update(settings.copyWith(hideCompletedPointsOnMap: value));
+                },
+              ),
+            ),
+            const SizedBox(height: 12),
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -3836,6 +3857,67 @@ class _SettingsDivider extends StatelessWidget {
   }
 }
 
+class _AnitabiServiceEntryRow extends StatelessWidget {
+  const _AnitabiServiceEntryRow({
+    super.key,
+    required this.siteUrl,
+    required this.usingDefaults,
+    required this.onTap,
+  });
+
+  final String siteUrl;
+  final bool usingDefaults;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Row(
+          children: [
+            const Icon(Icons.dns_outlined, color: AppColors.textSecondary),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    siteUrl,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    usingDefaults ? '使用默认地址，点击管理全部服务' : '已自定义，点击管理全部服务',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: _secondaryTextStyle,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            const Icon(
+              Icons.chevron_right,
+              color: AppColors.textSecondary,
+              size: 22,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _MapUrlRow extends StatelessWidget {
   const _MapUrlRow({
     super.key,
@@ -4261,6 +4343,15 @@ String _mapProviderHint(MapTileProvider provider) {
     MapTileProvider.customXyz => '\u74e6\u7247\u6a21\u677f',
     MapTileProvider.customMapLibreStyle => '\u6837\u5f0f URL',
   };
+}
+
+bool _usesDefaultAnitabiService(AppSettings settings) {
+  return settings.anitabiSiteBaseUrl == defaultAnitabiSiteBaseUrl &&
+      settings.anitabiStaticDataBaseUrl == defaultAnitabiStaticDataBaseUrl &&
+      settings.anitabiApiBaseUrl == defaultAnitabiApiBaseUrl &&
+      settings.anitabiOfficialImageBaseUrl ==
+          defaultAnitabiOfficialImageBaseUrl &&
+      settings.anitabiMirrorImageBaseUrl == defaultAnitabiMirrorImageBaseUrl;
 }
 
 String _anitabiImageSourceLabel(AnitabiImageSource source) {

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -18,6 +18,7 @@ import '../records/comparison_export_config_storage_stub.dart'
     if (dart.library.io) '../records/comparison_export_config_storage_io.dart';
 import '../widgets/copyable_text.dart';
 import '../widgets/confirm_action_dialog.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/snackbar_helper.dart';
 
@@ -103,22 +104,27 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        key: const ValueKey('settings-app-bar'),
+        toolbarHeight: kToolbarHeight,
         title: const Text(
           '设置',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
         ),
         actions: [
           IconButton(
+            key: const ValueKey('settings-reset-button'),
             tooltip: '恢复初始设置',
             onPressed: _confirmResetSettings,
             icon: const Icon(Icons.restart_alt_outlined),
           ),
+          const SizedBox(width: 16),
         ],
       ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         children: [
           _SettingsCard(
+            key: const ValueKey('settings-appearance-card'),
             header: _SettingsCardHeader(
               icon: Icons.palette_outlined,
               title: '外观设置',
@@ -730,6 +736,33 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                 value: settings.showPlanGroupProgress,
                 onChanged: (value) {
                   _update(settings.copyWith(showPlanGroupProgress: value));
+                },
+              ),
+            ),
+          ),
+          const SizedBox(height: 14),
+          _AppearancePanel(
+            child: Material(
+              color: Colors.transparent,
+              child: SwitchListTile(
+                key: const ValueKey(
+                  'dismiss-plan-actions-on-outside-tap-toggle',
+                ),
+                contentPadding: EdgeInsets.zero,
+                secondary: const Icon(
+                  Icons.touch_app_outlined,
+                  color: AppColors.textSecondary,
+                ),
+                title: const Text('点击空白收回计划操作', style: _titleTextStyle),
+                subtitle: const Text(
+                  '展开计划操作后，点击面板外的空白区域自动收回',
+                  style: _secondaryTextStyle,
+                ),
+                value: settings.dismissPlanActionsOnOutsideTap,
+                onChanged: (value) {
+                  _update(
+                    settings.copyWith(dismissPlanActionsOnOutsideTap: value),
+                  );
                 },
               ),
             ),
@@ -2163,7 +2196,10 @@ class _DetailScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(title)),
+      appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
+        title: Text(title),
+      ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         children: children,
@@ -2240,7 +2276,11 @@ extension _ZoomStepSnap on double {
 }
 
 class _SettingsCard extends StatelessWidget {
-  const _SettingsCard({required this.header, this.children = const []});
+  const _SettingsCard({
+    required this.header,
+    this.children = const [],
+    super.key,
+  });
 
   final _SettingsCardHeader header;
   final List<Widget> children;

--- a/lib/widgets/app_back_button.dart
+++ b/lib/widgets/app_back_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class AppBackButton extends StatelessWidget {
+  const AppBackButton({this.onPressed, super.key});
+
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox.square(
+        dimension: 40,
+        child: IconButton(
+          onPressed: onPressed ?? () => Navigator.of(context).maybePop(),
+          padding: const EdgeInsets.all(8),
+          constraints: const BoxConstraints.tightFor(width: 40, height: 40),
+          style: IconButton.styleFrom(
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          icon: const Icon(Icons.arrow_back, semanticLabel: '返回'),
+        ),
+      ),
+    );
+  }
+}
+
+Widget? appBackButtonIfCanPop(BuildContext context) {
+  return ModalRoute.of(context)?.canPop == true ? const AppBackButton() : null;
+}

--- a/lib/widgets/confirm_action_dialog.dart
+++ b/lib/widgets/confirm_action_dialog.dart
@@ -121,37 +121,12 @@ class ConfirmActionDialog extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 16),
-                OverflowBar(
-                  spacing: 10,
-                  overflowSpacing: 8,
-                  alignment: MainAxisAlignment.end,
-                  overflowAlignment: OverflowBarAlignment.end,
-                  children: [
-                    FilledButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      style: FilledButton.styleFrom(
-                        foregroundColor: AppColors.textPrimary,
-                        backgroundColor: AppColors.surfaceMuted,
-                        minimumSize: const Size.fromHeight(48),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      child: Text(cancelLabel),
-                    ),
-                    FilledButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      style: FilledButton.styleFrom(
-                        foregroundColor: Colors.white,
-                        backgroundColor: dangerColor,
-                        minimumSize: const Size.fromHeight(48),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      child: Text(confirmLabel),
-                    ),
-                  ],
+                AppDialogActionRow(
+                  cancelLabel: cancelLabel,
+                  confirmLabel: confirmLabel,
+                  confirmColor: dangerColor,
+                  onCancel: () => Navigator.of(context).pop(false),
+                  onConfirm: () => Navigator.of(context).pop(true),
                 ),
               ],
             ),
@@ -247,32 +222,87 @@ class _StandardConfirmDialog extends StatelessWidget {
                   ),
                 ],
                 const SizedBox(height: 16),
-                OverflowBar(
-                  spacing: 6,
-                  overflowSpacing: 8,
-                  alignment: MainAxisAlignment.end,
-                  overflowAlignment: OverflowBarAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: Text(cancelLabel),
-                    ),
-                    FilledButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      style: FilledButton.styleFrom(
-                        minimumSize: const Size(0, 46),
-                        padding: const EdgeInsets.symmetric(horizontal: 20),
-                        shape: const StadiumBorder(),
-                      ),
-                      child: Text(confirmLabel),
-                    ),
-                  ],
+                AppDialogActionRow(
+                  cancelLabel: cancelLabel,
+                  confirmLabel: confirmLabel,
+                  onCancel: () => Navigator.of(context).pop(false),
+                  onConfirm: () => Navigator.of(context).pop(true),
                 ),
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class AppDialogActionRow extends StatelessWidget {
+  const AppDialogActionRow({
+    required this.cancelLabel,
+    required this.confirmLabel,
+    required this.onCancel,
+    required this.onConfirm,
+    this.confirmColor,
+    super.key,
+  });
+
+  final String cancelLabel;
+  final String confirmLabel;
+  final VoidCallback onCancel;
+  final VoidCallback onConfirm;
+  final Color? confirmColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: FilledButton(
+            onPressed: onCancel,
+            style: FilledButton.styleFrom(
+              foregroundColor: AppColors.textPrimary,
+              backgroundColor: AppColors.surfaceMuted,
+              minimumSize: const Size.fromHeight(48),
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            child: _DialogActionLabel(cancelLabel),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: FilledButton(
+            onPressed: onConfirm,
+            style: FilledButton.styleFrom(
+              foregroundColor: Colors.white,
+              backgroundColor: confirmColor ?? AppColors.accent,
+              minimumSize: const Size.fromHeight(48),
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            child: _DialogActionLabel(confirmLabel),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DialogActionLabel extends StatelessWidget {
+  const _DialogActionLabel(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      child: Text(label, maxLines: 1, softWrap: false),
     );
   }
 }

--- a/lib/widgets/input_dialog.dart
+++ b/lib/widgets/input_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../app_theme.dart';
+import 'confirm_action_dialog.dart';
 
 class AppInputDialog extends StatelessWidget {
   const AppInputDialog({
@@ -50,29 +51,11 @@ class AppInputDialog extends StatelessWidget {
               const SizedBox(height: 18),
               Flexible(child: SingleChildScrollView(child: content)),
               const SizedBox(height: 16),
-              OverflowBar(
-                spacing: 6,
-                overflowSpacing: 8,
-                alignment: MainAxisAlignment.end,
-                overflowAlignment: OverflowBarAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    style: TextButton.styleFrom(
-                      foregroundColor: AppColors.textSecondary,
-                    ),
-                    child: Text(cancelLabel),
-                  ),
-                  FilledButton(
-                    onPressed: onConfirm,
-                    style: FilledButton.styleFrom(
-                      minimumSize: const Size(0, 46),
-                      padding: const EdgeInsets.symmetric(horizontal: 20),
-                      shape: const StadiumBorder(),
-                    ),
-                    child: Text(confirmLabel),
-                  ),
-                ],
+              AppDialogActionRow(
+                cancelLabel: cancelLabel,
+                confirmLabel: confirmLabel,
+                onCancel: () => Navigator.of(context).pop(),
+                onConfirm: onConfirm,
               ),
             ],
           ),

--- a/test/desktop_repository_state_test.dart
+++ b/test/desktop_repository_state_test.dart
@@ -50,6 +50,7 @@ void main() {
         mapThumbnailConcurrentLoads: 12,
         showPlanGroupProgress: false,
         dismissPlanActionsOnOutsideTap: false,
+        hideCompletedPointsOnMap: false,
         mapMarkerClusteringEnabled: false,
         mapMarkerClusterRadius: 88,
         mapMarkerClusterMaxZoom: 20,
@@ -144,6 +145,7 @@ void main() {
     expect(decoded.settings.mapThumbnailVisibleThreshold, 55);
     expect(decoded.settings.mapThumbnailConcurrentLoads, 12);
     expect(decoded.settings.showPlanGroupProgress, isFalse);
+    expect(decoded.settings.hideCompletedPointsOnMap, isFalse);
     expect(decoded.settings.mapMarkerClusteringEnabled, isFalse);
     expect(decoded.settings.mapMarkerClusterRadius, 88);
     expect(decoded.settings.mapMarkerClusterMaxZoom, 20);

--- a/test/desktop_repository_state_test.dart
+++ b/test/desktop_repository_state_test.dart
@@ -4,6 +4,18 @@ import 'package:miriago/desktop/desktop_repository_state.dart';
 import 'package:miriago/plan/pilgrimage_models.dart';
 
 void main() {
+  test('desktop persists plan action outside-tap preference', () {
+    final repository = SamplePilgrimageRepository(
+      settings: const AppSettings(dismissPlanActionsOnOutsideTap: false),
+    );
+    final encoded = encodeDesktopRepositoryState(repository.snapshot());
+
+    final decoded = decodeDesktopRepositoryState(encoded);
+
+    expect(decoded, isNotNull);
+    expect(decoded!.settings.dismissPlanActionsOnOutsideTap, isFalse);
+  });
+
   test('desktop repository state round-trips sample data', () async {
     final repository = SamplePilgrimageRepository();
     await repository.saveAppSettings(
@@ -37,6 +49,7 @@ void main() {
         mapThumbnailVisibleThreshold: 55,
         mapThumbnailConcurrentLoads: 12,
         showPlanGroupProgress: false,
+        dismissPlanActionsOnOutsideTap: false,
         mapMarkerClusteringEnabled: false,
         mapMarkerClusterRadius: 88,
         mapMarkerClusterMaxZoom: 20,
@@ -74,6 +87,7 @@ void main() {
     expect(decoded, isNotNull);
     expect(decoded!.activePlanId, source.activePlanId);
     expect(decoded.settings.uiScale, 1.0);
+    expect(decoded.settings.dismissPlanActionsOnOutsideTap, isFalse);
     expect(
       decoded.settings.cameraCaptureAspectRatio,
       CameraPhotoAspectRatio.landscape16x9,
@@ -231,6 +245,7 @@ void main() {
     final decoded = decodeDesktopRepositoryState(source);
     final point = decoded!.plans.single.points.single;
 
+    expect(decoded.settings.dismissPlanActionsOnOutsideTap, isTrue);
     expect(point.work.id, 'missing-work');
     expect(point.work.title, '未知作品');
     expect(point.work.title, isNot('不应该被绑定的作品'));

--- a/test/dialog_layout_test.dart
+++ b/test/dialog_layout_test.dart
@@ -34,6 +34,15 @@ void main() {
 
     expect(find.text('暂不删除'), findsOneWidget);
     expect(find.byType(SingleChildScrollView), findsOneWidget);
+    final actionButtons = find.descendant(
+      of: find.byType(AppDialogActionRow),
+      matching: find.byType(FilledButton),
+    );
+    expect(actionButtons, findsNWidgets(2));
+    expect(
+      tester.getTopLeft(actionButtons.first).dy,
+      closeTo(tester.getTopLeft(actionButtons.last).dy, 0.1),
+    );
     expect(tester.takeException(), isNull);
   });
 
@@ -74,6 +83,15 @@ void main() {
         )
         .singleWhere((box) => box.constraints.maxWidth == 420);
     expect(frame.constraints.maxHeight, 292);
+    final actionButtons = find.descendant(
+      of: find.byType(AppDialogActionRow),
+      matching: find.byType(FilledButton),
+    );
+    expect(actionButtons, findsNWidgets(2));
+    expect(
+      tester.getTopLeft(actionButtons.first).dy,
+      closeTo(tester.getTopLeft(actionButtons.last).dy, 0.1),
+    );
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/map_marker_clustering_test.dart
+++ b/test/map_marker_clustering_test.dart
@@ -372,4 +372,90 @@ void main() {
       );
     },
   );
+
+  testWidgets('hides completed point markers on the map by default', (
+    tester,
+  ) async {
+    const work = PilgrimageWork(
+      id: 'work',
+      title: '测试作品',
+      subtitle: '',
+      city: '',
+      source: WorkSource.manual,
+    );
+    const pending = PilgrimagePoint(
+      id: 'point-pending',
+      work: work,
+      name: '未完成点位',
+      subtitle: '',
+      position: LatLng(35, 139),
+      episodeLabel: '',
+      referenceLabel: '',
+    );
+    const completed = PilgrimagePoint(
+      id: 'point-completed',
+      work: work,
+      name: '已完成点位',
+      subtitle: '',
+      position: LatLng(35.001, 139.001),
+      episodeLabel: '',
+      referenceLabel: '',
+    );
+    final now = DateTime(2026);
+    final controller = PilgrimagePlanController(
+      plan: PilgrimagePlan(
+        id: 'plan',
+        name: '测试计划',
+        area: '',
+        works: const [work],
+        points: const [pending, completed],
+        createdAt: now,
+        updatedAt: now,
+        currentPointId: pending.id,
+        completedPointIds: {completed.id},
+      ),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PilgrimageMapScreen(
+          controller: controller,
+          settings: const AppSettings(mapMarkerClusteringEnabled: false),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('plan-map-marker-point-pending')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-map-marker-point-completed')),
+      findsNothing,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PilgrimageMapScreen(
+          controller: controller,
+          settings: const AppSettings(
+            mapMarkerClusteringEnabled: false,
+            hideCompletedPointsOnMap: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('plan-map-marker-point-pending')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-map-marker-point-completed')),
+      findsOneWidget,
+    );
+  });
 }

--- a/test/sqlite_pilgrimage_repository_test.dart
+++ b/test/sqlite_pilgrimage_repository_test.dart
@@ -66,6 +66,19 @@ void main() {
     expect(ungrouped.currentGroupId, 'ungrouped');
   });
 
+  test('persists plan action outside-tap preference', () async {
+    final database = AppDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+    final repository = SqlitePilgrimageRepository(database: database);
+
+    await repository.saveAppSettings(
+      const AppSettings(dismissPlanActionsOnOutsideTap: false),
+    );
+
+    final settings = await repository.loadAppSettings();
+    expect(settings.dismissPlanActionsOnOutsideTap, isFalse);
+  });
+
   test('persists work type and cover metadata', () async {
     final database = AppDatabase(NativeDatabase.memory());
     addTearDown(database.close);
@@ -503,6 +516,49 @@ void main() {
       expect(
         (await repository.loadAppSettings()).photoLocationStrategy,
         PhotoLocationStrategy.waitOnConfirmation,
+      );
+    },
+  );
+
+  test(
+    'schema 38 to 39 adds plan action dismissal preference without data loss',
+    () async {
+      final database = AppDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+      final repository = SqlitePilgrimageRepository(database: database);
+      final plan = await repository.createPlan(name: '计划操作设置迁移', area: '东京');
+      await repository.saveAppSettings(
+        const AppSettings(customXyzTileUrl: 'https://example.com/tiles'),
+      );
+      await database.customStatement(
+        'ALTER TABLE app_settings_entries '
+        'DROP COLUMN dismiss_plan_actions_on_outside_tap',
+      );
+
+      await database.migration.onUpgrade(
+        database.createMigrator(),
+        38,
+        database.schemaVersion,
+      );
+
+      expect(
+        await _tableColumnNames(database, 'app_settings_entries'),
+        contains('dismiss_plan_actions_on_outside_tap'),
+      );
+      final migratedPlan = (await repository.loadPlans()).singleWhere(
+        (candidate) => candidate.id == plan.id,
+      );
+      final settings = await repository.loadAppSettings();
+      expect(migratedPlan.name, plan.name);
+      expect(settings.customXyzTileUrl, 'https://example.com/tiles');
+      expect(settings.dismissPlanActionsOnOutsideTap, isTrue);
+
+      await repository.saveAppSettings(
+        settings.copyWith(dismissPlanActionsOnOutsideTap: false),
+      );
+      expect(
+        (await repository.loadAppSettings()).dismissPlanActionsOnOutsideTap,
+        isFalse,
       );
     },
   );

--- a/test/sqlite_pilgrimage_repository_test.dart
+++ b/test/sqlite_pilgrimage_repository_test.dart
@@ -233,6 +233,7 @@ void main() {
     expect(migratedPlan.name, plan.name);
     expect(settings.customXyzTileUrl, 'https://example.com/{z}/{x}/{y}.png');
     expect(settings.mapMarkerClusteringEnabled, isTrue);
+    expect(settings.hideCompletedPointsOnMap, isTrue);
     expect(settings.mapMarkerClusterRadius, 40);
     expect(settings.mapMarkerClusterMaxZoom, 21);
   });
@@ -558,6 +559,49 @@ void main() {
       );
       expect(
         (await repository.loadAppSettings()).dismissPlanActionsOnOutsideTap,
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'schema 39 to 40 adds hide completed map points preference without data loss',
+    () async {
+      final database = AppDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+      final repository = SqlitePilgrimageRepository(database: database);
+      final plan = await repository.createPlan(name: '隐藏完成点位迁移', area: '东京');
+      await repository.saveAppSettings(
+        const AppSettings(customXyzTileUrl: 'https://example.com/tiles'),
+      );
+      await database.customStatement(
+        'ALTER TABLE app_settings_entries '
+        'DROP COLUMN hide_completed_points_on_map',
+      );
+
+      await database.migration.onUpgrade(
+        database.createMigrator(),
+        39,
+        database.schemaVersion,
+      );
+
+      expect(
+        await _tableColumnNames(database, 'app_settings_entries'),
+        contains('hide_completed_points_on_map'),
+      );
+      final migratedPlan = (await repository.loadPlans()).singleWhere(
+        (candidate) => candidate.id == plan.id,
+      );
+      final settings = await repository.loadAppSettings();
+      expect(migratedPlan.name, plan.name);
+      expect(settings.customXyzTileUrl, 'https://example.com/tiles');
+      expect(settings.hideCompletedPointsOnMap, isTrue);
+
+      await repository.saveAppSettings(
+        settings.copyWith(hideCompletedPointsOnMap: false),
+      );
+      expect(
+        (await repository.loadAppSettings()).hideCompletedPointsOnMap,
         isFalse,
       );
     },
@@ -1696,6 +1740,7 @@ void main() {
         mapThumbnailVisibleThreshold: 55,
         mapThumbnailConcurrentLoads: 12,
         showPlanGroupProgress: false,
+        hideCompletedPointsOnMap: false,
         mapMarkerClusteringEnabled: false,
         mapMarkerClusterRadius: 88,
         mapMarkerClusterMaxZoom: 20,
@@ -1749,6 +1794,7 @@ void main() {
     expect(settings.mapThumbnailVisibleThreshold, 55);
     expect(settings.mapThumbnailConcurrentLoads, 12);
     expect(settings.showPlanGroupProgress, isFalse);
+    expect(settings.hideCompletedPointsOnMap, isFalse);
     expect(settings.mapMarkerClusteringEnabled, isFalse);
     expect(settings.mapMarkerClusterRadius, 88);
     expect(settings.mapMarkerClusterMaxZoom, 20);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -19,11 +19,13 @@ import 'package:miriago/plan/nearest_group_assign_screen.dart';
 import 'package:miriago/plan/plan_group_manager_screen.dart';
 import 'package:miriago/plan/plan_manager_screen.dart';
 import 'package:miriago/plan/point_manager_screen.dart';
+import 'package:miriago/plan/work_manager_screen.dart';
 import 'package:miriago/plan/pilgrimage_models.dart';
 import 'package:miriago/plan/pilgrimage_plan_controller.dart';
 import 'package:miriago/records/records_screen.dart';
 import 'package:miriago/records/comparison_export_config.dart';
 import 'package:miriago/widgets/constrained_menu_anchor.dart';
+import 'package:miriago/widgets/confirm_action_dialog.dart';
 import 'package:miriago/widgets/input_dialog.dart';
 import 'package:miriago/widgets/reference_image_placeholder.dart';
 
@@ -40,7 +42,7 @@ Future<void> _pumpAppWithEmptyPlan(WidgetTester tester) async {
 }
 
 Future<void> _openPlanMenu(WidgetTester tester) async {
-  await tester.tap(find.byTooltip('计划操作').first);
+  await tester.tap(find.byKey(const ValueKey('plan-actions-toggle')));
   await tester.pumpAndSettle();
 }
 
@@ -166,6 +168,214 @@ void main() {
     expect(find.text('默认计划'), findsOneWidget);
     expect(find.text('井用机前步行道'), findsWidgets);
     expect(find.textContaining('1 部作品'), findsOneWidget);
+    final planTitle = tester.widget<Text>(
+      find.descendant(of: find.byType(AppBar), matching: find.text('示例计划')),
+    );
+    expect(planTitle.style?.fontSize, 20);
+    expect(planTitle.style?.fontWeight, FontWeight.w900);
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
+    final metaStrip = tester.widget<Padding>(
+      find.byKey(const ValueKey('plan-meta-strip')),
+    );
+    expect(metaStrip.padding, const EdgeInsets.fromLTRB(16, 0, 16, 8));
+    final metaText = tester.widget<Text>(
+      find.byKey(const ValueKey('plan-meta-text')),
+    );
+    expect(metaText.textAlign, TextAlign.left);
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('plan-meta-text'))).dx,
+      closeTo(16, 0.1),
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-meta-strip')),
+        matching: find.byIcon(Icons.movie_filter_outlined),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('plan actions expand inline and keep five actions', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpApp(tester);
+
+    final switchButton = find.byKey(const ValueKey('plan-switch-button'));
+    final toggleButton = find.byKey(const ValueKey('plan-actions-toggle'));
+    final collapsedAppBarRect = tester.getRect(find.byType(AppBar));
+    final collapsedToggleRect = tester.getRect(toggleButton);
+    expect(switchButton, findsOneWidget);
+    expect(toggleButton, findsOneWidget);
+    expect(tester.getSize(switchButton), tester.getSize(toggleButton));
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: switchButton,
+        matching: find.byIcon(Icons.swap_horiz),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: toggleButton,
+        matching: find.byIcon(Icons.expand_more),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(toggleButton);
+    await tester.pumpAndSettle();
+
+    final panel = find.byKey(const ValueKey('plan-actions-panel'));
+    expect(panel, findsOneWidget);
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
+    expect(tester.getRect(find.byType(AppBar)), collapsedAppBarRect);
+    expect(tester.getRect(toggleButton), collapsedToggleRect);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
+    expect(
+      find.descendant(
+        of: toggleButton,
+        matching: find.byIcon(Icons.expand_less),
+      ),
+      findsOneWidget,
+    );
+    for (final key in const [
+      'plan-action-cache-references',
+      'plan-action-add-points',
+      'plan-action-manage-points',
+      'plan-action-memo',
+      'plan-action-import-export',
+    ]) {
+      expect(find.byKey(ValueKey(key)), findsOneWidget);
+    }
+    expect(
+      tester.getBottomLeft(panel).dy,
+      lessThanOrEqualTo(
+        tester.getTopLeft(find.byKey(const ValueKey('plan-group-switcher'))).dy,
+      ),
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-action-cache-references')),
+        matching: find.byIcon(Icons.download_for_offline_outlined),
+      ),
+      findsOneWidget,
+    );
+
+    final addPointsRect = tester.getRect(
+      find.byKey(const ValueKey('plan-action-add-points')),
+    );
+    final managePointsRect = tester.getRect(
+      find.byKey(const ValueKey('plan-action-manage-points')),
+    );
+    final cacheReferencesRect = tester.getRect(
+      find.byKey(const ValueKey('plan-action-cache-references')),
+    );
+    expect(addPointsRect.top, closeTo(managePointsRect.top, 0.1));
+    expect(addPointsRect.bottom, closeTo(managePointsRect.bottom, 0.1));
+    expect(cacheReferencesRect.top, greaterThan(addPointsRect.bottom));
+    expect(cacheReferencesRect.left, closeTo(addPointsRect.left, 0.1));
+
+    await tester.tap(find.byKey(const ValueKey('plan-action-add-points')));
+    await tester.pumpAndSettle();
+    expect(find.byType(AddPointsScreen), findsOneWidget);
+    expect(find.byTooltip('Back'), findsNothing);
+    final addPointsBackButton = tester.widget<IconButton>(
+      find
+          .descendant(
+            of: find.byType(AppBar),
+            matching: find.byType(IconButton),
+          )
+          .first,
+    );
+    expect(addPointsBackButton.tooltip, isNull);
+    Navigator.of(tester.element(find.byType(AddPointsScreen))).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+
+    await tester.tap(toggleButton);
+    await tester.pumpAndSettle();
+
+    final reopenedPanel = find.byKey(const ValueKey('plan-actions-panel'));
+    expect(reopenedPanel, findsOneWidget);
+    await tester.tapAt(Offset(5, tester.getCenter(reopenedPanel).dy));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
+    expect(
+      find.descendant(
+        of: toggleButton,
+        matching: find.byIcon(Icons.expand_more),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: toggleButton,
+        matching: find.byIcon(Icons.expand_more),
+      ),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('plan actions can ignore taps outside the panel', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(360, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final repository = SamplePilgrimageRepository();
+    await repository.saveAppSettings(
+      const AppSettings(dismissPlanActionsOnOutsideTap: false),
+    );
+    await tester.pumpWidget(MiriaGoApp(repository: repository));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('plan-actions-toggle')));
+    await tester.pumpAndSettle();
+    final panel = find.byKey(const ValueKey('plan-actions-panel'));
+    expect(panel, findsOneWidget);
+
+    await tester.tapAt(Offset(5, tester.getCenter(panel).dy));
+    await tester.pumpAndSettle();
+
+    expect(panel, findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey('plan-action-cache-references')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(ConfirmActionDialog), findsOneWidget);
+
+    final confirmButton = find
+        .descendant(
+          of: find.byType(AppDialogActionRow),
+          matching: find.byType(FilledButton),
+        )
+        .last;
+    await tester.tap(confirmButton);
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
   });
 
   testWidgets('restores the last selected plan group', (tester) async {
@@ -425,6 +635,13 @@ void main() {
 
     await tester.tap(find.text('记录').last);
     await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<AppBar>(find.byKey(const ValueKey('records-app-bar')))
+          .toolbarHeight,
+      kToolbarHeight,
+    );
 
     final title = tester.widget<Text>(
       find.descendant(of: find.byType(AppBar), matching: find.text('记录')),
@@ -727,6 +944,50 @@ void main() {
     expect(tester.testTextInput.isVisible, isFalse);
   });
 
+  testWidgets(
+    'records search empty state explains no matches and clears search',
+    (tester) async {
+      await _pumpApp(tester);
+
+      await tester.tap(find.text('记录').last);
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('records-search-field')),
+        '不存在的巡礼记录',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('records-empty-state')), findsOneWidget);
+      expect(find.text('没有找到相关记录'), findsOneWidget);
+      expect(find.byIcon(Icons.search_off_rounded), findsOneWidget);
+      expect(find.textContaining('点位、作品或场景'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('records-empty-clear-search')),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('records-empty-clear-search')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('records-empty-state')), findsNothing);
+      expect(
+        find.byKey(const ValueKey('record-card-sample-record-jr-uji-01')),
+        findsOneWidget,
+      );
+      expect(
+        tester
+            .widget<TextField>(
+              find.byKey(const ValueKey('records-search-field')),
+            )
+            .controller
+            ?.text,
+        isEmpty,
+      );
+    },
+  );
+
   testWidgets('records can filter by work and plan group', (tester) async {
     await _pumpApp(tester);
 
@@ -941,6 +1202,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('记录详情'), findsOneWidget);
+    expect(tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight, 44);
+    final backButton = tester.widget<IconButton>(
+      find.descendant(
+        of: find.byKey(const ValueKey('record-detail-back-button')),
+        matching: find.byType(IconButton),
+      ),
+    );
+    expect(backButton.tooltip, isNull);
+    expect(
+      tester.getSize(
+        find.descendant(
+          of: find.byKey(const ValueKey('record-detail-back-button')),
+          matching: find.byType(IconButton),
+        ),
+      ),
+      const Size.square(40),
+    );
+    expect(
+      tester
+          .widget<Icon>(
+            find.descendant(
+              of: find.byKey(const ValueKey('record-detail-back-button')),
+              matching: find.byType(Icon),
+            ),
+          )
+          .semanticLabel,
+      '返回',
+    );
 
     await tester.tap(find.byTooltip('删除记录'));
     await tester.pumpAndSettle();
@@ -1285,6 +1574,28 @@ void main() {
     );
   });
 
+  testWidgets(
+    'map point card content opens detail and keeps navigation actions',
+    (tester) async {
+      await _pumpApp(tester);
+
+      await tester.tap(find.byIcon(Icons.map_outlined).last);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.info_outline), findsNothing);
+      expect(find.byIcon(Icons.near_me_outlined), findsNWidgets(2));
+
+      await tester.tap(
+        find.byKey(
+          const ValueKey('map-point-card-content-anitabi-115908-7evkbmy2'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PointDetailSheet), findsOneWidget);
+    },
+  );
+
   testWidgets('plan map marker opens detail after selecting the point', (
     tester,
   ) async {
@@ -1495,6 +1806,76 @@ void main() {
     expect(find.textContaining('桌面启动器'), findsNothing);
   });
 
+  testWidgets('aligns plan, records, and settings root app bars', (
+    tester,
+  ) async {
+    await _pumpApp(tester);
+
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
+    final planAppBarTop = tester.getTopLeft(find.byType(AppBar)).dy;
+    final planActionTop = tester
+        .getTopLeft(find.byKey(const ValueKey('plan-actions-toggle')))
+        .dy;
+
+    await tester.tap(find.text('记录').last);
+    await tester.pumpAndSettle();
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('records-app-bar'))).dy,
+      closeTo(planAppBarTop, 0.1),
+    );
+    final recordsTitleTop = tester
+        .getTopLeft(
+          find.descendant(
+            of: find.byKey(const ValueKey('records-app-bar')),
+            matching: find.text('记录'),
+          ),
+        )
+        .dy;
+    final recordsActionTop = tester
+        .getTopLeft(find.byKey(const ValueKey('records-toggle-all-sections')))
+        .dy;
+    expect(recordsActionTop, closeTo(planActionTop, 0.1));
+
+    await tester.tap(find.text('设置').last);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<AppBar>(find.byKey(const ValueKey('settings-app-bar')))
+          .toolbarHeight,
+      kToolbarHeight,
+    );
+    expect(
+      tester
+          .getTopLeft(
+            find.descendant(
+              of: find.byKey(const ValueKey('settings-app-bar')),
+              matching: find.text('设置'),
+            ),
+          )
+          .dy,
+      closeTo(recordsTitleTop, 0.1),
+    );
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('settings-reset-button'))).dy,
+      closeTo(recordsActionTop, 0.1),
+    );
+    expect(
+      tester
+          .getTopRight(find.byKey(const ValueKey('settings-reset-button')))
+          .dx,
+      closeTo(
+        tester
+            .getTopRight(find.byKey(const ValueKey('settings-appearance-card')))
+            .dx,
+        0.1,
+      ),
+    );
+  });
+
   testWidgets('restores app and comparison settings together', (tester) async {
     final configured = const ComparisonExportConfig(
       borderWidthPercent: 2,
@@ -1547,6 +1928,15 @@ void main() {
       find.byKey(const ValueKey('plan-group-progress-toggle')),
     );
     expect(progressToggle.value, isTrue);
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('dismiss-plan-actions-on-outside-tap-toggle')),
+      180,
+      scrollable: find.byType(Scrollable).last,
+    );
+    final dismissToggle = tester.widget<SwitchListTile>(
+      find.byKey(const ValueKey('dismiss-plan-actions-on-outside-tap-toggle')),
+    );
+    expect(dismissToggle.value, isTrue);
 
     Navigator.of(tester.element(find.text('外观设置').first)).pop();
     await tester.pumpAndSettle();
@@ -1782,8 +2172,7 @@ void main() {
     await tester.pumpWidget(MiriaGoApp(repository: repository));
     await tester.pumpAndSettle();
 
-    await _openPlanMenu(tester);
-    await tester.tap(find.text('切换计划'));
+    await tester.tap(find.byKey(const ValueKey('plan-switch-button')));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('current-plan-section')), findsNothing);
     expect(find.byKey(const ValueKey('all-plans-section')), findsOneWidget);
@@ -2027,14 +2416,72 @@ void main() {
     expect(find.text('切换计划'), findsNothing);
   });
 
+  testWidgets('work manager opens a compact delete menu', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(360, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final repository = SamplePilgrimageRepository();
+    final plan = await repository.loadActivePlan();
+    final work = plan.works.first;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: WorkManagerScreen(
+          plan: plan,
+          repository: repository,
+          settings: const AppSettings(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final moreButton = find.byKey(ValueKey('work-manage-more-${work.id}'));
+    expect(moreButton, findsOneWidget);
+    expect(
+      find.descendant(of: moreButton, matching: find.byIcon(Icons.more_horiz)),
+      findsOneWidget,
+    );
+    expect(tester.getSize(moreButton), const Size.square(34));
+    final moreMenu = tester.widget<PopupMenuButton<String>>(moreButton);
+    expect(moreMenu.style?.side?.resolve({}), isNull);
+    expect(find.byKey(const ValueKey('work-action-delete')), findsNothing);
+    final cardBadgeTexts = tester.widgetList<Text>(
+      find.descendant(
+        of: find.byKey(ValueKey('work-manage-badges-${work.id}')),
+        matching: find.byType(Text),
+      ),
+    );
+    expect(cardBadgeTexts, isNotEmpty);
+    for (final badgeText in cardBadgeTexts) {
+      expect(badgeText.maxLines, 1);
+      expect(badgeText.softWrap, isFalse);
+    }
+
+    await tester.tap(moreButton);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('work-action-delete')), findsOneWidget);
+    expect(find.text('删除作品'), findsOneWidget);
+    expect(find.text('作品操作'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('work-action-delete')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('删除作品'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, '删除'), findsOneWidget);
+    await tester.tap(find.text('取消'));
+    await tester.pumpAndSettle();
+    expect(find.text('作品管理'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('switches plan when tapping copyable card title', (tester) async {
     final repository = SamplePilgrimageRepository();
     await repository.createPlan(name: '第二计划', area: '京都');
     await tester.pumpWidget(MiriaGoApp(repository: repository));
     await tester.pumpAndSettle();
 
-    await _openPlanMenu(tester);
-    await tester.tap(find.text('切换计划'));
+    await tester.tap(find.byKey(const ValueKey('plan-switch-button')));
     await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('plan-card-title-sample-uji-hibike')),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -167,7 +167,6 @@ void main() {
     expect(find.text('宇治站附近'), findsWidgets);
     expect(find.text('默认计划'), findsOneWidget);
     expect(find.text('井用机前步行道'), findsWidgets);
-    expect(find.textContaining('1 部作品'), findsOneWidget);
     final planTitle = tester.widget<Text>(
       find.descendant(of: find.byType(AppBar), matching: find.text('示例计划')),
     );
@@ -177,25 +176,8 @@ void main() {
       tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
       kToolbarHeight,
     );
-    final metaStrip = tester.widget<Padding>(
-      find.byKey(const ValueKey('plan-meta-strip')),
-    );
-    expect(metaStrip.padding, const EdgeInsets.fromLTRB(16, 0, 16, 8));
-    final metaText = tester.widget<Text>(
-      find.byKey(const ValueKey('plan-meta-text')),
-    );
-    expect(metaText.textAlign, TextAlign.left);
-    expect(
-      tester.getTopLeft(find.byKey(const ValueKey('plan-meta-text'))).dx,
-      closeTo(16, 0.1),
-    );
-    expect(
-      find.descendant(
-        of: find.byKey(const ValueKey('plan-meta-strip')),
-        matching: find.byIcon(Icons.movie_filter_outlined),
-      ),
-      findsNothing,
-    );
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-text')), findsNothing);
   });
 
   testWidgets('plan actions expand inline and keep five actions', (
@@ -213,8 +195,8 @@ void main() {
     expect(toggleButton, findsOneWidget);
     expect(tester.getSize(switchButton), tester.getSize(toggleButton));
     expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
-    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
-    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
     expect(
       find.descendant(
         of: switchButton,
@@ -304,8 +286,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
-    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
-    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
 
     await tester.tap(toggleButton);
     await tester.pumpAndSettle();
@@ -327,8 +309,8 @@ void main() {
       tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
       kToolbarHeight,
     );
-    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
-    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
     expect(
       find.descendant(
         of: toggleButton,
@@ -1202,7 +1184,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('记录详情'), findsOneWidget);
-    expect(tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight, 44);
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
     final backButton = tester.widget<IconButton>(
       find.descendant(
         of: find.byKey(const ValueKey('record-detail-back-button')),
@@ -1953,6 +1938,7 @@ void main() {
 
     expect(find.text('最大缩放倍率'), findsOneWidget);
     expect(find.text('地图标记大小'), findsOneWidget);
+    expect(find.text('隐藏已完成点位'), findsOneWidget);
     expect(find.text('片区范围半径'), findsOneWidget);
     expect(find.text('显示片区进度条'), findsNothing);
     expect(find.text('90%'), findsOneWidget);


### PR DESCRIPTION
## 简介

本次更新集中优化地图、计划、记录与设置页面的交互和视觉一致性，并补充跨平台设置持久化。最新一版默认在地图上隐藏已完成点位，同时精简计划页标题区，统一其余页面的 AppBar 高度。

## 主要修改

- 地图点位卡片支持点击打开详情，调整详情与导航图标
- 重构计划操作面板，保留五项操作并支持二级页面、缓存及点击空白后的自动收回
- 新增“点击空白收回计划操作”外观设置，并持久化到桌面 JSON 与移动端 SQLite
- 去掉计划页片区摘要和计划名称下方小标题，让标题区更紧凑
- 计划页展开操作按钮贴齐右侧，不与记录页 AppBar 按钮留白对齐
- 统一非计划页 AppBar 高度（记录、记录详情、点位拍摄记录、设置等）
- 优化记录页搜索无结果状态、标题栏布局和记录详情交互
- 统一无 tooltip 返回按钮并缩小 hover 范围
- 优化作品管理更多菜单、badge 与全局弹出菜单样式
- 统一删除及其他确认弹窗的双按钮同行布局
- Anitabi 服务地址改为导航入口，直接显示当前主站及默认/自定义状态
- 地图页默认隐藏已完成点位，可在设置 → 地图显示中关闭
- SQLite schema 升级至 40，并补充桌面端和移动端迁移与持久化测试

## 验证

- Flutter 组件与布局回归测试通过
- 桌面 JSON 与移动端 SQLite 持久化测试通过
- schema 38 到 40 迁移测试通过
- 相关文件静态分析通过
- Web 构建成功