### PR TITLE
feat: polish plan/map chrome, in-app nav, and status feedback

### DIFF
--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -18,16 +18,21 @@ import 'plan_transfer/incoming_plan_file.dart';
 import 'plan_transfer/plan_import_file_stub.dart'
     if (dart.library.io) 'plan_transfer/plan_import_file_io.dart';
 import 'plan_transfer/plan_import_preview_screen.dart';
+import 'widgets/snackbar_helper.dart';
 import 'records/records_screen.dart';
 import 'records/comparison_export_config_migration.dart';
 import 'settings/settings_screen.dart';
 import 'widgets/app_scaled_route.dart';
 
 class AppShell extends StatefulWidget {
-  AppShell({PilgrimageRepository? repository, super.key})
-    : repository = repository ?? SamplePilgrimageRepository();
+  AppShell({
+    PilgrimageRepository? repository,
+    this.onSettingsChanged,
+    super.key,
+  }) : repository = repository ?? SamplePilgrimageRepository();
 
   final PilgrimageRepository repository;
+  final ValueChanged<AppSettings>? onSettingsChanged;
 
   @override
   State<AppShell> createState() => _AppShellState();
@@ -70,6 +75,7 @@ class _AppShellState extends State<AppShell> {
       }
 
       _applyAnitabiServiceConfig(settings);
+      _publishSettingsAfterLoad(settings);
       _planController?.dispose();
       setState(() {
         _planController = PilgrimagePlanController(
@@ -170,10 +176,28 @@ class _AppShellState extends State<AppShell> {
 
   Future<void> _saveSettings(AppSettings settings) async {
     _applyAnitabiServiceConfig(settings);
+    applyAppColorsFromSettings(
+      settings,
+      platformBrightness: currentPlatformBrightness(),
+    );
+    widget.onSettingsChanged?.call(settings);
     setState(() {
       _settings = settings;
     });
     await widget.repository.saveAppSettings(settings);
+  }
+
+  void _publishSettingsAfterLoad(AppSettings settings) {
+    final callback = widget.onSettingsChanged;
+    if (callback == null) {
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      callback(settings);
+    });
   }
 
   void _applyAnitabiServiceConfig(AppSettings settings) {
@@ -218,18 +242,31 @@ class _AppShellState extends State<AppShell> {
       }
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('计划文件导入失败')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '计划文件导入失败');
     }
   }
 
   @override
   Widget build(BuildContext context) {
     final controller = _planController;
-    AppColors.palette = _settings.themePalette;
-    AppColors.customAccentValue = _settings.customThemeColorValue;
+    final platformBrightness = MediaQuery.platformBrightnessOf(context);
+    applyAppColorsFromSettings(
+      _settings,
+      platformBrightness: platformBrightness,
+    );
+    final brightness = resolvedAppBrightness(
+      _settings,
+      platformBrightness: platformBrightness,
+    );
 
     if (controller == null) {
-      return _PlanLoadState(error: _loadError, onRetry: _loadActivePlan);
+      return Theme(
+        data: appThemeFor(
+          _settings,
+          platformBrightness: MediaQuery.platformBrightnessOf(context),
+        ),
+        child: _PlanLoadState(error: _loadError, onRetry: _loadActivePlan),
+      );
     }
 
     return ListenableBuilder(
@@ -244,11 +281,13 @@ class _AppShellState extends State<AppShell> {
             child: AppUiScaleView(
               scale: _settings.uiScale,
               child: Theme(
-                data: AppTheme.light(
+                data: AppTheme.of(
+                  brightness: brightness,
                   palette: _settings.themePalette,
                   customAccentValue: _settings.customThemeColorValue,
                 ),
                 child: Scaffold(
+                  backgroundColor: AppColors.background,
                   body: IndexedStack(
                     index: _selectedIndex,
                     children: [
@@ -262,9 +301,12 @@ class _AppShellState extends State<AppShell> {
                         onOpenPointManager: _openPointManager,
                         onOpenImportExport: _openImportExport,
                       ),
-                      PilgrimageMapScreen(
-                        controller: controller,
-                        settings: _settings,
+                      TickerMode(
+                        enabled: _selectedIndex == 1,
+                        child: PilgrimageMapScreen(
+                          controller: controller,
+                          settings: _settings,
+                        ),
                       ),
                       RecordsScreen(
                         controller: controller,
@@ -285,13 +327,11 @@ class _AppShellState extends State<AppShell> {
                           return IconThemeData(color: AppColors.onAccent);
                         }
 
-                        return const IconThemeData(
-                          color: AppColors.textPrimary,
-                        );
+                        return IconThemeData(color: AppColors.textPrimary);
                       }),
                       labelTextStyle: WidgetStateProperty.resolveWith((states) {
                         if (states.contains(WidgetState.selected)) {
-                          return const TextStyle(
+                          return TextStyle(
                             color: AppColors.textPrimary,
                             fontSize: 12,
                             fontWeight: FontWeight.w800,
@@ -299,7 +339,7 @@ class _AppShellState extends State<AppShell> {
                           );
                         }
 
-                        return const TextStyle(
+                        return TextStyle(
                           color: AppColors.textPrimary,
                           fontSize: 12,
                           fontWeight: FontWeight.w500,
@@ -388,7 +428,7 @@ class _PlanLoadState extends StatelessWidget {
               Text(
                 hasError ? '请稍后重试。' : '准备今日点位和当前目标。',
                 textAlign: TextAlign.center,
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 14,
                   letterSpacing: 0,
@@ -399,7 +439,7 @@ class _PlanLoadState extends StatelessWidget {
                 SelectableText(
                   error.toString(),
                   textAlign: TextAlign.center,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.error,
                     fontSize: 12,
                     letterSpacing: 0,

--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 export 'widgets/keyboard_dismiss_on_tap.dart' show dismissKeyboardOnTapOutside;
 
@@ -9,13 +10,38 @@ class AppColors {
 
   static AppThemePalette palette = AppThemePalette.classicGreen;
   static int customAccentValue = 0xFF16C6A8;
+  static Brightness brightness = Brightness.light;
 
-  static const background = Color(0xFFF7F8FA);
-  static const surface = Color(0xFFFFFFFF);
-  static const surfaceMuted = Color(0xFFEEF1F4);
-  static const textPrimary = Color(0xFF111827);
-  static const textSecondary = Color(0xFF5B6472);
-  static const border = Color(0xFFD8DEE6);
+  static bool get isDark => brightness == Brightness.dark;
+
+  static const _lightBackground = Color(0xFFF7F8FA);
+  static const _darkBackground = Color(0xFF121417);
+  static const _lightSurface = Color(0xFFFFFFFF);
+  static const _darkSurface = Color(0xFF1C1C1E);
+  static const _lightSurfaceMuted = Color(0xFFEEF1F4);
+  static const _darkSurfaceMuted = Color(0xFF1C1C1E);
+  static const _lightTextPrimary = Color(0xFF111827);
+  static const _darkTextPrimary = Color(0xFFF3F4F6);
+  static const _lightTextSecondary = Color(0xFF5B6472);
+  static const _darkTextSecondary = Color(0xFF9CA3AF);
+  static const _lightBorder = Color(0xFFD8DEE6);
+  static const _darkBorder = Color(0xFF2C2C2E);
+  static const _lightWarning = Color(0xFFC87900);
+  static const _darkWarning = Color(0xFFE0A33A);
+  static const _lightError = Color(0xFFC2413A);
+  static const _darkError = Color(0xFFE56A64);
+
+  static Color get background => isDark ? _darkBackground : _lightBackground;
+  static Color get surface => isDark ? _darkSurface : _lightSurface;
+  static Color get surfaceMuted =>
+      isDark ? _darkSurfaceMuted : _lightSurfaceMuted;
+  static Color get textPrimary => isDark ? _darkTextPrimary : _lightTextPrimary;
+  static Color get textSecondary =>
+      isDark ? _darkTextSecondary : _lightTextSecondary;
+  static Color get border => isDark ? _darkBorder : _lightBorder;
+  static Color get warning => isDark ? _darkWarning : _lightWarning;
+  static Color get error => isDark ? _darkError : _lightError;
+
   static const miriaYellow = Color(0xFFFFCE00);
   static const miriaYellowDark = Color(0xFFB77C00);
   static const classicGreen = Color(0xFF0F8B8D);
@@ -30,12 +56,13 @@ class AppColors {
   static const graphiteDark = Color(0xFF000000);
   static const aurora = Color(0xFF16C6A8);
   static const auroraDark = Color(0xFF0A7E83);
-  static const warning = Color(0xFFC87900);
-  static const error = Color(0xFFC2413A);
   static const cameraDarkSurface = Color(0xFF101418);
   static const cameraDarkOverlay = Color(0xFF171C21);
 
   static Color get accent {
+    if (isDark && palette == AppThemePalette.graphite) {
+      return const Color(0xFFD1D5DB);
+    }
     return switch (palette) {
       AppThemePalette.classicGreen => classicGreen,
       AppThemePalette.deepBlue => deepBlue,
@@ -48,6 +75,9 @@ class AppColors {
   }
 
   static Color get accentDark {
+    if (isDark && palette == AppThemePalette.graphite) {
+      return const Color(0xFF9CA3AF);
+    }
     return switch (palette) {
       AppThemePalette.classicGreen => classicGreenDark,
       AppThemePalette.deepBlue => deepBlueDark,
@@ -65,8 +95,8 @@ class AppColors {
       AppThemePalette.deepBlue => Colors.white,
       AppThemePalette.cherryPink => Colors.white,
       AppThemePalette.twilightPurple => Colors.white,
-      AppThemePalette.miriaYellow => textPrimary,
-      AppThemePalette.graphite => Colors.white,
+      AppThemePalette.miriaYellow => _lightTextPrimary,
+      AppThemePalette.graphite => isDark ? _lightTextPrimary : Colors.white,
       AppThemePalette.aurora => _foregroundFor(Color(customAccentValue)),
     };
   }
@@ -77,7 +107,29 @@ class AppColors {
   }
 
   static Color _foregroundFor(Color color) {
-    return color.computeLuminance() > 0.55 ? textPrimary : Colors.white;
+    return color.computeLuminance() > 0.55 ? _lightTextPrimary : Colors.white;
+  }
+}
+
+/// Settings chrome uses a 1px *gap* over a filled [AppColors.border] parent
+/// instead of a 1px stroke. Flutter web rasterizes horizontal (and rotated)
+/// hairlines as near-white lines.
+class AppHairline extends StatelessWidget {
+  const AppHairline({super.key, this.color, this.axis = Axis.horizontal});
+
+  final Color? color;
+  final Axis axis;
+
+  @override
+  Widget build(BuildContext context) {
+    final lineColor = color ?? AppColors.border;
+    if (axis == Axis.vertical) {
+      return ColoredBox(color: lineColor, child: const SizedBox(width: 1));
+    }
+    return ColoredBox(
+      color: lineColor,
+      child: const SizedBox(height: 1, width: double.infinity),
+    );
   }
 }
 
@@ -90,10 +142,34 @@ class AppTheme {
     AppThemePalette palette = AppThemePalette.classicGreen,
     int customAccentValue = 0xFF16C6A8,
   }) {
+    return of(
+      brightness: Brightness.light,
+      palette: palette,
+      customAccentValue: customAccentValue,
+    );
+  }
+
+  static ThemeData dark({
+    AppThemePalette palette = AppThemePalette.classicGreen,
+    int customAccentValue = 0xFF16C6A8,
+  }) {
+    return of(
+      brightness: Brightness.dark,
+      palette: palette,
+      customAccentValue: customAccentValue,
+    );
+  }
+
+  static ThemeData of({
+    required Brightness brightness,
+    AppThemePalette palette = AppThemePalette.classicGreen,
+    int customAccentValue = 0xFF16C6A8,
+  }) {
+    AppColors.brightness = brightness;
     AppColors.palette = palette;
     AppColors.customAccentValue = customAccentValue;
     final colorScheme = ColorScheme(
-      brightness: Brightness.light,
+      brightness: brightness,
       primary: AppColors.accent,
       onPrimary: AppColors.onAccent,
       secondary: AppColors.accentDark,
@@ -102,23 +178,37 @@ class AppTheme {
       onError: Colors.white,
       surface: AppColors.surface,
       onSurface: AppColors.textPrimary,
+      onSurfaceVariant: AppColors.textSecondary,
+      outline: AppColors.border,
+      outlineVariant: AppColors.border,
+      surfaceContainerLowest: AppColors.background,
+      surfaceContainerLow: AppColors.surface,
+      surfaceContainer: AppColors.surface,
+      surfaceContainerHigh: AppColors.surfaceMuted,
+      surfaceContainerHighest: AppColors.surfaceMuted,
+      inverseSurface: AppColors.textPrimary,
+      onInverseSurface: AppColors.background,
+      inversePrimary: AppColors.accentDark,
     );
 
     final base = ThemeData(
       useMaterial3: true,
-      brightness: Brightness.light,
+      brightness: brightness,
       colorScheme: colorScheme,
       scaffoldBackgroundColor: AppColors.background,
       fontFamily: null,
     );
 
     return base.copyWith(
-      appBarTheme: const AppBarTheme(
+      appBarTheme: AppBarTheme(
         backgroundColor: AppColors.background,
         foregroundColor: AppColors.textPrimary,
         elevation: 0,
         toolbarHeight: AppTheme.appBarHeight,
         centerTitle: false,
+        systemOverlayStyle: brightness == Brightness.dark
+            ? SystemUiOverlayStyle.light
+            : SystemUiOverlayStyle.dark,
         titleTextStyle: TextStyle(
           color: AppColors.textPrimary,
           fontSize: 20,
@@ -126,10 +216,16 @@ class AppTheme {
           letterSpacing: 0,
         ),
       ),
+      iconTheme: IconThemeData(color: AppColors.textPrimary),
+      listTileTheme: ListTileThemeData(
+        iconColor: AppColors.textSecondary,
+        textColor: AppColors.textPrimary,
+      ),
       textTheme: base.textTheme.apply(
         bodyColor: AppColors.textPrimary,
         displayColor: AppColors.textPrimary,
       ),
+      dividerColor: AppColors.border,
       filledButtonTheme: FilledButtonThemeData(
         style: FilledButton.styleFrom(
           backgroundColor: AppColors.accent,
@@ -149,7 +245,7 @@ class AppTheme {
         style: OutlinedButton.styleFrom(
           foregroundColor: AppColors.textPrimary,
           minimumSize: const Size(44, 44),
-          side: const BorderSide(color: AppColors.border),
+          side: BorderSide(color: AppColors.border),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           textStyle: const TextStyle(
             fontSize: 15,
@@ -174,9 +270,9 @@ class AppTheme {
         position: PopupMenuPosition.under,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8),
-          side: const BorderSide(color: AppColors.border),
+          side: BorderSide(color: AppColors.border),
         ),
-        textStyle: const TextStyle(
+        textStyle: TextStyle(
           color: AppColors.textPrimary,
           fontSize: 14,
           fontWeight: FontWeight.w600,
@@ -194,9 +290,7 @@ class AppTheme {
           padding: const WidgetStatePropertyAll(
             EdgeInsets.symmetric(vertical: 4),
           ),
-          side: const WidgetStatePropertyAll(
-            BorderSide(color: AppColors.border),
-          ),
+          side: WidgetStatePropertyAll(BorderSide(color: AppColors.border)),
           shape: WidgetStatePropertyAll(
             RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           ),
@@ -204,7 +298,7 @@ class AppTheme {
       ),
       menuButtonTheme: MenuButtonThemeData(
         style: ButtonStyle(
-          foregroundColor: const WidgetStatePropertyAll(AppColors.textPrimary),
+          foregroundColor: WidgetStatePropertyAll(AppColors.textPrimary),
           minimumSize: const WidgetStatePropertyAll(Size(0, 44)),
           padding: const WidgetStatePropertyAll(
             EdgeInsets.symmetric(horizontal: 12),
@@ -228,13 +322,27 @@ class AppTheme {
         overlayColor: AppColors.accent.withValues(alpha: 0.12),
       ),
       snackBarTheme: const SnackBarThemeData(
-        backgroundColor: AppColors.cameraDarkOverlay,
-        contentTextStyle: TextStyle(
-          color: Colors.white,
-          fontSize: 14,
-          letterSpacing: 0,
-        ),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
         behavior: SnackBarBehavior.floating,
+      ),
+      dialogTheme: DialogThemeData(
+        backgroundColor: AppColors.surface,
+        surfaceTintColor: Colors.transparent,
+      ),
+      bottomSheetTheme: BottomSheetThemeData(
+        backgroundColor: AppColors.surface,
+        surfaceTintColor: Colors.transparent,
+      ),
+      navigationBarTheme: NavigationBarThemeData(
+        backgroundColor: AppColors.surface,
+        indicatorColor: AppColors.accent,
+        surfaceTintColor: Colors.transparent,
+      ),
+      dividerTheme: DividerThemeData(
+        color: AppColors.border,
+        space: 1,
+        thickness: 1,
       ),
     );
   }
@@ -249,6 +357,47 @@ TextScaler appTextScaler(double fontScale) {
 double appUiScaler(double uiScale) {
   final clampedScale = uiScale.clamp(0.8, 1.0);
   return 1 + (clampedScale - 1) * 0.72;
+}
+
+Brightness resolvedAppBrightness(
+  AppSettings settings, {
+  required Brightness platformBrightness,
+}) {
+  return switch (settings.themeMode) {
+    AppThemeMode.light => Brightness.light,
+    AppThemeMode.dark => Brightness.dark,
+    AppThemeMode.system => platformBrightness,
+  };
+}
+
+ThemeData appThemeFor(
+  AppSettings settings, {
+  required Brightness platformBrightness,
+}) {
+  return AppTheme.of(
+    brightness: resolvedAppBrightness(
+      settings,
+      platformBrightness: platformBrightness,
+    ),
+    palette: settings.themePalette,
+    customAccentValue: settings.customThemeColorValue,
+  );
+}
+
+void applyAppColorsFromSettings(
+  AppSettings settings, {
+  required Brightness platformBrightness,
+}) {
+  AppColors.brightness = resolvedAppBrightness(
+    settings,
+    platformBrightness: platformBrightness,
+  );
+  AppColors.palette = settings.themePalette;
+  AppColors.customAccentValue = settings.customThemeColorValue;
+}
+
+Brightness currentPlatformBrightness() {
+  return WidgetsBinding.instance.platformDispatcher.platformBrightness;
 }
 
 class AppUiScaleView extends StatelessWidget {
@@ -315,7 +464,7 @@ class AppButtonStyles {
       minimumSize: compactSize,
       padding: EdgeInsets.zero,
       visualDensity: VisualDensity.standard,
-      side: const BorderSide(color: AppColors.border),
+      side: BorderSide(color: AppColors.border),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
     );
   }

--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -162,6 +162,62 @@ class AppTheme {
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
       ),
+      popupMenuTheme: PopupMenuThemeData(
+        color: AppColors.surface,
+        surfaceTintColor: Colors.transparent,
+        elevation: 8,
+        shadowColor: Colors.black.withValues(alpha: 0.16),
+        menuPadding: const EdgeInsets.symmetric(vertical: 4),
+        position: PopupMenuPosition.under,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+          side: const BorderSide(color: AppColors.border),
+        ),
+        textStyle: const TextStyle(
+          color: AppColors.textPrimary,
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+      ),
+      menuTheme: MenuThemeData(
+        style: MenuStyle(
+          backgroundColor: WidgetStatePropertyAll(AppColors.surface),
+          surfaceTintColor: const WidgetStatePropertyAll(Colors.transparent),
+          elevation: const WidgetStatePropertyAll(8),
+          shadowColor: WidgetStatePropertyAll(
+            Colors.black.withValues(alpha: 0.16),
+          ),
+          padding: const WidgetStatePropertyAll(
+            EdgeInsets.symmetric(vertical: 4),
+          ),
+          side: const WidgetStatePropertyAll(
+            BorderSide(color: AppColors.border),
+          ),
+          shape: WidgetStatePropertyAll(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+          ),
+        ),
+      ),
+      menuButtonTheme: MenuButtonThemeData(
+        style: ButtonStyle(
+          foregroundColor: const WidgetStatePropertyAll(AppColors.textPrimary),
+          minimumSize: const WidgetStatePropertyAll(Size(0, 44)),
+          padding: const WidgetStatePropertyAll(
+            EdgeInsets.symmetric(horizontal: 12),
+          ),
+          textStyle: const WidgetStatePropertyAll(
+            TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0,
+            ),
+          ),
+          shape: WidgetStatePropertyAll(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
+          ),
+        ),
+      ),
       sliderTheme: base.sliderTheme.copyWith(
         activeTrackColor: AppColors.accent,
         inactiveTrackColor: AppColors.border,

--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -84,6 +84,8 @@ class AppColors {
 class AppTheme {
   const AppTheme._();
 
+  static const double appBarHeight = kToolbarHeight;
+
   static ThemeData light({
     AppThemePalette palette = AppThemePalette.classicGreen,
     int customAccentValue = 0xFF16C6A8,
@@ -115,6 +117,7 @@ class AppTheme {
         backgroundColor: AppColors.background,
         foregroundColor: AppColors.textPrimary,
         elevation: 0,
+        toolbarHeight: AppTheme.appBarHeight,
         centerTitle: false,
         titleTextStyle: TextStyle(
           color: AppColors.textPrimary,

--- a/lib/camera_reference/camerawesome_reference_screen.dart
+++ b/lib/camera_reference/camerawesome_reference_screen.dart
@@ -18,6 +18,7 @@ import '../plan/pilgrimage_plan_controller.dart';
 import '../plan/reference_image_status.dart';
 import '../records/visit_record_file_ops_stub.dart'
     if (dart.library.io) '../records/visit_record_file_ops_io.dart';
+import '../widgets/snackbar_helper.dart';
 import '../widgets/anitabi_network_image.dart';
 import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
@@ -31,6 +32,7 @@ import 'camera_zoom_capabilities.dart';
 import 'gallery_capture_time_stub.dart'
     if (dart.library.io) 'gallery_capture_time_io.dart';
 import 'photo_location.dart';
+import 'photo_location_choice_sheet.dart';
 import 'reference_image_bytes_stub.dart'
     if (dart.library.io) 'reference_image_bytes_io.dart'
     as reference_image_bytes;
@@ -200,7 +202,7 @@ class _CamerawesomeReferenceScreenState
       }
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('照片导入失败，请重新选择。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '照片导入失败，请重新选择。');
       await _restoreCameraOrientation(landscape: restoreLandscape);
       return;
     }
@@ -342,40 +344,8 @@ class _CamerawesomeReferenceScreenState
     final selected = await showModalBottomSheet<PhotoLocationStrategy>(
       context: context,
       showDragHandle: true,
-      builder: (context) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const ListTile(
-              title: Text('是否在巡礼照片中记录定位？'),
-              subtitle: Text('以后可以在“拍摄设置”中修改。不会使用点位坐标代替实际定位。'),
-            ),
-            ListTile(
-              leading: const Icon(Icons.history_toggle_off_outlined),
-              title: const Text('使用最近一次定位'),
-              subtitle: const Text('优先快速写入近期有效定位，没有时获取一次。'),
-              onTap: () => Navigator.of(
-                context,
-              ).pop(PhotoLocationStrategy.useRecentLocation),
-            ),
-            ListTile(
-              leading: const Icon(Icons.my_location_outlined),
-              title: const Text('确认记录时获取定位（推荐）'),
-              subtitle: const Text('拍摄后在确认页面等待新定位，适合需要更准确位置时。'),
-              onTap: () => Navigator.of(
-                context,
-              ).pop(PhotoLocationStrategy.waitOnConfirmation),
-            ),
-            ListTile(
-              leading: const Icon(Icons.location_off_outlined),
-              title: const Text('不记录定位'),
-              onTap: () =>
-                  Navigator.of(context).pop(PhotoLocationStrategy.disabled),
-            ),
-            const SizedBox(height: 8),
-          ],
-        ),
-      ),
+      isScrollControlled: true,
+      builder: (context) => const PhotoLocationChoiceSheet(),
     );
     if (selected == null || !mounted) {
       return null;
@@ -401,10 +371,9 @@ class _CamerawesomeReferenceScreenState
       return await resolveRecentPhotoLocation();
     } on CurrentLocationException catch (error) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('${currentLocationFailureMessage(error)}本次照片不记录定位。'),
-          ),
+        ScaffoldMessenger.of(context).showStatusSnack(
+          kind: AppStatusBannerKind.warning,
+          title: '${currentLocationFailureMessage(error)}本次照片不记录定位。',
         );
       }
       return null;
@@ -412,7 +381,10 @@ class _CamerawesomeReferenceScreenState
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(const SnackBar(content: Text('定位获取失败，本次照片不记录定位。')));
+        ).showStatusSnack(
+          kind: AppStatusBannerKind.warning,
+          title: '定位获取失败，本次照片不记录定位。',
+        );
       }
       return null;
     }
@@ -504,8 +476,10 @@ class _CamerawesomeReferenceScreenState
               onOpacityChanged: (value) => _overlayOpacity.value = value,
               onCapture: () async {
                 if (_shouldWaitForReferenceAspectRatio(reference)) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('正在读取参考图比例，请稍后拍摄。')),
+                  ScaffoldMessenger.of(context).showStatusSnack(
+                    kind: AppStatusBannerKind.running,
+                    title: '正在读取参考图比例，请稍后拍摄。',
+                    icon: Icons.aspect_ratio_outlined,
                   );
                   return;
                 }

--- a/lib/camera_reference/camerawesome_reference_screen.dart
+++ b/lib/camera_reference/camerawesome_reference_screen.dart
@@ -1444,7 +1444,8 @@ class _NativeCameraTopBar extends StatelessWidget {
       child: Row(
         children: [
           _CameraCircleButton(
-            tooltip: '返回',
+            tooltip: null,
+            semanticLabel: '返回',
             icon: Icons.arrow_back,
             onPressed: () => Navigator.of(context).maybePop(),
           ),
@@ -1675,7 +1676,8 @@ class _NativeLandscapeLeftRail extends StatelessWidget {
               _CameraCircleButton(
                 size: metrics.controlButtonSize,
                 iconSize: metrics.controlIconSize,
-                tooltip: '返回',
+                tooltip: null,
+                semanticLabel: '返回',
                 icon: Icons.arrow_back,
                 onPressed: onBack,
               ),
@@ -2454,7 +2456,8 @@ class _CameraTopBar extends StatelessWidget {
       child: Row(
         children: [
           _CameraCircleButton(
-            tooltip: '返回',
+            tooltip: null,
+            semanticLabel: '返回',
             icon: Icons.arrow_back,
             onPressed: () => Navigator.of(context).maybePop(),
           ),
@@ -2655,6 +2658,7 @@ class _CameraCircleButton extends StatelessWidget {
     required this.icon,
     required this.onPressed,
     this.text,
+    this.semanticLabel,
     this.size = 44,
     this.iconSize = 21,
   });
@@ -2663,6 +2667,7 @@ class _CameraCircleButton extends StatelessWidget {
   final IconData icon;
   final VoidCallback onPressed;
   final String? text;
+  final String? semanticLabel;
   final double size;
   final double iconSize;
 
@@ -2681,7 +2686,18 @@ class _CameraCircleButton extends StatelessWidget {
         shape: const CircleBorder(),
       ),
       onPressed: onPressed,
-      icon: _CameraButtonIcon(icon: icon, iconSize: iconSize, text: text),
+      icon: semanticLabel == null
+          ? _CameraButtonIcon(icon: icon, iconSize: iconSize, text: text)
+          : Semantics(
+              label: semanticLabel,
+              child: ExcludeSemantics(
+                child: _CameraButtonIcon(
+                  icon: icon,
+                  iconSize: iconSize,
+                  text: text,
+                ),
+              ),
+            ),
     );
     return SizedBox.square(dimension: size, child: button);
   }
@@ -3727,9 +3743,8 @@ class _FallbackTopBar extends StatelessWidget {
       child: Row(
         children: [
           IconButton(
-            tooltip: '返回',
             onPressed: () => Navigator.of(context).maybePop(),
-            icon: const Icon(Icons.arrow_back),
+            icon: const Icon(Icons.arrow_back, semanticLabel: '返回'),
           ),
           Expanded(
             child: Text(

--- a/lib/camera_reference/photo_location_choice_sheet.dart
+++ b/lib/camera_reference/photo_location_choice_sheet.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+
+import '../app_theme.dart';
+import '../plan/pilgrimage_models.dart';
+
+class PhotoLocationChoiceSheet extends StatelessWidget {
+  const PhotoLocationChoiceSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 4, 20, 16),
+        child: Column(
+          key: const ValueKey('photo-location-choice-sheet'),
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '是否在巡礼照片中记录定位？',
+              style: TextStyle(
+                color: AppColors.textPrimary,
+                fontSize: 20,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 0,
+                height: 1.25,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '以后可以在“拍摄设置”中修改。',
+              style: TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 14,
+                height: 1.4,
+                letterSpacing: 0,
+              ),
+            ),
+            Text(
+              '不会使用点位坐标代替实际定位。',
+              style: TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 14,
+                height: 1.4,
+                letterSpacing: 0,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _PhotoLocationChoiceTile(
+              key: const ValueKey('photo-location-choice-recent'),
+              icon: Icons.history_toggle_off_outlined,
+              title: '使用最近一次定位',
+              subtitle: '优先快速写入近期有效定位，没有时获取一次。',
+              onTap: () => Navigator.of(
+                context,
+              ).pop(PhotoLocationStrategy.useRecentLocation),
+            ),
+            const SizedBox(height: 10),
+            _PhotoLocationChoiceTile(
+              key: const ValueKey('photo-location-choice-confirm'),
+              icon: Icons.my_location_outlined,
+              title: '确认记录时获取定位',
+              subtitle: '拍摄后在确认页面等待新定位，适合需要更准确位置时。',
+              recommended: true,
+              highlighted: true,
+              onTap: () => Navigator.of(
+                context,
+              ).pop(PhotoLocationStrategy.waitOnConfirmation),
+            ),
+            const SizedBox(height: 10),
+            _PhotoLocationChoiceTile(
+              key: const ValueKey('photo-location-choice-disabled'),
+              icon: Icons.location_off_outlined,
+              title: '不记录定位',
+              onTap: () =>
+                  Navigator.of(context).pop(PhotoLocationStrategy.disabled),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PhotoLocationChoiceTile extends StatelessWidget {
+  const _PhotoLocationChoiceTile({
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    this.subtitle,
+    this.recommended = false,
+    this.highlighted = false,
+    super.key,
+  });
+
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final bool recommended;
+  final bool highlighted;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor = highlighted
+        ? AppColors.accent
+        : AppColors.border.withValues(alpha: 0.9);
+    final fillColor = highlighted
+        ? AppColors.accent.withValues(alpha: 0.08)
+        : AppColors.surface;
+    return Material(
+      color: fillColor,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: borderColor, width: highlighted ? 1.5 : 1),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                icon,
+                color: highlighted ? AppColors.accent : AppColors.textPrimary,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: AppColors.textPrimary,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w700,
+                              letterSpacing: 0,
+                            ),
+                          ),
+                        ),
+                        if (recommended) ...[
+                          const SizedBox(width: 8),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 6,
+                              vertical: 2,
+                            ),
+                            decoration: BoxDecoration(
+                              color: AppColors.accent.withValues(alpha: 0.08),
+                              border: Border.all(
+                                color: AppColors.accent.withValues(alpha: 0.42),
+                              ),
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: Text(
+                              '推荐',
+                              style: TextStyle(
+                                color: AppColors.accent,
+                                fontSize: 11,
+                                fontWeight: FontWeight.w700,
+                                height: 1.15,
+                                letterSpacing: 0,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        subtitle!,
+                        style: TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 13,
+                          height: 1.35,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/camera_reference/photo_location_status_panel.dart
+++ b/lib/camera_reference/photo_location_status_panel.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../app_theme.dart';
+
+class PhotoLocationStatusPanel extends StatelessWidget {
+  const PhotoLocationStatusPanel({
+    required this.label,
+    required this.loading,
+    this.onSkip,
+    super.key,
+  });
+
+  final String label;
+  final bool loading;
+  final VoidCallback? onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(14, 8, 8, 8),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceMuted,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          if (loading)
+            const SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          else
+            Icon(
+              Icons.location_on_outlined,
+              size: 18,
+              color: AppColors.textSecondary,
+            ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              label,
+              style: TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0,
+              ),
+            ),
+          ),
+          if (onSkip != null)
+            OutlinedButton(
+              onPressed: onSkip,
+              style: AppButtonStyles.compactOutlinedButton(),
+              child: const Text('跳过'),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/camera_reference/visit_record_confirmation_screen.dart
+++ b/lib/camera_reference/visit_record_confirmation_screen.dart
@@ -13,6 +13,7 @@ import '../records/visit_record_photo_stub.dart'
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/anitabi_network_image.dart';
 import '../widgets/reference_image_placeholder.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/reference_image_source_stub.dart'
     if (dart.library.io) '../widgets/reference_image_source_io.dart';
 import '../widgets/reference_thumbnail_stub.dart'
@@ -234,7 +235,10 @@ class _VisitRecordConfirmationScreenState
         }
       },
       child: Scaffold(
-        appBar: AppBar(title: const Text('确认记录')),
+        appBar: AppBar(
+          leading: appBackButtonIfCanPop(context),
+          title: const Text('确认记录'),
+        ),
         body: ListView(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
           children: [

--- a/lib/camera_reference/visit_record_confirmation_screen.dart
+++ b/lib/camera_reference/visit_record_confirmation_screen.dart
@@ -23,6 +23,7 @@ import 'camera_storage_stub.dart'
     if (dart.library.io) 'camera_storage_io.dart'
     as camera_storage;
 import 'photo_location.dart';
+import 'photo_location_status_panel.dart';
 import '../map/current_location_resolver.dart';
 
 enum VisitRecordConfirmationResult { saved, completed }
@@ -215,7 +216,7 @@ class _VisitRecordConfirmationScreenState
     );
     ScaffoldMessenger.of(
       context,
-    ).showReplacingSnackBar(SnackBar(content: Text(message)));
+    ).showStatusSnack(kind: AppStatusBannerKind.success, title: message);
     if (completePoint) {
       Navigator.of(context).pop(VisitRecordConfirmationResult.completed);
     } else {
@@ -229,9 +230,11 @@ class _VisitRecordConfirmationScreenState
       canPop: !_saving,
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop && _saving) {
-          ScaffoldMessenger.of(
-            context,
-          ).showReplacingSnackBar(const SnackBar(content: Text('正在保存记录，请稍候。')));
+          ScaffoldMessenger.of(context).showStatusSnack(
+            kind: AppStatusBannerKind.running,
+            title: '正在保存记录，请稍候。',
+            icon: Icons.save_outlined,
+          );
         }
       },
       child: Scaffold(
@@ -253,7 +256,7 @@ class _VisitRecordConfirmationScreenState
             const SizedBox(height: 4),
             Text(
               '${widget.point.work.title} / ${widget.point.displayEpisodeLabel}',
-              style: const TextStyle(
+              style: TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 14,
                 letterSpacing: 0,
@@ -270,7 +273,7 @@ class _VisitRecordConfirmationScreenState
             _InfoPanel(referenceMode: widget.referenceMode),
             if (_locationStatus != null) ...[
               const SizedBox(height: 12),
-              _PhotoLocationStatusPanel(
+              PhotoLocationStatusPanel(
                 label: _locationStatus!,
                 loading: _locating,
                 onSkip: _locating
@@ -388,8 +391,9 @@ Future<void> _showGallerySaveSheet(
   final success = await saveImageToGallery(photoPath);
   if (!context.mounted) return;
 
-  ScaffoldMessenger.of(context).showReplacingSnackBar(
-    SnackBar(content: Text(success ? '已保存到相册' : '保存失败，请稍后重试。')),
+  ScaffoldMessenger.of(context).showStatusSnack(
+    kind: success ? AppStatusBannerKind.success : AppStatusBannerKind.error,
+    title: success ? '已保存到相册' : '保存失败，请稍后重试。',
   );
 }
 
@@ -470,7 +474,7 @@ class _ImageCompareTile extends StatelessWidget {
         Text(
           label,
           textAlign: TextAlign.center,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textSecondary,
             fontSize: 12,
             fontWeight: FontWeight.w800,
@@ -560,9 +564,9 @@ class _InfoPanel extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const Icon(Icons.layers_outlined, color: AppColors.textSecondary),
+          Icon(Icons.layers_outlined, color: AppColors.textSecondary),
           const SizedBox(width: 8),
-          const Text(
+          Text(
             '参考模式',
             style: TextStyle(
               color: AppColors.textSecondary,
@@ -611,7 +615,7 @@ class _SavingProgressPanel extends StatelessWidget {
           Expanded(
             child: Text(
               label,
-              style: const TextStyle(
+              style: TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 13,
                 fontWeight: FontWeight.w700,
@@ -619,60 +623,6 @@ class _SavingProgressPanel extends StatelessWidget {
               ),
             ),
           ),
-        ],
-      ),
-    );
-  }
-}
-
-class _PhotoLocationStatusPanel extends StatelessWidget {
-  const _PhotoLocationStatusPanel({
-    required this.label,
-    required this.loading,
-    this.onSkip,
-  });
-
-  final String label;
-  final bool loading;
-  final VoidCallback? onSkip;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.fromLTRB(14, 10, 8, 10),
-      decoration: BoxDecoration(
-        color: AppColors.surfaceMuted,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Row(
-        children: [
-          if (loading)
-            const SizedBox(
-              width: 18,
-              height: 18,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
-          else
-            const Icon(
-              Icons.location_on_outlined,
-              size: 18,
-              color: AppColors.textSecondary,
-            ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              label,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0,
-              ),
-            ),
-          ),
-          if (onSkip != null)
-            TextButton(onPressed: onSkip, child: const Text('跳过')),
         ],
       ),
     );

--- a/lib/color_grading/color_grading_parameter_summary.dart
+++ b/lib/color_grading/color_grading_parameter_summary.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+
+import '../app_theme.dart';
+import 'color_grading_params.dart';
+
+class ColorGradingParameterSummary extends StatelessWidget {
+  const ColorGradingParameterSummary({required this.activeParams, super.key});
+
+  final ColorGradingParams activeParams;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  '调色参数',
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ),
+              OutlinedButton.icon(
+                onPressed: () => _showParameterSheet(context),
+                style: AppButtonStyles.compactOutlinedButton(),
+                icon: const Icon(Icons.tune, size: 18),
+                label: const Text('查看'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '显示当前调色强度下实际生效的参数。',
+            style: TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 13,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showParameterSheet(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      backgroundColor: AppColors.surface,
+      builder: (context) =>
+          _ColorGradingParameterSheet(activeParams: activeParams),
+    );
+  }
+}
+
+class _ColorGradingParameterSheet extends StatelessWidget {
+  const _ColorGradingParameterSheet({required this.activeParams});
+
+  final ColorGradingParams activeParams;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = <_ParameterItem>[
+      _ParameterItem('亮度', activeParams.brightness, -0.25, 0.25),
+      _ParameterItem('曝光', activeParams.exposure, -1.0, 1.0),
+      _ParameterItem('对比度', activeParams.contrast, 0.7, 1.4),
+      _ParameterItem('饱和度', activeParams.saturation, 0.5, 1.6),
+      _ParameterItem('色温', activeParams.temperature, -1.0, 1.0),
+      _ParameterItem('色调', activeParams.tint, -1.0, 1.0),
+      _ParameterItem('高光', activeParams.highlights, -1.0, 1.0),
+      _ParameterItem('阴影', activeParams.shadows, -1.0, 1.0),
+      _ParameterItem('红暗部曲线', activeParams.redShadowCurve, -1.0, 1.0),
+      _ParameterItem('红中间调曲线', activeParams.redMidCurve, -1.0, 1.0),
+      _ParameterItem('红高光曲线', activeParams.redHighlightCurve, -1.0, 1.0),
+      _ParameterItem('绿暗部曲线', activeParams.greenShadowCurve, -1.0, 1.0),
+      _ParameterItem('绿中间调曲线', activeParams.greenMidCurve, -1.0, 1.0),
+      _ParameterItem('绿高光曲线', activeParams.greenHighlightCurve, -1.0, 1.0),
+      _ParameterItem('蓝暗部曲线', activeParams.blueShadowCurve, -1.0, 1.0),
+      _ParameterItem('蓝中间调曲线', activeParams.blueMidCurve, -1.0, 1.0),
+      _ParameterItem('蓝高光曲线', activeParams.blueHighlightCurve, -1.0, 1.0),
+    ];
+
+    return SafeArea(
+      top: false,
+      child: SizedBox(
+        height: MediaQuery.sizeOf(context).height * 0.74,
+        child: ListView.separated(
+          padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
+          itemCount: items.length + 1,
+          separatorBuilder: (_, index) => index == 0
+              ? const SizedBox(height: 10)
+              : const Divider(height: 18),
+          itemBuilder: (context, index) {
+            if (index == 0) {
+              return const Text(
+                '调色参数',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w900,
+                  letterSpacing: 0,
+                ),
+              );
+            }
+            return _ParameterRow(item: items[index - 1]);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _ParameterItem {
+  const _ParameterItem(this.label, this.value, this.min, this.max);
+
+  final String label;
+  final double value;
+  final double min;
+  final double max;
+}
+
+class _ParameterRow extends StatelessWidget {
+  const _ParameterRow({required this.item});
+
+  final _ParameterItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final activeT = ((item.value - item.min) / (item.max - item.min))
+        .clamp(0.0, 1.0)
+        .toDouble();
+    final activeText = item.value.toStringAsFixed(3);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                item.label,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+            Text(
+              activeText,
+              style: TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 0,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: activeT,
+            minHeight: 7,
+            backgroundColor: AppColors.surfaceMuted,
+            color: AppColors.accent,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/color_grading/color_grading_screen.dart
+++ b/lib/color_grading/color_grading_screen.dart
@@ -11,6 +11,7 @@ import '../plan/pilgrimage_plan_controller.dart';
 import '../records/visit_record_photo_stub.dart'
     if (dart.library.io) '../records/visit_record_photo_io.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'color_adjustment.dart';
 import 'color_grading_params.dart';
 import 'graded_photo_storage_stub.dart'
@@ -271,6 +272,7 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: const Text('自动调色'),
         actions: [TextButton(onPressed: _reset, child: const Text('重置'))],
       ),

--- a/lib/color_grading/color_grading_screen.dart
+++ b/lib/color_grading/color_grading_screen.dart
@@ -12,7 +12,9 @@ import '../records/visit_record_photo_stub.dart'
     if (dart.library.io) '../records/visit_record_photo_io.dart';
 import '../widgets/snackbar_helper.dart';
 import '../widgets/app_back_button.dart';
+import '../widgets/confirm_action_dialog.dart';
 import 'color_adjustment.dart';
+import 'color_grading_parameter_summary.dart';
 import 'color_grading_params.dart';
 import 'graded_photo_storage_stub.dart'
     if (dart.library.io) 'graded_photo_storage_io.dart';
@@ -156,12 +158,16 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
     final reference = _referenceBytes;
     final messenger = ScaffoldMessenger.of(context);
     if (captured == null) {
-      messenger.showReplacingSnackBar(const SnackBar(content: Text('巡礼图读取失败')));
+      messenger.showStatusSnack(
+        kind: AppStatusBannerKind.error,
+        title: '巡礼图读取失败',
+      );
       return;
     }
     if (reference == null) {
-      messenger.showReplacingSnackBar(
-        const SnackBar(content: Text('没有可用于自动调色的参考图')),
+      messenger.showStatusSnack(
+        kind: AppStatusBannerKind.warning,
+        title: '没有可用于自动调色的参考图',
       );
       return;
     }
@@ -191,8 +197,11 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
       }
     });
 
-    messenger.showReplacingSnackBar(
-      SnackBar(content: Text(result == null ? '自动调色失败' : '已生成自动调色参数')),
+    messenger.showStatusSnack(
+      kind: result == null
+          ? AppStatusBannerKind.error
+          : AppStatusBannerKind.success,
+      title: result == null ? '自动调色失败' : '已生成自动调色参数',
     );
   }
 
@@ -213,13 +222,17 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
       }
 
       setState(() => _saving = false);
-      messenger.showReplacingSnackBar(const SnackBar(content: Text('已还原为原图')));
+      messenger.showStatusSnack(
+        kind: AppStatusBannerKind.success,
+        title: '已还原为原图',
+      );
       Navigator.of(context).pop(updated);
       return;
     }
     if (targetParams == null) {
-      messenger.showReplacingSnackBar(
-        const SnackBar(content: Text('请先自动匹配色调')),
+      messenger.showStatusSnack(
+        kind: AppStatusBannerKind.warning,
+        title: '请先自动匹配色调',
       );
       return;
     }
@@ -235,7 +248,7 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
         return;
       }
       setState(() => _saving = false);
-      messenger.showReplacingSnackBar(const SnackBar(content: Text('保存失败')));
+      messenger.showStatusSnack(kind: AppStatusBannerKind.error, title: '保存失败');
       return;
     }
 
@@ -253,7 +266,10 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
     }
 
     setState(() => _saving = false);
-    messenger.showReplacingSnackBar(const SnackBar(content: Text('已保存调色结果')));
+    messenger.showStatusSnack(
+      kind: AppStatusBannerKind.success,
+      title: '已保存调色结果',
+    );
     Navigator.of(context).pop(updated);
   }
 
@@ -268,13 +284,32 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
     });
   }
 
+  Future<void> _confirmReset() async {
+    final confirmed = await showConfirmActionDialog(
+      context,
+      title: '重置调色',
+      message: '将清除当前调色，恢复为原图。',
+      confirmLabel: '重置',
+    );
+    if (!confirmed || !mounted) {
+      return;
+    }
+    _reset();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         leading: appBackButtonIfCanPop(context),
         title: const Text('自动调色'),
-        actions: [TextButton(onPressed: _reset, child: const Text('重置'))],
+        actions: [
+          IconButton(
+            tooltip: '重置',
+            onPressed: _confirmReset,
+            icon: const Icon(Icons.restart_alt),
+          ),
+        ],
       ),
       body: _buildBody(context),
     );
@@ -349,7 +384,7 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
             onChanged: (value) => setState(() => _intensity = value),
           ),
           const SizedBox(height: 12),
-          _ParameterSummary(activeParams: _activeParams),
+          ColorGradingParameterSummary(activeParams: _activeParams),
         ],
         const SizedBox(height: 12),
         _SavePanel(saving: _saving, onSave: _save),
@@ -577,7 +612,7 @@ class _ScorePanel extends StatelessWidget {
                 Expanded(
                   child: Text(
                     hasSavedParams ? '已恢复上次调色参数' : '自动匹配后可保存调色结果',
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 13,
                       fontWeight: FontWeight.w700,
@@ -602,13 +637,13 @@ class _ScorePanel extends StatelessWidget {
                 Row(
                   children: [
                     _ScoreValue(label: '原图', score: beforeScore!),
-                    const Icon(
+                    Icon(
                       Icons.arrow_forward,
                       size: 18,
                       color: AppColors.textSecondary,
                     ),
                     _ScoreValue(label: '当前', score: currentToneScore ?? 0),
-                    const Icon(
+                    Icon(
                       Icons.arrow_forward,
                       size: 18,
                       color: AppColors.textSecondary,
@@ -644,7 +679,7 @@ class _ScoreValue extends StatelessWidget {
           ),
           Text(
             label,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 12,
               fontWeight: FontWeight.w700,
@@ -711,185 +746,6 @@ class _IntensityControl extends StatelessWidget {
   }
 }
 
-class _ParameterSummary extends StatelessWidget {
-  const _ParameterSummary({required this.activeParams});
-
-  final ColorGradingParams activeParams;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            children: [
-              const Expanded(
-                child: Text(
-                  '调色参数',
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: 0,
-                  ),
-                ),
-              ),
-              TextButton.icon(
-                onPressed: () => _showParameterSheet(context),
-                icon: const Icon(Icons.tune, size: 18),
-                label: const Text('查看'),
-              ),
-            ],
-          ),
-          const SizedBox(height: 4),
-          const Text(
-            '显示当前调色强度下实际生效的参数。',
-            style: TextStyle(
-              color: AppColors.textSecondary,
-              fontSize: 13,
-              letterSpacing: 0,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showParameterSheet(BuildContext context) {
-    showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      isScrollControlled: true,
-      backgroundColor: AppColors.surface,
-      builder: (context) => _ParameterSheet(activeParams: activeParams),
-    );
-  }
-}
-
-class _ParameterSheet extends StatelessWidget {
-  const _ParameterSheet({required this.activeParams});
-
-  final ColorGradingParams activeParams;
-
-  @override
-  Widget build(BuildContext context) {
-    final items = <_ParameterItem>[
-      _ParameterItem('亮度', activeParams.brightness, -0.25, 0.25),
-      _ParameterItem('曝光', activeParams.exposure, -1.0, 1.0),
-      _ParameterItem('对比度', activeParams.contrast, 0.7, 1.4),
-      _ParameterItem('饱和度', activeParams.saturation, 0.5, 1.6),
-      _ParameterItem('色温', activeParams.temperature, -1.0, 1.0),
-      _ParameterItem('色调', activeParams.tint, -1.0, 1.0),
-      _ParameterItem('高光', activeParams.highlights, -1.0, 1.0),
-      _ParameterItem('阴影', activeParams.shadows, -1.0, 1.0),
-      _ParameterItem('红暗部曲线', activeParams.redShadowCurve, -1.0, 1.0),
-      _ParameterItem('红中间调曲线', activeParams.redMidCurve, -1.0, 1.0),
-      _ParameterItem('红高光曲线', activeParams.redHighlightCurve, -1.0, 1.0),
-      _ParameterItem('绿暗部曲线', activeParams.greenShadowCurve, -1.0, 1.0),
-      _ParameterItem('绿中间调曲线', activeParams.greenMidCurve, -1.0, 1.0),
-      _ParameterItem('绿高光曲线', activeParams.greenHighlightCurve, -1.0, 1.0),
-      _ParameterItem('蓝暗部曲线', activeParams.blueShadowCurve, -1.0, 1.0),
-      _ParameterItem('蓝中间调曲线', activeParams.blueMidCurve, -1.0, 1.0),
-      _ParameterItem('蓝高光曲线', activeParams.blueHighlightCurve, -1.0, 1.0),
-    ];
-
-    return SafeArea(
-      top: false,
-      child: SizedBox(
-        height: MediaQuery.sizeOf(context).height * 0.74,
-        child: ListView.separated(
-          padding: const EdgeInsets.fromLTRB(20, 4, 20, 24),
-          itemCount: items.length + 1,
-          separatorBuilder: (_, index) => index == 0
-              ? const SizedBox(height: 10)
-              : const Divider(height: 18),
-          itemBuilder: (context, index) {
-            if (index == 0) {
-              return const Text(
-                '调色参数',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.w900,
-                  letterSpacing: 0,
-                ),
-              );
-            }
-            return _ParameterRow(item: items[index - 1]);
-          },
-        ),
-      ),
-    );
-  }
-}
-
-class _ParameterItem {
-  const _ParameterItem(this.label, this.value, this.min, this.max);
-
-  final String label;
-  final double value;
-  final double min;
-  final double max;
-}
-
-class _ParameterRow extends StatelessWidget {
-  const _ParameterRow({required this.item});
-
-  final _ParameterItem item;
-
-  @override
-  Widget build(BuildContext context) {
-    final activeT = ((item.value - item.min) / (item.max - item.min))
-        .clamp(0.0, 1.0)
-        .toDouble();
-    final activeText = item.value.toStringAsFixed(3);
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                item.label,
-                style: TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 0,
-                ),
-              ),
-            ),
-            Text(
-              activeText,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 12,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0,
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 8),
-        ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: LinearProgressIndicator(
-            value: activeT,
-            minHeight: 7,
-            backgroundColor: AppColors.surfaceMuted,
-            color: AppColors.accent,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
 class _SavePanel extends StatelessWidget {
   const _SavePanel({required this.saving, required this.onSave});
 
@@ -917,7 +773,7 @@ class _SavePanel extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 6),
-          const Text(
+          Text(
             '保存后记录详情和导出会使用调色后的图片，原图和调色参数会保留。',
             style: TextStyle(
               color: AppColors.textSecondary,

--- a/lib/data/local/app_database.dart
+++ b/lib/data/local/app_database.dart
@@ -172,6 +172,8 @@ class AppSettingsEntries extends Table {
       boolean().withDefault(const Constant(true))();
   BoolColumn get dismissPlanActionsOnOutsideTap =>
       boolean().withDefault(const Constant(true))();
+  BoolColumn get hideCompletedPointsOnMap =>
+      boolean().withDefault(const Constant(true))();
   BoolColumn get mapMarkerClusteringEnabled =>
       boolean().withDefault(const Constant(true))();
   IntColumn get mapMarkerClusterRadius =>
@@ -194,7 +196,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 39;
+  int get schemaVersion => 40;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -635,6 +637,15 @@ class AppDatabase extends _$AppDatabase {
           'dismiss_plan_actions_on_outside_tap',
           appSettingsEntries,
           appSettingsEntries.dismissPlanActionsOnOutsideTap,
+        );
+      }
+      if (from < 40) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'hide_completed_points_on_map',
+          appSettingsEntries,
+          appSettingsEntries.hideCompletedPointsOnMap,
         );
       }
     },

--- a/lib/data/local/app_database.dart
+++ b/lib/data/local/app_database.dart
@@ -170,6 +170,8 @@ class AppSettingsEntries extends Table {
       integer().withDefault(const Constant(10))();
   BoolColumn get showPlanGroupProgress =>
       boolean().withDefault(const Constant(true))();
+  BoolColumn get dismissPlanActionsOnOutsideTap =>
+      boolean().withDefault(const Constant(true))();
   BoolColumn get mapMarkerClusteringEnabled =>
       boolean().withDefault(const Constant(true))();
   IntColumn get mapMarkerClusterRadius =>
@@ -192,7 +194,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);
 
   @override
-  int get schemaVersion => 38;
+  int get schemaVersion => 39;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -624,6 +626,15 @@ class AppDatabase extends _$AppDatabase {
           'photo_location_strategy',
           appSettingsEntries,
           appSettingsEntries.photoLocationStrategy,
+        );
+      }
+      if (from < 39) {
+        await _addColumnIfMissing(
+          migrator,
+          'app_settings_entries',
+          'dismiss_plan_actions_on_outside_tap',
+          appSettingsEntries,
+          appSettingsEntries.dismissPlanActionsOnOutsideTap,
         );
       }
     },

--- a/lib/data/local/app_database.g.dart
+++ b/lib/data/local/app_database.g.dart
@@ -4590,6 +4590,21 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
         defaultValue: const Constant(true),
       );
+  static const VerificationMeta _hideCompletedPointsOnMapMeta =
+      const VerificationMeta('hideCompletedPointsOnMap');
+  @override
+  late final GeneratedColumn<bool> hideCompletedPointsOnMap =
+      GeneratedColumn<bool>(
+        'hide_completed_points_on_map',
+        aliasedName,
+        false,
+        type: DriftSqlType.bool,
+        requiredDuringInsert: false,
+        defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("hide_completed_points_on_map" IN (0, 1))',
+        ),
+        defaultValue: const Constant(true),
+      );
   static const VerificationMeta _mapMarkerClusteringEnabledMeta =
       const VerificationMeta('mapMarkerClusteringEnabled');
   @override
@@ -4704,6 +4719,7 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
     mapThumbnailConcurrentLoads,
     showPlanGroupProgress,
     dismissPlanActionsOnOutsideTap,
+    hideCompletedPointsOnMap,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -5052,6 +5068,15 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
       );
     }
+    if (data.containsKey('hide_completed_points_on_map')) {
+      context.handle(
+        _hideCompletedPointsOnMapMeta,
+        hideCompletedPointsOnMap.isAcceptableOrUnknown(
+          data['hide_completed_points_on_map']!,
+          _hideCompletedPointsOnMapMeta,
+        ),
+      );
+    }
     if (data.containsKey('map_marker_clustering_enabled')) {
       context.handle(
         _mapMarkerClusteringEnabledMeta,
@@ -5267,6 +5292,10 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         DriftSqlType.bool,
         data['${effectivePrefix}dismiss_plan_actions_on_outside_tap'],
       )!,
+      hideCompletedPointsOnMap: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}hide_completed_points_on_map'],
+      )!,
       mapMarkerClusteringEnabled: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}map_marker_clustering_enabled'],
@@ -5340,6 +5369,7 @@ class AppSettingsEntry extends DataClass
   final int mapThumbnailConcurrentLoads;
   final bool showPlanGroupProgress;
   final bool dismissPlanActionsOnOutsideTap;
+  final bool hideCompletedPointsOnMap;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -5385,6 +5415,7 @@ class AppSettingsEntry extends DataClass
     required this.mapThumbnailConcurrentLoads,
     required this.showPlanGroupProgress,
     required this.dismissPlanActionsOnOutsideTap,
+    required this.hideCompletedPointsOnMap,
     required this.mapMarkerClusteringEnabled,
     required this.mapMarkerClusterRadius,
     required this.mapMarkerClusterMaxZoom,
@@ -5465,6 +5496,9 @@ class AppSettingsEntry extends DataClass
     map['dismiss_plan_actions_on_outside_tap'] = Variable<bool>(
       dismissPlanActionsOnOutsideTap,
     );
+    map['hide_completed_points_on_map'] = Variable<bool>(
+      hideCompletedPointsOnMap,
+    );
     map['map_marker_clustering_enabled'] = Variable<bool>(
       mapMarkerClusteringEnabled,
     );
@@ -5518,6 +5552,7 @@ class AppSettingsEntry extends DataClass
       mapThumbnailConcurrentLoads: Value(mapThumbnailConcurrentLoads),
       showPlanGroupProgress: Value(showPlanGroupProgress),
       dismissPlanActionsOnOutsideTap: Value(dismissPlanActionsOnOutsideTap),
+      hideCompletedPointsOnMap: Value(hideCompletedPointsOnMap),
       mapMarkerClusteringEnabled: Value(mapMarkerClusteringEnabled),
       mapMarkerClusterRadius: Value(mapMarkerClusterRadius),
       mapMarkerClusterMaxZoom: Value(mapMarkerClusterMaxZoom),
@@ -5621,6 +5656,9 @@ class AppSettingsEntry extends DataClass
       dismissPlanActionsOnOutsideTap: serializer.fromJson<bool>(
         json['dismissPlanActionsOnOutsideTap'],
       ),
+      hideCompletedPointsOnMap: serializer.fromJson<bool>(
+        json['hideCompletedPointsOnMap'],
+      ),
       mapMarkerClusteringEnabled: serializer.fromJson<bool>(
         json['mapMarkerClusteringEnabled'],
       ),
@@ -5711,6 +5749,9 @@ class AppSettingsEntry extends DataClass
       'dismissPlanActionsOnOutsideTap': serializer.toJson<bool>(
         dismissPlanActionsOnOutsideTap,
       ),
+      'hideCompletedPointsOnMap': serializer.toJson<bool>(
+        hideCompletedPointsOnMap,
+      ),
       'mapMarkerClusteringEnabled': serializer.toJson<bool>(
         mapMarkerClusteringEnabled,
       ),
@@ -5765,6 +5806,7 @@ class AppSettingsEntry extends DataClass
     int? mapThumbnailConcurrentLoads,
     bool? showPlanGroupProgress,
     bool? dismissPlanActionsOnOutsideTap,
+    bool? hideCompletedPointsOnMap,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -5826,6 +5868,8 @@ class AppSettingsEntry extends DataClass
     showPlanGroupProgress: showPlanGroupProgress ?? this.showPlanGroupProgress,
     dismissPlanActionsOnOutsideTap:
         dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
+    hideCompletedPointsOnMap:
+        hideCompletedPointsOnMap ?? this.hideCompletedPointsOnMap,
     mapMarkerClusteringEnabled:
         mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
     mapMarkerClusterRadius:
@@ -5947,6 +5991,9 @@ class AppSettingsEntry extends DataClass
           data.dismissPlanActionsOnOutsideTap.present
           ? data.dismissPlanActionsOnOutsideTap.value
           : this.dismissPlanActionsOnOutsideTap,
+      hideCompletedPointsOnMap: data.hideCompletedPointsOnMap.present
+          ? data.hideCompletedPointsOnMap.value
+          : this.hideCompletedPointsOnMap,
       mapMarkerClusteringEnabled: data.mapMarkerClusteringEnabled.present
           ? data.mapMarkerClusteringEnabled.value
           : this.mapMarkerClusteringEnabled,
@@ -6019,6 +6066,7 @@ class AppSettingsEntry extends DataClass
           ..write(
             'dismissPlanActionsOnOutsideTap: $dismissPlanActionsOnOutsideTap, ',
           )
+          ..write('hideCompletedPointsOnMap: $hideCompletedPointsOnMap, ')
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -6069,6 +6117,7 @@ class AppSettingsEntry extends DataClass
     mapThumbnailConcurrentLoads,
     showPlanGroupProgress,
     dismissPlanActionsOnOutsideTap,
+    hideCompletedPointsOnMap,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -6127,6 +6176,7 @@ class AppSettingsEntry extends DataClass
           other.showPlanGroupProgress == this.showPlanGroupProgress &&
           other.dismissPlanActionsOnOutsideTap ==
               this.dismissPlanActionsOnOutsideTap &&
+          other.hideCompletedPointsOnMap == this.hideCompletedPointsOnMap &&
           other.mapMarkerClusteringEnabled == this.mapMarkerClusteringEnabled &&
           other.mapMarkerClusterRadius == this.mapMarkerClusterRadius &&
           other.mapMarkerClusterMaxZoom == this.mapMarkerClusterMaxZoom &&
@@ -6174,6 +6224,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
   final Value<int> mapThumbnailConcurrentLoads;
   final Value<bool> showPlanGroupProgress;
   final Value<bool> dismissPlanActionsOnOutsideTap;
+  final Value<bool> hideCompletedPointsOnMap;
   final Value<bool> mapMarkerClusteringEnabled;
   final Value<int> mapMarkerClusterRadius;
   final Value<int> mapMarkerClusterMaxZoom;
@@ -6220,6 +6271,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.mapThumbnailConcurrentLoads = const Value.absent(),
     this.showPlanGroupProgress = const Value.absent(),
     this.dismissPlanActionsOnOutsideTap = const Value.absent(),
+    this.hideCompletedPointsOnMap = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -6267,6 +6319,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.mapThumbnailConcurrentLoads = const Value.absent(),
     this.showPlanGroupProgress = const Value.absent(),
     this.dismissPlanActionsOnOutsideTap = const Value.absent(),
+    this.hideCompletedPointsOnMap = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -6314,6 +6367,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Expression<int>? mapThumbnailConcurrentLoads,
     Expression<bool>? showPlanGroupProgress,
     Expression<bool>? dismissPlanActionsOnOutsideTap,
+    Expression<bool>? hideCompletedPointsOnMap,
     Expression<bool>? mapMarkerClusteringEnabled,
     Expression<int>? mapMarkerClusterRadius,
     Expression<int>? mapMarkerClusterMaxZoom,
@@ -6386,6 +6440,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         'show_plan_group_progress': showPlanGroupProgress,
       if (dismissPlanActionsOnOutsideTap != null)
         'dismiss_plan_actions_on_outside_tap': dismissPlanActionsOnOutsideTap,
+      if (hideCompletedPointsOnMap != null)
+        'hide_completed_points_on_map': hideCompletedPointsOnMap,
       if (mapMarkerClusteringEnabled != null)
         'map_marker_clustering_enabled': mapMarkerClusteringEnabled,
       if (mapMarkerClusterRadius != null)
@@ -6439,6 +6495,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Value<int>? mapThumbnailConcurrentLoads,
     Value<bool>? showPlanGroupProgress,
     Value<bool>? dismissPlanActionsOnOutsideTap,
+    Value<bool>? hideCompletedPointsOnMap,
     Value<bool>? mapMarkerClusteringEnabled,
     Value<int>? mapMarkerClusterRadius,
     Value<int>? mapMarkerClusterMaxZoom,
@@ -6507,6 +6564,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           showPlanGroupProgress ?? this.showPlanGroupProgress,
       dismissPlanActionsOnOutsideTap:
           dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
+      hideCompletedPointsOnMap:
+          hideCompletedPointsOnMap ?? this.hideCompletedPointsOnMap,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:
@@ -6684,6 +6743,11 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         dismissPlanActionsOnOutsideTap.value,
       );
     }
+    if (hideCompletedPointsOnMap.present) {
+      map['hide_completed_points_on_map'] = Variable<bool>(
+        hideCompletedPointsOnMap.value,
+      );
+    }
     if (mapMarkerClusteringEnabled.present) {
       map['map_marker_clustering_enabled'] = Variable<bool>(
         mapMarkerClusteringEnabled.value,
@@ -6767,6 +6831,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           ..write(
             'dismissPlanActionsOnOutsideTap: $dismissPlanActionsOnOutsideTap, ',
           )
+          ..write('hideCompletedPointsOnMap: $hideCompletedPointsOnMap, ')
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -9678,6 +9743,7 @@ typedef $$AppSettingsEntriesTableCreateCompanionBuilder =
       Value<int> mapThumbnailConcurrentLoads,
       Value<bool> showPlanGroupProgress,
       Value<bool> dismissPlanActionsOnOutsideTap,
+      Value<bool> hideCompletedPointsOnMap,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9726,6 +9792,7 @@ typedef $$AppSettingsEntriesTableUpdateCompanionBuilder =
       Value<int> mapThumbnailConcurrentLoads,
       Value<bool> showPlanGroupProgress,
       Value<bool> dismissPlanActionsOnOutsideTap,
+      Value<bool> hideCompletedPointsOnMap,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9931,6 +9998,11 @@ class $$AppSettingsEntriesTableFilterComposer
 
   ColumnFilters<bool> get dismissPlanActionsOnOutsideTap => $composableBuilder(
     column: $table.dismissPlanActionsOnOutsideTap,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get hideCompletedPointsOnMap => $composableBuilder(
+    column: $table.hideCompletedPointsOnMap,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -10168,6 +10240,11 @@ class $$AppSettingsEntriesTableOrderingComposer
         builder: (column) => ColumnOrderings(column),
       );
 
+  ColumnOrderings<bool> get hideCompletedPointsOnMap => $composableBuilder(
+    column: $table.hideCompletedPointsOnMap,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => ColumnOrderings(column),
@@ -10394,6 +10471,11 @@ class $$AppSettingsEntriesTableAnnotationComposer
         builder: (column) => column,
       );
 
+  GeneratedColumn<bool> get hideCompletedPointsOnMap => $composableBuilder(
+    column: $table.hideCompletedPointsOnMap,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => column,
@@ -10509,6 +10591,7 @@ class $$AppSettingsEntriesTableTableManager
                 Value<bool> showPlanGroupProgress = const Value.absent(),
                 Value<bool> dismissPlanActionsOnOutsideTap =
                     const Value.absent(),
+                Value<bool> hideCompletedPointsOnMap = const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -10555,6 +10638,7 @@ class $$AppSettingsEntriesTableTableManager
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
                 showPlanGroupProgress: showPlanGroupProgress,
                 dismissPlanActionsOnOutsideTap: dismissPlanActionsOnOutsideTap,
+                hideCompletedPointsOnMap: hideCompletedPointsOnMap,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,
@@ -10609,6 +10693,7 @@ class $$AppSettingsEntriesTableTableManager
                 Value<bool> showPlanGroupProgress = const Value.absent(),
                 Value<bool> dismissPlanActionsOnOutsideTap =
                     const Value.absent(),
+                Value<bool> hideCompletedPointsOnMap = const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -10655,6 +10740,7 @@ class $$AppSettingsEntriesTableTableManager
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
                 showPlanGroupProgress: showPlanGroupProgress,
                 dismissPlanActionsOnOutsideTap: dismissPlanActionsOnOutsideTap,
+                hideCompletedPointsOnMap: hideCompletedPointsOnMap,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,

--- a/lib/data/local/app_database.g.dart
+++ b/lib/data/local/app_database.g.dart
@@ -4575,6 +4575,21 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
         defaultValue: const Constant(true),
       );
+  static const VerificationMeta _dismissPlanActionsOnOutsideTapMeta =
+      const VerificationMeta('dismissPlanActionsOnOutsideTap');
+  @override
+  late final GeneratedColumn<bool> dismissPlanActionsOnOutsideTap =
+      GeneratedColumn<bool>(
+        'dismiss_plan_actions_on_outside_tap',
+        aliasedName,
+        false,
+        type: DriftSqlType.bool,
+        requiredDuringInsert: false,
+        defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'CHECK ("dismiss_plan_actions_on_outside_tap" IN (0, 1))',
+        ),
+        defaultValue: const Constant(true),
+      );
   static const VerificationMeta _mapMarkerClusteringEnabledMeta =
       const VerificationMeta('mapMarkerClusteringEnabled');
   @override
@@ -4688,6 +4703,7 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
     mapThumbnailVisibleThreshold,
     mapThumbnailConcurrentLoads,
     showPlanGroupProgress,
+    dismissPlanActionsOnOutsideTap,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -5027,6 +5043,15 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         ),
       );
     }
+    if (data.containsKey('dismiss_plan_actions_on_outside_tap')) {
+      context.handle(
+        _dismissPlanActionsOnOutsideTapMeta,
+        dismissPlanActionsOnOutsideTap.isAcceptableOrUnknown(
+          data['dismiss_plan_actions_on_outside_tap']!,
+          _dismissPlanActionsOnOutsideTapMeta,
+        ),
+      );
+    }
     if (data.containsKey('map_marker_clustering_enabled')) {
       context.handle(
         _mapMarkerClusteringEnabledMeta,
@@ -5238,6 +5263,10 @@ class $AppSettingsEntriesTable extends AppSettingsEntries
         DriftSqlType.bool,
         data['${effectivePrefix}show_plan_group_progress'],
       )!,
+      dismissPlanActionsOnOutsideTap: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}dismiss_plan_actions_on_outside_tap'],
+      )!,
       mapMarkerClusteringEnabled: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}map_marker_clustering_enabled'],
@@ -5310,6 +5339,7 @@ class AppSettingsEntry extends DataClass
   final int mapThumbnailVisibleThreshold;
   final int mapThumbnailConcurrentLoads;
   final bool showPlanGroupProgress;
+  final bool dismissPlanActionsOnOutsideTap;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -5354,6 +5384,7 @@ class AppSettingsEntry extends DataClass
     required this.mapThumbnailVisibleThreshold,
     required this.mapThumbnailConcurrentLoads,
     required this.showPlanGroupProgress,
+    required this.dismissPlanActionsOnOutsideTap,
     required this.mapMarkerClusteringEnabled,
     required this.mapMarkerClusterRadius,
     required this.mapMarkerClusterMaxZoom,
@@ -5431,6 +5462,9 @@ class AppSettingsEntry extends DataClass
       mapThumbnailConcurrentLoads,
     );
     map['show_plan_group_progress'] = Variable<bool>(showPlanGroupProgress);
+    map['dismiss_plan_actions_on_outside_tap'] = Variable<bool>(
+      dismissPlanActionsOnOutsideTap,
+    );
     map['map_marker_clustering_enabled'] = Variable<bool>(
       mapMarkerClusteringEnabled,
     );
@@ -5483,6 +5517,7 @@ class AppSettingsEntry extends DataClass
       mapThumbnailVisibleThreshold: Value(mapThumbnailVisibleThreshold),
       mapThumbnailConcurrentLoads: Value(mapThumbnailConcurrentLoads),
       showPlanGroupProgress: Value(showPlanGroupProgress),
+      dismissPlanActionsOnOutsideTap: Value(dismissPlanActionsOnOutsideTap),
       mapMarkerClusteringEnabled: Value(mapMarkerClusteringEnabled),
       mapMarkerClusterRadius: Value(mapMarkerClusterRadius),
       mapMarkerClusterMaxZoom: Value(mapMarkerClusterMaxZoom),
@@ -5583,6 +5618,9 @@ class AppSettingsEntry extends DataClass
       showPlanGroupProgress: serializer.fromJson<bool>(
         json['showPlanGroupProgress'],
       ),
+      dismissPlanActionsOnOutsideTap: serializer.fromJson<bool>(
+        json['dismissPlanActionsOnOutsideTap'],
+      ),
       mapMarkerClusteringEnabled: serializer.fromJson<bool>(
         json['mapMarkerClusteringEnabled'],
       ),
@@ -5670,6 +5708,9 @@ class AppSettingsEntry extends DataClass
         mapThumbnailConcurrentLoads,
       ),
       'showPlanGroupProgress': serializer.toJson<bool>(showPlanGroupProgress),
+      'dismissPlanActionsOnOutsideTap': serializer.toJson<bool>(
+        dismissPlanActionsOnOutsideTap,
+      ),
       'mapMarkerClusteringEnabled': serializer.toJson<bool>(
         mapMarkerClusteringEnabled,
       ),
@@ -5723,6 +5764,7 @@ class AppSettingsEntry extends DataClass
     int? mapThumbnailVisibleThreshold,
     int? mapThumbnailConcurrentLoads,
     bool? showPlanGroupProgress,
+    bool? dismissPlanActionsOnOutsideTap,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -5782,6 +5824,8 @@ class AppSettingsEntry extends DataClass
     mapThumbnailConcurrentLoads:
         mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
     showPlanGroupProgress: showPlanGroupProgress ?? this.showPlanGroupProgress,
+    dismissPlanActionsOnOutsideTap:
+        dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
     mapMarkerClusteringEnabled:
         mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
     mapMarkerClusterRadius:
@@ -5899,6 +5943,10 @@ class AppSettingsEntry extends DataClass
       showPlanGroupProgress: data.showPlanGroupProgress.present
           ? data.showPlanGroupProgress.value
           : this.showPlanGroupProgress,
+      dismissPlanActionsOnOutsideTap:
+          data.dismissPlanActionsOnOutsideTap.present
+          ? data.dismissPlanActionsOnOutsideTap.value
+          : this.dismissPlanActionsOnOutsideTap,
       mapMarkerClusteringEnabled: data.mapMarkerClusteringEnabled.present
           ? data.mapMarkerClusteringEnabled.value
           : this.mapMarkerClusteringEnabled,
@@ -5968,6 +6016,9 @@ class AppSettingsEntry extends DataClass
           )
           ..write('mapThumbnailConcurrentLoads: $mapThumbnailConcurrentLoads, ')
           ..write('showPlanGroupProgress: $showPlanGroupProgress, ')
+          ..write(
+            'dismissPlanActionsOnOutsideTap: $dismissPlanActionsOnOutsideTap, ',
+          )
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -6017,6 +6068,7 @@ class AppSettingsEntry extends DataClass
     mapThumbnailVisibleThreshold,
     mapThumbnailConcurrentLoads,
     showPlanGroupProgress,
+    dismissPlanActionsOnOutsideTap,
     mapMarkerClusteringEnabled,
     mapMarkerClusterRadius,
     mapMarkerClusterMaxZoom,
@@ -6073,6 +6125,8 @@ class AppSettingsEntry extends DataClass
           other.mapThumbnailConcurrentLoads ==
               this.mapThumbnailConcurrentLoads &&
           other.showPlanGroupProgress == this.showPlanGroupProgress &&
+          other.dismissPlanActionsOnOutsideTap ==
+              this.dismissPlanActionsOnOutsideTap &&
           other.mapMarkerClusteringEnabled == this.mapMarkerClusteringEnabled &&
           other.mapMarkerClusterRadius == this.mapMarkerClusterRadius &&
           other.mapMarkerClusterMaxZoom == this.mapMarkerClusterMaxZoom &&
@@ -6119,6 +6173,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
   final Value<int> mapThumbnailVisibleThreshold;
   final Value<int> mapThumbnailConcurrentLoads;
   final Value<bool> showPlanGroupProgress;
+  final Value<bool> dismissPlanActionsOnOutsideTap;
   final Value<bool> mapMarkerClusteringEnabled;
   final Value<int> mapMarkerClusterRadius;
   final Value<int> mapMarkerClusterMaxZoom;
@@ -6164,6 +6219,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.mapThumbnailVisibleThreshold = const Value.absent(),
     this.mapThumbnailConcurrentLoads = const Value.absent(),
     this.showPlanGroupProgress = const Value.absent(),
+    this.dismissPlanActionsOnOutsideTap = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -6210,6 +6266,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     this.mapThumbnailVisibleThreshold = const Value.absent(),
     this.mapThumbnailConcurrentLoads = const Value.absent(),
     this.showPlanGroupProgress = const Value.absent(),
+    this.dismissPlanActionsOnOutsideTap = const Value.absent(),
     this.mapMarkerClusteringEnabled = const Value.absent(),
     this.mapMarkerClusterRadius = const Value.absent(),
     this.mapMarkerClusterMaxZoom = const Value.absent(),
@@ -6256,6 +6313,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Expression<int>? mapThumbnailVisibleThreshold,
     Expression<int>? mapThumbnailConcurrentLoads,
     Expression<bool>? showPlanGroupProgress,
+    Expression<bool>? dismissPlanActionsOnOutsideTap,
     Expression<bool>? mapMarkerClusteringEnabled,
     Expression<int>? mapMarkerClusterRadius,
     Expression<int>? mapMarkerClusterMaxZoom,
@@ -6326,6 +6384,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         'map_thumbnail_concurrent_loads': mapThumbnailConcurrentLoads,
       if (showPlanGroupProgress != null)
         'show_plan_group_progress': showPlanGroupProgress,
+      if (dismissPlanActionsOnOutsideTap != null)
+        'dismiss_plan_actions_on_outside_tap': dismissPlanActionsOnOutsideTap,
       if (mapMarkerClusteringEnabled != null)
         'map_marker_clustering_enabled': mapMarkerClusteringEnabled,
       if (mapMarkerClusterRadius != null)
@@ -6378,6 +6438,7 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
     Value<int>? mapThumbnailVisibleThreshold,
     Value<int>? mapThumbnailConcurrentLoads,
     Value<bool>? showPlanGroupProgress,
+    Value<bool>? dismissPlanActionsOnOutsideTap,
     Value<bool>? mapMarkerClusteringEnabled,
     Value<int>? mapMarkerClusterRadius,
     Value<int>? mapMarkerClusterMaxZoom,
@@ -6444,6 +6505,8 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
       showPlanGroupProgress:
           showPlanGroupProgress ?? this.showPlanGroupProgress,
+      dismissPlanActionsOnOutsideTap:
+          dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:
@@ -6616,6 +6679,11 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
         showPlanGroupProgress.value,
       );
     }
+    if (dismissPlanActionsOnOutsideTap.present) {
+      map['dismiss_plan_actions_on_outside_tap'] = Variable<bool>(
+        dismissPlanActionsOnOutsideTap.value,
+      );
+    }
     if (mapMarkerClusteringEnabled.present) {
       map['map_marker_clustering_enabled'] = Variable<bool>(
         mapMarkerClusteringEnabled.value,
@@ -6696,6 +6764,9 @@ class AppSettingsEntriesCompanion extends UpdateCompanion<AppSettingsEntry> {
           )
           ..write('mapThumbnailConcurrentLoads: $mapThumbnailConcurrentLoads, ')
           ..write('showPlanGroupProgress: $showPlanGroupProgress, ')
+          ..write(
+            'dismissPlanActionsOnOutsideTap: $dismissPlanActionsOnOutsideTap, ',
+          )
           ..write('mapMarkerClusteringEnabled: $mapMarkerClusteringEnabled, ')
           ..write('mapMarkerClusterRadius: $mapMarkerClusterRadius, ')
           ..write('mapMarkerClusterMaxZoom: $mapMarkerClusterMaxZoom, ')
@@ -9606,6 +9677,7 @@ typedef $$AppSettingsEntriesTableCreateCompanionBuilder =
       Value<int> mapThumbnailVisibleThreshold,
       Value<int> mapThumbnailConcurrentLoads,
       Value<bool> showPlanGroupProgress,
+      Value<bool> dismissPlanActionsOnOutsideTap,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9653,6 +9725,7 @@ typedef $$AppSettingsEntriesTableUpdateCompanionBuilder =
       Value<int> mapThumbnailVisibleThreshold,
       Value<int> mapThumbnailConcurrentLoads,
       Value<bool> showPlanGroupProgress,
+      Value<bool> dismissPlanActionsOnOutsideTap,
       Value<bool> mapMarkerClusteringEnabled,
       Value<int> mapMarkerClusterRadius,
       Value<int> mapMarkerClusterMaxZoom,
@@ -9853,6 +9926,11 @@ class $$AppSettingsEntriesTableFilterComposer
 
   ColumnFilters<bool> get showPlanGroupProgress => $composableBuilder(
     column: $table.showPlanGroupProgress,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get dismissPlanActionsOnOutsideTap => $composableBuilder(
+    column: $table.dismissPlanActionsOnOutsideTap,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -10084,6 +10162,12 @@ class $$AppSettingsEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<bool> get dismissPlanActionsOnOutsideTap =>
+      $composableBuilder(
+        column: $table.dismissPlanActionsOnOutsideTap,
+        builder: (column) => ColumnOrderings(column),
+      );
+
   ColumnOrderings<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => ColumnOrderings(column),
@@ -10304,6 +10388,12 @@ class $$AppSettingsEntriesTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<bool> get dismissPlanActionsOnOutsideTap =>
+      $composableBuilder(
+        column: $table.dismissPlanActionsOnOutsideTap,
+        builder: (column) => column,
+      );
+
   GeneratedColumn<bool> get mapMarkerClusteringEnabled => $composableBuilder(
     column: $table.mapMarkerClusteringEnabled,
     builder: (column) => column,
@@ -10417,6 +10507,8 @@ class $$AppSettingsEntriesTableTableManager
                 Value<int> mapThumbnailVisibleThreshold = const Value.absent(),
                 Value<int> mapThumbnailConcurrentLoads = const Value.absent(),
                 Value<bool> showPlanGroupProgress = const Value.absent(),
+                Value<bool> dismissPlanActionsOnOutsideTap =
+                    const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -10462,6 +10554,7 @@ class $$AppSettingsEntriesTableTableManager
                 mapThumbnailVisibleThreshold: mapThumbnailVisibleThreshold,
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
                 showPlanGroupProgress: showPlanGroupProgress,
+                dismissPlanActionsOnOutsideTap: dismissPlanActionsOnOutsideTap,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,
@@ -10514,6 +10607,8 @@ class $$AppSettingsEntriesTableTableManager
                 Value<int> mapThumbnailVisibleThreshold = const Value.absent(),
                 Value<int> mapThumbnailConcurrentLoads = const Value.absent(),
                 Value<bool> showPlanGroupProgress = const Value.absent(),
+                Value<bool> dismissPlanActionsOnOutsideTap =
+                    const Value.absent(),
                 Value<bool> mapMarkerClusteringEnabled = const Value.absent(),
                 Value<int> mapMarkerClusterRadius = const Value.absent(),
                 Value<int> mapMarkerClusterMaxZoom = const Value.absent(),
@@ -10559,6 +10654,7 @@ class $$AppSettingsEntriesTableTableManager
                 mapThumbnailVisibleThreshold: mapThumbnailVisibleThreshold,
                 mapThumbnailConcurrentLoads: mapThumbnailConcurrentLoads,
                 showPlanGroupProgress: showPlanGroupProgress,
+                dismissPlanActionsOnOutsideTap: dismissPlanActionsOnOutsideTap,
                 mapMarkerClusteringEnabled: mapMarkerClusteringEnabled,
                 mapMarkerClusterRadius: mapMarkerClusterRadius,
                 mapMarkerClusterMaxZoom: mapMarkerClusterMaxZoom,

--- a/lib/data/local/sqlite_pilgrimage_repository.dart
+++ b/lib/data/local/sqlite_pilgrimage_repository.dart
@@ -130,6 +130,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
       ),
       mapThumbnailConcurrentLoads: row.mapThumbnailConcurrentLoads.clamp(1, 30),
       showPlanGroupProgress: row.showPlanGroupProgress,
+      dismissPlanActionsOnOutsideTap: row.dismissPlanActionsOnOutsideTap,
       mapMarkerClusteringEnabled: row.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius: row.mapMarkerClusterRadius.clamp(32, 120),
       mapMarkerClusterMaxZoom: row.mapMarkerClusterMaxZoom.clamp(10, 22),
@@ -1173,6 +1174,9 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
               settings.mapThumbnailConcurrentLoads.clamp(1, 30),
             ),
             showPlanGroupProgress: Value(settings.showPlanGroupProgress),
+            dismissPlanActionsOnOutsideTap: Value(
+              settings.dismissPlanActionsOnOutsideTap,
+            ),
             mapMarkerClusteringEnabled: Value(
               settings.mapMarkerClusteringEnabled,
             ),

--- a/lib/data/local/sqlite_pilgrimage_repository.dart
+++ b/lib/data/local/sqlite_pilgrimage_repository.dart
@@ -131,6 +131,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
       mapThumbnailConcurrentLoads: row.mapThumbnailConcurrentLoads.clamp(1, 30),
       showPlanGroupProgress: row.showPlanGroupProgress,
       dismissPlanActionsOnOutsideTap: row.dismissPlanActionsOnOutsideTap,
+      hideCompletedPointsOnMap: row.hideCompletedPointsOnMap,
       mapMarkerClusteringEnabled: row.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius: row.mapMarkerClusterRadius.clamp(32, 120),
       mapMarkerClusterMaxZoom: row.mapMarkerClusterMaxZoom.clamp(10, 22),
@@ -1177,6 +1178,7 @@ class SqlitePilgrimageRepository implements PilgrimageRepository {
             dismissPlanActionsOnOutsideTap: Value(
               settings.dismissPlanActionsOnOutsideTap,
             ),
+            hideCompletedPointsOnMap: Value(settings.hideCompletedPointsOnMap),
             mapMarkerClusteringEnabled: Value(
               settings.mapMarkerClusteringEnabled,
             ),

--- a/lib/desktop/desktop_repository_state.dart
+++ b/lib/desktop/desktop_repository_state.dart
@@ -104,6 +104,7 @@ Map<String, Object?> _settingsJson(AppSettings settings) {
     'mapThumbnailVisibleThreshold': settings.mapThumbnailVisibleThreshold,
     'mapThumbnailConcurrentLoads': settings.mapThumbnailConcurrentLoads,
     'showPlanGroupProgress': settings.showPlanGroupProgress,
+    'dismissPlanActionsOnOutsideTap': settings.dismissPlanActionsOnOutsideTap,
     'mapMarkerClusteringEnabled': settings.mapMarkerClusteringEnabled,
     'mapMarkerClusterRadius': settings.mapMarkerClusterRadius,
     'mapMarkerClusterMaxZoom': settings.mapMarkerClusterMaxZoom,
@@ -215,6 +216,8 @@ AppSettings _settingsFromJson(Map<String, Object?> json) {
     mapThumbnailConcurrentLoads:
         _intValue(json['mapThumbnailConcurrentLoads']) ?? 10,
     showPlanGroupProgress: _boolValue(json['showPlanGroupProgress']) ?? true,
+    dismissPlanActionsOnOutsideTap:
+        _boolValue(json['dismissPlanActionsOnOutsideTap']) ?? true,
     mapMarkerClusteringEnabled:
         _boolValue(json['mapMarkerClusteringEnabled']) ?? true,
     mapMarkerClusterRadius: _intValue(json['mapMarkerClusterRadius']) ?? 40,

--- a/lib/desktop/desktop_repository_state.dart
+++ b/lib/desktop/desktop_repository_state.dart
@@ -105,6 +105,7 @@ Map<String, Object?> _settingsJson(AppSettings settings) {
     'mapThumbnailConcurrentLoads': settings.mapThumbnailConcurrentLoads,
     'showPlanGroupProgress': settings.showPlanGroupProgress,
     'dismissPlanActionsOnOutsideTap': settings.dismissPlanActionsOnOutsideTap,
+    'hideCompletedPointsOnMap': settings.hideCompletedPointsOnMap,
     'mapMarkerClusteringEnabled': settings.mapMarkerClusteringEnabled,
     'mapMarkerClusterRadius': settings.mapMarkerClusterRadius,
     'mapMarkerClusterMaxZoom': settings.mapMarkerClusterMaxZoom,
@@ -218,6 +219,8 @@ AppSettings _settingsFromJson(Map<String, Object?> json) {
     showPlanGroupProgress: _boolValue(json['showPlanGroupProgress']) ?? true,
     dismissPlanActionsOnOutsideTap:
         _boolValue(json['dismissPlanActionsOnOutsideTap']) ?? true,
+    hideCompletedPointsOnMap:
+        _boolValue(json['hideCompletedPointsOnMap']) ?? true,
     mapMarkerClusteringEnabled:
         _boolValue(json['mapMarkerClusteringEnabled']) ?? true,
     mapMarkerClusterRadius: _intValue(json['mapMarkerClusterRadius']) ?? 40,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'data/pilgrimage_repository.dart';
 import 'data/sample_pilgrimage_repository.dart';
 import 'desktop/desktop_pilgrimage_repository.dart';
 import 'desktop/tauri_bridge.dart';
+import 'plan/pilgrimage_models.dart';
 import 'widgets/copyable_text.dart';
 
 Future<void> main() async {
@@ -17,24 +18,76 @@ Future<void> main() async {
   runApp(MiriaGoApp(repository: await _createDefaultRepository()));
 }
 
-class MiriaGoApp extends StatelessWidget {
+class MiriaGoApp extends StatefulWidget {
   const MiriaGoApp({this.repository, super.key});
 
   final PilgrimageRepository? repository;
 
   @override
+  State<MiriaGoApp> createState() => _MiriaGoAppState();
+}
+
+class _MiriaGoAppState extends State<MiriaGoApp> with WidgetsBindingObserver {
+  AppSettings _themeSettings = const AppSettings();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangePlatformBrightness() {
+    if (!mounted) {
+      return;
+    }
+    applyAppColorsFromSettings(
+      _themeSettings,
+      platformBrightness: currentPlatformBrightness(),
+    );
+    setState(() {});
+  }
+
+  void _handleSettingsChanged(AppSettings settings) {
+    if (!mounted) {
+      return;
+    }
+    applyAppColorsFromSettings(
+      settings,
+      platformBrightness: currentPlatformBrightness(),
+    );
+    setState(() {
+      _themeSettings = settings;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final theme = appThemeFor(
+      _themeSettings,
+      platformBrightness: currentPlatformBrightness(),
+    );
+
     return MaterialApp(
       title: 'MiriaGo',
       debugShowCheckedModeBanner: false,
-      theme: AppTheme.light(),
+      theme: theme,
+      themeAnimationDuration: Duration.zero,
+      themeAnimationStyle: AnimationStyle.noAnimation,
       navigatorObservers: [copyOverlayNavigatorObserver],
       home: AppShell(
         repository:
-            repository ??
+            widget.repository ??
             (kIsWeb
                 ? SamplePilgrimageRepository()
                 : SqlitePilgrimageRepository()),
+        onSettingsChanged: _handleSettingsChanged,
       ),
     );
   }

--- a/lib/map/in_app_navigation_screen.dart
+++ b/lib/map/in_app_navigation_screen.dart
@@ -1,0 +1,1514 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../app_theme.dart';
+import '../camera_reference/camerawesome_reference_screen.dart';
+import '../plan/pilgrimage_models.dart';
+import '../plan/pilgrimage_plan_controller.dart';
+import '../plan/plan_group_utils.dart';
+import 'map_tile_config.dart';
+
+const _endRouteRed = Color(0xFFFF3B30);
+
+class _NavigationChrome {
+  const _NavigationChrome({
+    required this.brightness,
+    required this.scaffold,
+    required this.panel,
+    required this.row,
+    required this.primaryText,
+    required this.secondaryText,
+    required this.inactiveDot,
+    required this.iconButton,
+    required this.recenterFill,
+    required this.detailsIconBackground,
+    required this.systemOverlay,
+  });
+
+  const _NavigationChrome.light()
+    : brightness = Brightness.light,
+      scaffold = const Color(0xFFF2F2F7),
+      panel = const Color(0xF7FFFFFF),
+      row = const Color(0xFFF2F2F7),
+      primaryText = const Color(0xFF1C1C1E),
+      secondaryText = const Color(0xFF8E8E93),
+      inactiveDot = const Color(0xFFC7C7CC),
+      iconButton = const Color(0xFFE5E5EA),
+      recenterFill = Colors.white,
+      detailsIconBackground = const Color(0xFFE5E5EA),
+      systemOverlay = SystemUiOverlayStyle.dark;
+
+  const _NavigationChrome.dark()
+    : brightness = Brightness.dark,
+      scaffold = const Color(0xFF1C1C1E),
+      panel = const Color(0xF21C1C1E),
+      row = const Color(0xFF2C2C2E),
+      primaryText = Colors.white,
+      secondaryText = const Color(0xFFAEAEB2),
+      inactiveDot = const Color(0xFF636366),
+      iconButton = const Color(0xFF3A3A3C),
+      recenterFill = const Color(0xFF2C2C2E),
+      detailsIconBackground = const Color(0xFF3A3A3C),
+      systemOverlay = SystemUiOverlayStyle.light;
+
+  factory _NavigationChrome.of(Brightness brightness) {
+    return brightness == Brightness.dark
+        ? const _NavigationChrome.dark()
+        : const _NavigationChrome.light();
+  }
+
+  final Brightness brightness;
+  final Color scaffold;
+  final Color panel;
+  final Color row;
+  final Color primaryText;
+  final Color secondaryText;
+  final Color inactiveDot;
+  final Color iconButton;
+  final Color recenterFill;
+  final Color detailsIconBackground;
+  final SystemUiOverlayStyle systemOverlay;
+
+  bool get isDark => brightness == Brightness.dark;
+}
+
+class InAppNavigationScreen extends StatefulWidget {
+  const InAppNavigationScreen({
+    required this.point,
+    required this.settings,
+    this.groupName,
+    this.stops = const [],
+    this.planController,
+    super.key,
+  });
+
+  final PilgrimagePoint point;
+  final AppSettings settings;
+  final String? groupName;
+  final List<PilgrimagePoint> stops;
+  final PilgrimagePlanController? planController;
+
+  static Route<void> route({
+    required PilgrimagePoint point,
+    required AppSettings settings,
+    String? groupName,
+    List<PilgrimagePoint> stops = const [],
+    PilgrimagePlanController? planController,
+  }) {
+    return MaterialPageRoute<void>(
+      fullscreenDialog: true,
+      builder: (_) => InAppNavigationScreen(
+        point: point,
+        settings: settings,
+        groupName: groupName,
+        stops: stops,
+        planController: planController,
+      ),
+    );
+  }
+
+  static Future<void> open(
+    BuildContext context, {
+    required PilgrimagePoint point,
+    required AppSettings settings,
+    String? groupName,
+    List<PilgrimagePoint> stops = const [],
+    PilgrimagePlanController? planController,
+  }) {
+    return Navigator.of(context).push<void>(
+      route(
+        point: point,
+        settings: settings,
+        groupName: groupName,
+        stops: stops,
+        planController: planController,
+      ),
+    );
+  }
+
+  @override
+  State<InAppNavigationScreen> createState() => _InAppNavigationScreenState();
+}
+
+class _InAppNavigationScreenState extends State<InAppNavigationScreen> {
+  final MapController _mapController = MapController();
+  final PageController _stepController = PageController();
+  var _stepIndex = 0;
+  var _sheetExpanded = false;
+  var _debugStopIndex = 0;
+
+  late final List<PilgrimagePoint> _stops = _resolvedStops(
+    point: widget.point,
+    stops: widget.stops,
+  );
+  late final int _startIndex = navigationStartIndex(
+    point: widget.point,
+    stops: _stops,
+  );
+  late final List<PilgrimagePoint> _activeStops = remainingNavigationStops(
+    point: widget.point,
+    stops: _stops,
+  );
+  late final List<_PreviewStep> _steps = _previewStepsFor(widget.point);
+  late final List<LatLng> _route = () {
+    final route = _previewRouteForStops([
+      for (final stop in _activeStops) stop.position,
+    ]);
+    if (route.isEmpty) {
+      return _previewRouteFor(widget.point.position);
+    }
+    return route;
+  }();
+  late LatLng _currentLocation = _route.first;
+
+  PilgrimagePoint get _currentTarget {
+    if (_activeStops.isEmpty) {
+      return widget.point;
+    }
+    final index = _debugStopIndex.clamp(0, _activeStops.length - 1);
+    return _activeStops[index];
+  }
+
+  bool get _currentIsLast {
+    if (_activeStops.isEmpty) {
+      return true;
+    }
+    return _debugStopIndex >= _activeStops.length - 1;
+  }
+
+  PilgrimagePoint? get _nextDebugStop {
+    if (_currentIsLast || _debugStopIndex + 1 >= _activeStops.length) {
+      return null;
+    }
+    return _activeStops[_debugStopIndex + 1];
+  }
+
+  @override
+  void dispose() {
+    _stepController.dispose();
+    super.dispose();
+  }
+
+  void _openReferenceCamera(PilgrimagePoint point) {
+    Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => CamerawesomeReferenceScreen(
+          point: point,
+          settings: widget.settings,
+          controller: widget.planController,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showArriveDebug(
+    BuildContext context,
+    _NavigationChrome chrome,
+  ) {
+    final arrived = _currentTarget;
+    final next = _nextDebugStop;
+    final remainingCount = _activeStops.isEmpty ? 1 : _activeStops.length;
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: chrome.panel,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (sheetContext) {
+        return _ArriveDebugSheet(
+          chrome: chrome,
+          arrived: arrived,
+          isLast: _currentIsLast,
+          stopNumber: _debugStopIndex + 1,
+          remainingCount: remainingCount,
+          nextStop: next,
+          onOpenCamera: () => _openReferenceCamera(arrived),
+          onGoNext: next == null
+              ? null
+              : () {
+                  Navigator.of(sheetContext).pop();
+                  setState(() {
+                    _debugStopIndex++;
+                    _currentLocation = _currentTarget.position;
+                    _sheetExpanded = false;
+                  });
+                  _mapController.move(_currentLocation, 17);
+                },
+        );
+      },
+    );
+  }
+
+  Future<void> _showAllStops(BuildContext context, _NavigationChrome chrome) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: chrome.panel,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (context) {
+        return _AllStopsSheet(
+          chrome: chrome,
+          groupName: widget.groupName,
+          stops: _stops,
+          startIndex: _startIndex,
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+    final platformBrightness = MediaQuery.platformBrightnessOf(context);
+    applyAppColorsFromSettings(
+      widget.settings,
+      platformBrightness: platformBrightness,
+    );
+    final chrome = _NavigationChrome.of(
+      resolvedAppBrightness(
+        widget.settings,
+        platformBrightness: platformBrightness,
+      ),
+    );
+
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: chrome.systemOverlay,
+      child: Scaffold(
+        key: const ValueKey('in-app-navigation-screen'),
+        backgroundColor: chrome.scaffold,
+        body: Stack(
+          children: [
+            FlutterMap(
+              mapController: _mapController,
+              options: MapOptions(
+                initialCameraFit: CameraFit.coordinates(
+                  coordinates: _route,
+                  padding: const EdgeInsets.fromLTRB(48, 260, 48, 200),
+                  maxZoom: 18,
+                ),
+                minZoom: 4,
+                maxZoom: widget.settings.mapMaxZoom.toDouble(),
+                interactionOptions: const InteractionOptions(
+                  flags: InteractiveFlag.all,
+                ),
+              ),
+              children: [
+                configuredNavigationMapTileLayer(
+                  widget.settings,
+                  dark: chrome.isDark,
+                ),
+                PolylineLayer(
+                  polylines: [
+                    Polyline(
+                      points: _route,
+                      color: AppColors.accent.withValues(alpha: 0.28),
+                      strokeWidth: 12,
+                    ),
+                    Polyline(
+                      points: _route,
+                      color: AppColors.accent,
+                      strokeWidth: 6,
+                    ),
+                  ],
+                ),
+                MarkerLayer(
+                  markers: [
+                    Marker(
+                      point: _currentLocation,
+                      width: 44,
+                      height: 44,
+                      child: const _LocationPuck(),
+                    ),
+                    for (var i = 0; i < _stops.length; i++)
+                      if (i < _startIndex)
+                        Marker(
+                          point: _stops[i].position,
+                          width: 24,
+                          height: 24,
+                          child: const _SkippedWaypointDot(),
+                        )
+                      else if (i == _stops.length - 1)
+                        Marker(
+                          point: _stops[i].position,
+                          width: 40,
+                          height: 48,
+                          alignment: Alignment.bottomCenter,
+                          child: const _DestinationPin(),
+                        )
+                      else
+                        Marker(
+                          point: _stops[i].position,
+                          width: 28,
+                          height: 28,
+                          child: _WaypointDot(index: i - _startIndex + 1),
+                        ),
+                  ],
+                ),
+              ],
+            ),
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: _InstructionBanner(
+                chrome: chrome,
+                groupName: widget.groupName,
+                steps: _steps,
+                controller: _stepController,
+                index: _stepIndex,
+                onIndexChanged: (index) {
+                  setState(() => _stepIndex = index);
+                },
+              ),
+            ),
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                    child: _RecenterButton(
+                      chrome: chrome,
+                      onTap: () => _mapController.move(_currentLocation, 17),
+                    ),
+                  ),
+                  _BottomPanel(
+                    chrome: chrome,
+                    point: _currentTarget,
+                    currentIsLast: _currentIsLast,
+                    stops: _stops,
+                    metrics: _tripMetricsFor(_route),
+                    expanded: _sheetExpanded,
+                    bottomInset: bottomInset,
+                    onToggleExpanded: () {
+                      setState(() => _sheetExpanded = !_sheetExpanded);
+                    },
+                    onShowAllStops: () => _showAllStops(context, chrome),
+                    onArriveDebug: () => _showArriveDebug(context, chrome),
+                    onEndRoute: () => Navigator.of(context).maybePop(),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TripMetrics {
+  const _TripMetrics({
+    required this.arrivalText,
+    required this.durationText,
+    required this.distanceText,
+  });
+
+  final String arrivalText;
+  final String durationText;
+  final String distanceText;
+}
+
+_TripMetrics _tripMetricsFor(List<LatLng> route, {DateTime? now}) {
+  final clock = now ?? DateTime.now();
+  var meters = 0.0;
+  final calculator = Distance();
+  for (var i = 1; i < route.length; i++) {
+    meters += calculator(route[i - 1], route[i]);
+  }
+  final minutes = math.max(1, (meters * 0.015).round());
+  final arrival = clock.add(Duration(minutes: minutes));
+  final km = meters / 1000;
+  return _TripMetrics(
+    arrivalText:
+        '${arrival.hour.toString().padLeft(2, '0')}:'
+        '${arrival.minute.toString().padLeft(2, '0')}',
+    durationText:
+        '${minutes ~/ 60}:${(minutes % 60).toString().padLeft(2, '0')}',
+    distanceText: km >= 10
+        ? km.round().toString()
+        : (km < 0.1 ? 0.1 : km).toStringAsFixed(1),
+  );
+}
+
+class _PreviewStep {
+  const _PreviewStep({
+    required this.icon,
+    required this.distanceLabel,
+    required this.instruction,
+  });
+
+  final IconData icon;
+  final String distanceLabel;
+  final String instruction;
+}
+
+List<_PreviewStep> _previewStepsFor(PilgrimagePoint point) {
+  final road = _roadHint(point);
+  return [
+    _PreviewStep(
+      icon: Icons.turn_right_rounded,
+      distanceLabel: '475米',
+      instruction: '右转进入$road',
+    ),
+    _PreviewStep(
+      icon: Icons.straight_rounded,
+      distanceLabel: '210米',
+      instruction: '沿$road直行',
+    ),
+    _PreviewStep(
+      icon: Icons.turn_left_rounded,
+      distanceLabel: '80米',
+      instruction: '左转进入附近道路',
+    ),
+    _PreviewStep(
+      icon: Icons.turn_slight_right_rounded,
+      distanceLabel: '150米',
+      instruction: '靠右前往${point.name}',
+    ),
+    _PreviewStep(
+      icon: Icons.flag_rounded,
+      distanceLabel: '40米',
+      instruction: '到达终点',
+    ),
+  ];
+}
+
+String _roadHint(PilgrimagePoint point) {
+  final subtitle = point.subtitle.trim();
+  if (subtitle.isNotEmpty) {
+    return subtitle;
+  }
+  final city = point.work.city.trim();
+  if (city.isNotEmpty) {
+    return '$city附近道路';
+  }
+  return '前方道路';
+}
+
+List<PilgrimagePoint> _resolvedStops({
+  required PilgrimagePoint point,
+  required List<PilgrimagePoint> stops,
+}) {
+  final resolved = [
+    for (final stop in stops)
+      if (stop.hasCoordinate) stop,
+  ];
+  if (resolved.isEmpty && point.hasCoordinate) {
+    return [point];
+  }
+  return resolved;
+}
+
+String _stopHeadline(PilgrimagePoint stop, {required bool isLast}) {
+  return isLast ? '终点: ${stop.name}' : stop.name;
+}
+
+List<LatLng> _previewRouteFor(LatLng destination) {
+  return [
+    LatLng(destination.latitude - 0.0034, destination.longitude - 0.0026),
+    LatLng(destination.latitude - 0.0021, destination.longitude - 0.0024),
+    LatLng(destination.latitude - 0.0011, destination.longitude - 0.0008),
+    LatLng(destination.latitude - 0.0004, destination.longitude - 0.0002),
+    destination,
+  ];
+}
+
+List<LatLng> _previewRouteForStops(List<LatLng> stops) {
+  if (stops.isEmpty) {
+    return const [];
+  }
+  if (stops.length == 1) {
+    return _previewRouteFor(stops.first);
+  }
+  final first = stops.first;
+  return [
+    LatLng(first.latitude - 0.0028, first.longitude - 0.0022),
+    LatLng(first.latitude - 0.0012, first.longitude - 0.0009),
+    ...stops,
+  ];
+}
+
+class _InstructionBanner extends StatelessWidget {
+  const _InstructionBanner({
+    required this.chrome,
+    required this.steps,
+    this.groupName,
+    this.controller,
+    this.index = 0,
+    this.onIndexChanged,
+  });
+
+  final _NavigationChrome chrome;
+  final String? groupName;
+  final List<_PreviewStep> steps;
+  final PageController? controller;
+  final int index;
+  final ValueChanged<int>? onIndexChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    if (steps.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final zoneName = groupName?.trim() ?? '';
+
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(bottom: Radius.circular(22)),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: chrome.panel,
+            borderRadius: const BorderRadius.vertical(
+              bottom: Radius.circular(22),
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.08),
+                blurRadius: 18,
+                offset: const Offset(0, 6),
+              ),
+            ],
+          ),
+          child: SafeArea(
+            bottom: false,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (zoneName.isNotEmpty)
+                  Padding(
+                    key: const ValueKey('in-app-navigation-top-zone'),
+                    padding: const EdgeInsets.fromLTRB(20, 8, 20, 0),
+                    child: Center(
+                      child: _GroupNameRow(
+                        chrome: chrome,
+                        name: zoneName,
+                        centered: true,
+                      ),
+                    ),
+                  ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 14),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                  SizedBox(
+                    height: 72,
+                    child: PageView.builder(
+                      key: const ValueKey('in-app-navigation-steps'),
+                      controller: controller,
+                      onPageChanged: onIndexChanged,
+                      itemCount: steps.length,
+                      itemBuilder: (context, pageIndex) {
+                        final step = steps[pageIndex];
+                        return Row(
+                          children: [
+                            Icon(
+                              step.icon,
+                              size: 52,
+                              color: chrome.primaryText,
+                            ),
+                            const SizedBox(width: 16),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    step.distanceLabel,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      color: chrome.primaryText,
+                                      fontSize: 34,
+                                      height: 1.05,
+                                      fontWeight: FontWeight.w800,
+                                      letterSpacing: 0,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 2),
+                                  Text(
+                                    step.instruction,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      color: chrome.primaryText,
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w500,
+                                      letterSpacing: 0,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      for (var i = 0; i < steps.length; i++)
+                        Container(
+                          width: 6,
+                          height: 6,
+                          margin: const EdgeInsets.symmetric(horizontal: 3),
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: i == index
+                                ? chrome.primaryText
+                                : chrome.inactiveDot,
+                          ),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BottomPanel extends StatelessWidget {
+  const _BottomPanel({
+    required this.chrome,
+    required this.point,
+    required this.currentIsLast,
+    required this.stops,
+    required this.metrics,
+    required this.expanded,
+    required this.bottomInset,
+    required this.onToggleExpanded,
+    required this.onShowAllStops,
+    required this.onArriveDebug,
+    required this.onEndRoute,
+  });
+
+  final _NavigationChrome chrome;
+  final PilgrimagePoint point;
+  final bool currentIsLast;
+  final List<PilgrimagePoint> stops;
+  final _TripMetrics metrics;
+  final bool expanded;
+  final double bottomInset;
+  final VoidCallback onToggleExpanded;
+  final VoidCallback onShowAllStops;
+  final VoidCallback onArriveDebug;
+  final VoidCallback onEndRoute;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      key: const ValueKey('in-app-navigation-bottom-panel'),
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(22)),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: chrome.panel,
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.1),
+                blurRadius: 18,
+                offset: const Offset(0, -4),
+              ),
+            ],
+          ),
+          child: AnimatedSize(
+            duration: const Duration(milliseconds: 280),
+            curve: Curves.easeOutCubic,
+            alignment: Alignment.topCenter,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(20, 16, 16, 16 + bottomInset),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _SheetHeader(
+                    chrome: chrome,
+                    headline: _stopHeadline(point, isLast: currentIsLast),
+                    metrics: metrics,
+                    expanded: expanded,
+                    onToggleExpanded: onToggleExpanded,
+                  ),
+                  if (expanded) ...[
+                    const SizedBox(height: 16),
+                    _InfoRow(
+                      chrome: chrome,
+                      icon: Icons.location_on,
+                      iconColor: Colors.white,
+                      iconBackground: _endRouteRed,
+                      title: point.name,
+                      subtitle: _destinationSubtitle(point),
+                    ),
+                    const SizedBox(height: 10),
+                    _InfoRow(
+                      key: const ValueKey('in-app-navigation-all-stops'),
+                      chrome: chrome,
+                      icon: Icons.list,
+                      iconColor: chrome.primaryText,
+                      iconBackground: chrome.detailsIconBackground,
+                      title: '全部点位',
+                      subtitle: stops.isEmpty ? null : '共 ${stops.length} 个',
+                      onTap: onShowAllStops,
+                    ),
+                    const SizedBox(height: 16),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 52,
+                      child: OutlinedButton(
+                        key: const ValueKey('in-app-navigation-arrive-debug'),
+                        onPressed: onArriveDebug,
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: chrome.primaryText,
+                          side: BorderSide(color: chrome.iconButton),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          textStyle: const TextStyle(
+                            fontSize: 17,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                        child: const Text('已到达'),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 52,
+                      child: FilledButton(
+                        key: const ValueKey('in-app-navigation-end-route'),
+                        onPressed: onEndRoute,
+                        style: FilledButton.styleFrom(
+                          backgroundColor: _endRouteRed,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          textStyle: const TextStyle(
+                            fontSize: 17,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                        child: const Text('结束路线'),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  const _SheetHeader({
+    required this.chrome,
+    required this.headline,
+    required this.metrics,
+    required this.expanded,
+    required this.onToggleExpanded,
+  });
+
+  final _NavigationChrome chrome;
+  final String headline;
+  final _TripMetrics metrics;
+  final bool expanded;
+  final VoidCallback onToggleExpanded;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                headline,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: chrome.primaryText,
+                  fontSize: 17,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Tooltip(
+              message: expanded ? '收起' : '展开',
+              child: Material(
+                color: chrome.iconButton,
+                shape: const CircleBorder(),
+                child: InkWell(
+                  key: ValueKey(
+                    expanded
+                        ? 'in-app-navigation-collapse'
+                        : 'in-app-navigation-expand',
+                  ),
+                  customBorder: const CircleBorder(),
+                  onTap: onToggleExpanded,
+                  child: SizedBox(
+                    width: 40,
+                    height: 40,
+                    child: Icon(
+                      expanded
+                          ? Icons.keyboard_arrow_down_rounded
+                          : Icons.keyboard_arrow_up_rounded,
+                      color: chrome.primaryText,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 14),
+        _TripSummaryRow(chrome: chrome, metrics: metrics),
+      ],
+    );
+  }
+}
+
+class _TripSummaryRow extends StatelessWidget {
+  const _TripSummaryRow({required this.chrome, required this.metrics});
+
+  final _NavigationChrome chrome;
+  final _TripMetrics metrics;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      key: const ValueKey('in-app-navigation-trip-summary'),
+      children: [
+        _TripMetricColumn(
+          chrome: chrome,
+          value: metrics.arrivalText,
+          label: '到达',
+        ),
+        _TripMetricColumn(
+          chrome: chrome,
+          value: metrics.durationText,
+          label: '小时',
+        ),
+        _TripMetricColumn(
+          chrome: chrome,
+          value: metrics.distanceText,
+          label: '公里',
+        ),
+      ],
+    );
+  }
+}
+
+class _TripMetricColumn extends StatelessWidget {
+  const _TripMetricColumn({
+    required this.chrome,
+    required this.value,
+    required this.label,
+  });
+
+  final _NavigationChrome chrome;
+  final String value;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: chrome.primaryText,
+              fontSize: 28,
+              height: 1.05,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            label,
+            style: TextStyle(
+              color: chrome.secondaryText,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GroupNameRow extends StatelessWidget {
+  const _GroupNameRow({
+    required this.chrome,
+    required this.name,
+    this.centered = false,
+    super.key,
+  });
+
+  final _NavigationChrome chrome;
+  final String name;
+  final bool centered;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: centered ? MainAxisSize.min : MainAxisSize.max,
+      mainAxisAlignment: centered
+          ? MainAxisAlignment.center
+          : MainAxisAlignment.start,
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+          decoration: BoxDecoration(
+            color: AppColors.accent.withValues(alpha: 0.08),
+            border: Border.all(color: AppColors.accent.withValues(alpha: 0.42)),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(
+            '片区',
+            style: TextStyle(
+              color: AppColors.accent,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              height: 1.15,
+              letterSpacing: 0,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Flexible(
+          child: Text(
+            name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: centered ? TextAlign.center : TextAlign.start,
+            style: TextStyle(
+              color: chrome.primaryText,
+              fontSize: 14,
+              letterSpacing: 0,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    super.key,
+    required this.chrome,
+    required this.icon,
+    required this.iconColor,
+    required this.iconBackground,
+    required this.title,
+    this.subtitle,
+    this.onTap,
+  });
+
+  final _NavigationChrome chrome;
+  final IconData icon;
+  final Color iconColor;
+  final Color iconBackground;
+  final String title;
+  final String? subtitle;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: chrome.row,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: iconBackground,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(icon, size: 20, color: iconColor),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: chrome.primaryText,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: chrome.secondaryText,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              if (onTap != null)
+                Icon(Icons.chevron_right_rounded, color: chrome.secondaryText),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RecenterButton extends StatelessWidget {
+  const _RecenterButton({required this.chrome, required this.onTap});
+
+  final _NavigationChrome chrome;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: '回到当前位置',
+      child: Material(
+        color: chrome.recenterFill,
+        shape: const CircleBorder(),
+        elevation: 2,
+        shadowColor: Colors.black.withValues(alpha: 0.18),
+        child: InkWell(
+          key: const ValueKey('in-app-navigation-recenter'),
+          customBorder: const CircleBorder(),
+          onTap: onTap,
+          child: SizedBox(
+            width: 44,
+            height: 44,
+            child: Icon(Icons.navigation, color: AppColors.accent, size: 22),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LocationPuck extends StatelessWidget {
+  const _LocationPuck();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        width: 42,
+        height: 42,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Container(
+              width: 42,
+              height: 42,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.accent.withValues(alpha: 0.18),
+              ),
+            ),
+            Container(
+              width: 18,
+              height: 18,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: AppColors.accent,
+                border: Border.all(color: Colors.white, width: 3),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SkippedWaypointDot extends StatelessWidget {
+  const _SkippedWaypointDot();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 14,
+        height: 14,
+        decoration: BoxDecoration(
+          color: const Color(0xFFC7C7CC),
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white, width: 2),
+        ),
+      ),
+    );
+  }
+}
+
+class _WaypointDot extends StatelessWidget {
+  const _WaypointDot({required this.index});
+
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 22,
+        height: 22,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: AppColors.accent,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white, width: 2),
+        ),
+        child: Text(
+          '$index',
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 11,
+            fontWeight: FontWeight.w800,
+            height: 1,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DestinationPin extends StatelessWidget {
+  const _DestinationPin();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: _endRouteRed,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white, width: 2.5),
+          boxShadow: [
+            BoxShadow(
+              color: _endRouteRed.withValues(alpha: 0.35),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: const Icon(Icons.location_on, color: Colors.white, size: 18),
+      ),
+    );
+  }
+}
+
+String _destinationSubtitle(PilgrimagePoint point) {
+  final episode = point.displayEpisodeLabel.trim();
+  if (episode.isEmpty) {
+    return point.work.title;
+  }
+  return '${point.work.title} · $episode';
+}
+
+class _ArriveDebugSheet extends StatelessWidget {
+  const _ArriveDebugSheet({
+    required this.chrome,
+    required this.arrived,
+    required this.isLast,
+    required this.stopNumber,
+    required this.remainingCount,
+    required this.onOpenCamera,
+    this.nextStop,
+    this.onGoNext,
+  });
+
+  final _NavigationChrome chrome;
+  final PilgrimagePoint arrived;
+  final bool isLast;
+  final int stopNumber;
+  final int remainingCount;
+  final VoidCallback onOpenCamera;
+  final PilgrimagePoint? nextStop;
+  final VoidCallback? onGoNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 4, 20, 16),
+        child: Column(
+          key: const ValueKey('in-app-navigation-arrive-debug-sheet'),
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '到达点位',
+              style: TextStyle(
+                color: chrome.primaryText,
+                fontSize: 20,
+                fontWeight: FontWeight.w800,
+                letterSpacing: 0,
+              ),
+            ),
+            const SizedBox(height: 12),
+            _InfoRow(
+              chrome: chrome,
+              icon: Icons.flag_rounded,
+              iconColor: Colors.white,
+              iconBackground: isLast ? _endRouteRed : AppColors.accent,
+              title: arrived.name,
+              subtitle: _destinationSubtitle(arrived),
+            ),
+            const SizedBox(height: 10),
+            _InfoRow(
+              key: const ValueKey('in-app-navigation-open-camera'),
+              chrome: chrome,
+              icon: Icons.photo_camera_outlined,
+              iconColor: chrome.primaryText,
+              iconBackground: chrome.detailsIconBackground,
+              title: '打开相机',
+              subtitle: '第 $stopNumber / $remainingCount 个剩余点位',
+              onTap: onOpenCamera,
+            ),
+            if (nextStop != null) ...[
+              const SizedBox(height: 10),
+              _InfoRow(
+                chrome: chrome,
+                icon: Icons.arrow_forward_rounded,
+                iconColor: chrome.primaryText,
+                iconBackground: chrome.detailsIconBackground,
+                title: nextStop!.name,
+                subtitle: '下一点位 · ${_destinationSubtitle(nextStop!)}',
+              ),
+            ],
+            if (onGoNext != null) ...[
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: FilledButton(
+                  key: const ValueKey('in-app-navigation-arrive-debug-next'),
+                  onPressed: onGoNext,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.accent,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    textStyle: const TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  child: const Text('前往下一点'),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AllStopsSheet extends StatelessWidget {
+  const _AllStopsSheet({
+    required this.chrome,
+    required this.stops,
+    required this.startIndex,
+    this.groupName,
+  });
+
+  final _NavigationChrome chrome;
+  final String? groupName;
+  final List<PilgrimagePoint> stops;
+  final int startIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    final zoneName = groupName?.trim() ?? '';
+    final maxHeight = MediaQuery.sizeOf(context).height * 0.72;
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 4, 20, 16),
+          child: SingleChildScrollView(
+            child: Column(
+              key: const ValueKey('in-app-navigation-all-stops-sheet'),
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '全部点位',
+                  style: TextStyle(
+                    color: chrome.primaryText,
+                    fontSize: 20,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+                if (zoneName.isNotEmpty) ...[
+                  const SizedBox(height: 10),
+                  _GroupNameRow(chrome: chrome, name: zoneName),
+                ],
+                const SizedBox(height: 12),
+                for (var index = 0; index < stops.length; index++) ...[
+                  if (index > 0) const SizedBox(height: 8),
+                  _AllStopTile(
+                    chrome: chrome,
+                    index: index,
+                    stop: stops[index],
+                    isLast: index == stops.length - 1,
+                    skipped: index < startIndex,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AllStopTile extends StatelessWidget {
+  const _AllStopTile({
+    required this.chrome,
+    required this.index,
+    required this.stop,
+    required this.isLast,
+    required this.skipped,
+  });
+
+  final _NavigationChrome chrome;
+  final int index;
+  final PilgrimagePoint stop;
+  final bool isLast;
+  final bool skipped;
+
+  @override
+  Widget build(BuildContext context) {
+    final titleColor = skipped ? chrome.secondaryText : chrome.primaryText;
+    final subtitleColor = skipped ? chrome.inactiveDot : chrome.secondaryText;
+    return Container(
+      key: skipped
+          ? ValueKey('in-app-navigation-stop-skipped-${stop.id}')
+          : null,
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+      decoration: BoxDecoration(
+        color: chrome.row,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 32,
+            height: 32,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: skipped
+                  ? chrome.iconButton
+                  : isLast
+                  ? _endRouteRed
+                  : AppColors.accent,
+              shape: BoxShape.circle,
+            ),
+            child: Text(
+              '${index + 1}',
+              style: TextStyle(
+                color: skipped ? chrome.secondaryText : Colors.white,
+                fontSize: 13,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  skipped ? stop.name : _stopHeadline(stop, isLast: isLast),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: titleColor,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  _destinationSubtitle(stop),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: subtitleColor,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/map/map_marker_clustering.dart
+++ b/lib/map/map_marker_clustering.dart
@@ -207,7 +207,7 @@ class MapOverlapPointPager extends StatelessWidget {
             '重合点位  ${currentIndex + 1} / $total',
             textAlign: TextAlign.center,
             maxLines: 1,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 13,
               fontWeight: FontWeight.w700,

--- a/lib/map/map_tile_config.dart
+++ b/lib/map/map_tile_config.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_maplibre/flutter_map_maplibre.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../app_theme.dart';
 import '../plan/pilgrimage_models.dart';
 
 const openFreeMapStyleUrl = 'https://tiles.openfreemap.org/styles/liberty';
@@ -130,13 +131,37 @@ String xyzTileUrl(AppSettings settings) {
   return openStreetMapTileUrl;
 }
 
-Widget configuredMapTileLayer(AppSettings settings) {
-  final layerKey = ValueKey(mapTileConfigSignature(settings));
-  if (mapProviderUsesMapLibre(settings.mapTileProvider) &&
+Widget configuredNavigationMapTileLayer(
+  AppSettings settings, {
+  required bool dark,
+}) {
+  return configuredMapTileLayer(settings, dark: dark);
+}
+
+Widget configuredMapTileLayer(AppSettings settings, {bool? dark}) {
+  final effectiveSettings = _mapTileSettingsForBrightness(
+    settings,
+    dark: dark ?? AppColors.isDark,
+  );
+  final layerKey = ValueKey(mapTileConfigSignature(effectiveSettings));
+  if (mapProviderUsesMapLibre(effectiveSettings.mapTileProvider) &&
       !_isFlutterWidgetTest) {
-    return MapLibreLayer(key: layerKey, initStyle: mapLibreStyleUrl(settings));
+    return MapLibreLayer(
+      key: layerKey,
+      initStyle: mapLibreStyleUrl(effectiveSettings),
+    );
   }
-  return configuredRasterTileLayer(settings, key: layerKey);
+  return configuredRasterTileLayer(effectiveSettings, key: layerKey);
+}
+
+AppSettings _mapTileSettingsForBrightness(
+  AppSettings settings, {
+  required bool dark,
+}) {
+  if (dark && settings.mapTileProvider == MapTileProvider.openFreeMap) {
+    return settings.copyWith(openFreeMapStyle: OpenFreeMapStyle.dark);
+  }
+  return settings;
 }
 
 TileLayer configuredRasterTileLayer(AppSettings settings, {Key? key}) {

--- a/lib/map/navigation_route_confirm_screen.dart
+++ b/lib/map/navigation_route_confirm_screen.dart
@@ -1,0 +1,462 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../app_theme.dart';
+import '../plan/pilgrimage_models.dart';
+import '../plan/pilgrimage_plan_controller.dart';
+import '../plan/plan_group_utils.dart';
+import '../widgets/app_back_button.dart';
+import 'in_app_navigation_screen.dart';
+import 'map_tile_config.dart';
+
+const _endRouteRed = Color(0xFFFF3B30);
+
+class NavigationRouteConfirmScreen extends StatelessWidget {
+  const NavigationRouteConfirmScreen({
+    required this.point,
+    required this.settings,
+    this.groupName,
+    this.stops = const [],
+    this.planController,
+    super.key,
+  });
+
+  final PilgrimagePoint point;
+  final AppSettings settings;
+  final String? groupName;
+  final List<PilgrimagePoint> stops;
+  final PilgrimagePlanController? planController;
+
+  static Route<void> route({
+    required PilgrimagePoint point,
+    required AppSettings settings,
+    String? groupName,
+    List<PilgrimagePoint> stops = const [],
+    PilgrimagePlanController? planController,
+  }) {
+    return MaterialPageRoute<void>(
+      fullscreenDialog: true,
+      builder: (_) => NavigationRouteConfirmScreen(
+        point: point,
+        settings: settings,
+        groupName: groupName,
+        stops: stops,
+        planController: planController,
+      ),
+    );
+  }
+
+  static Future<void> open(
+    BuildContext context, {
+    required PilgrimagePoint point,
+    required AppSettings settings,
+    String? groupName,
+    List<PilgrimagePoint> stops = const [],
+    PilgrimagePlanController? planController,
+  }) {
+    return Navigator.of(context).push<void>(
+      route(
+        point: point,
+        settings: settings,
+        groupName: groupName,
+        stops: stops,
+        planController: planController,
+      ),
+    );
+  }
+
+  static Future<void> openForPoint(
+    BuildContext context, {
+    required PilgrimagePoint point,
+    required AppSettings settings,
+    List<PlanGroupBucket> buckets = const [],
+    PilgrimagePlanController? planController,
+  }) {
+    final tour = inAppNavigationTourFor(point: point, buckets: buckets);
+    return open(
+      context,
+      point: point,
+      settings: settings,
+      groupName: tour.groupName,
+      stops: tour.stops,
+      planController: planController,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedStops = _coordinateStops(point: point, stops: stops);
+    final remainingStops = remainingNavigationStops(
+      point: point,
+      stops: resolvedStops,
+    );
+    final canChainZone = remainingStops.length >= 2;
+    final routePoints = _previewPolyline([
+      for (final stop in remainingStops) stop.position,
+    ]);
+    final brightness = resolvedAppBrightness(
+      settings,
+      platformBrightness: MediaQuery.platformBrightnessOf(context),
+    );
+    applyAppColorsFromSettings(
+      settings,
+      platformBrightness: MediaQuery.platformBrightnessOf(context),
+    );
+
+    return Scaffold(
+      key: const ValueKey('navigation-route-confirm-screen'),
+      backgroundColor: AppColors.background,
+      appBar: AppBar(leading: const AppBackButton(), title: const Text('确认路线')),
+      body: Column(
+        children: [
+          Expanded(
+            child: _RoutePreviewMap(
+              settings: settings,
+              dark: brightness == Brightness.dark,
+              routePoints: routePoints,
+              stops: remainingStops,
+            ),
+          ),
+          Material(
+            color: AppColors.surface,
+            elevation: 8,
+            shadowColor: Colors.black.withValues(alpha: 0.12),
+            child: SafeArea(
+              top: false,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (groupName != null && groupName!.trim().isNotEmpty) ...[
+                      _GroupNameRow(name: groupName!.trim()),
+                      const SizedBox(height: 12),
+                    ],
+                    Text(
+                      canChainZone ? '串联整个片区' : '导航到选中点',
+                      style: TextStyle(
+                        color: AppColors.textPrimary,
+                        fontSize: 20,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      canChainZone
+                          ? '按顺序连接 ${remainingStops.length} 个点位：${_stopChainLabel(remainingStops)}'
+                          : '终点：${point.name}',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: AppColors.textSecondary,
+                        fontSize: 14,
+                        height: 1.45,
+                        fontWeight: FontWeight.w500,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    if (canChainZone) ...[
+                      _PrimaryZoneButton(
+                        onTap: () => _startNavigation(
+                          context,
+                          chainZone: true,
+                          resolvedStops: resolvedStops,
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+                      _SecondaryPointButton(
+                        onTap: () => _startNavigation(
+                          context,
+                          chainZone: false,
+                          resolvedStops: resolvedStops,
+                        ),
+                      ),
+                    ] else
+                      _PrimaryZoneButton(
+                        singlePoint: true,
+                        onTap: () => _startNavigation(
+                          context,
+                          chainZone: false,
+                          resolvedStops: resolvedStops,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _startNavigation(
+    BuildContext context, {
+    required bool chainZone,
+    required List<PilgrimagePoint> resolvedStops,
+  }) {
+    final selectedStops = chainZone ? resolvedStops : [point];
+    Navigator.of(context).pushReplacement(
+      InAppNavigationScreen.route(
+        point: point,
+        settings: settings,
+        groupName: chainZone ? groupName : null,
+        stops: selectedStops,
+        planController: planController,
+      ),
+    );
+  }
+}
+
+class _PrimaryZoneButton extends StatelessWidget {
+  const _PrimaryZoneButton({required this.onTap, this.singlePoint = false});
+
+  final VoidCallback onTap;
+  final bool singlePoint;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      key: ValueKey(
+        singlePoint
+            ? 'navigation-route-confirm-point'
+            : 'navigation-route-confirm-zone',
+      ),
+      onPressed: onTap,
+      style: FilledButton.styleFrom(
+        minimumSize: const Size.fromHeight(46),
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+      ),
+      icon: Icon(
+        singlePoint ? Icons.near_me_outlined : Icons.route_rounded,
+        size: 20,
+      ),
+      label: Text(singlePoint ? '开始导航' : '串联整个片区导航'),
+    );
+  }
+}
+
+class _SecondaryPointButton extends StatelessWidget {
+  const _SecondaryPointButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      key: const ValueKey('navigation-route-confirm-point'),
+      onPressed: onTap,
+      style: OutlinedButton.styleFrom(
+        minimumSize: const Size.fromHeight(46),
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+      ),
+      icon: const Icon(Icons.location_on_outlined, size: 20),
+      label: const Text('仅导航到选中点'),
+    );
+  }
+}
+
+class _GroupNameRow extends StatelessWidget {
+  const _GroupNameRow({required this.name});
+
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+          decoration: BoxDecoration(
+            color: AppColors.accent.withValues(alpha: 0.08),
+            border: Border.all(color: AppColors.accent.withValues(alpha: 0.42)),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(
+            '片区',
+            style: TextStyle(
+              color: AppColors.accent,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              height: 1.15,
+              letterSpacing: 0,
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Text(
+            name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 14,
+              letterSpacing: 0,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RoutePreviewMap extends StatelessWidget {
+  const _RoutePreviewMap({
+    required this.settings,
+    required this.dark,
+    required this.routePoints,
+    required this.stops,
+  });
+
+  final AppSettings settings;
+  final bool dark;
+  final List<LatLng> routePoints;
+  final List<PilgrimagePoint> stops;
+
+  @override
+  Widget build(BuildContext context) {
+    if (routePoints.isEmpty) {
+      return const SizedBox.expand();
+    }
+
+    return FlutterMap(
+      options: MapOptions(
+        initialCameraFit: CameraFit.coordinates(
+          coordinates: routePoints,
+          padding: const EdgeInsets.fromLTRB(40, 28, 40, 28),
+          maxZoom: 17,
+        ),
+        minZoom: 4,
+        maxZoom: settings.mapMaxZoom.toDouble(),
+        interactionOptions: const InteractionOptions(
+          flags: InteractiveFlag.all,
+        ),
+      ),
+      children: [
+        configuredNavigationMapTileLayer(settings, dark: dark),
+        PolylineLayer(
+          polylines: [
+            Polyline(
+              points: routePoints,
+              color: AppColors.accent.withValues(alpha: 0.28),
+              strokeWidth: 12,
+            ),
+            Polyline(
+              points: routePoints,
+              color: AppColors.accent,
+              strokeWidth: 6,
+            ),
+          ],
+        ),
+        MarkerLayer(
+          markers: [
+            for (var i = 0; i < stops.length; i++)
+              if (i == stops.length - 1)
+                Marker(
+                  point: stops[i].position,
+                  width: 36,
+                  height: 44,
+                  alignment: Alignment.bottomCenter,
+                  child: const _DestinationPin(),
+                )
+              else
+                Marker(
+                  point: stops[i].position,
+                  width: 26,
+                  height: 26,
+                  child: _WaypointDot(index: i + 1),
+                ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _WaypointDot extends StatelessWidget {
+  const _WaypointDot({required this.index});
+
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 22,
+        height: 22,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: AppColors.accent,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white, width: 2),
+        ),
+        child: Text(
+          '$index',
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 11,
+            fontWeight: FontWeight.w800,
+            height: 1,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DestinationPin extends StatelessWidget {
+  const _DestinationPin();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        width: 28,
+        height: 28,
+        decoration: BoxDecoration(
+          color: _endRouteRed,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white, width: 2.5),
+        ),
+        child: const Icon(Icons.location_on, color: Colors.white, size: 16),
+      ),
+    );
+  }
+}
+
+List<PilgrimagePoint> _coordinateStops({
+  required PilgrimagePoint point,
+  required List<PilgrimagePoint> stops,
+}) {
+  final resolved = [
+    for (final stop in stops)
+      if (stop.hasCoordinate) stop,
+  ];
+  if (resolved.isEmpty && point.hasCoordinate) {
+    return [point];
+  }
+  return resolved;
+}
+
+String _stopChainLabel(List<PilgrimagePoint> stops) {
+  return [for (final stop in stops) stop.name].join(' → ');
+}
+
+List<LatLng> _previewPolyline(List<LatLng> stops) {
+  if (stops.isEmpty) {
+    return const [];
+  }
+  if (stops.length == 1) {
+    final destination = stops.first;
+    return [
+      LatLng(destination.latitude - 0.0034, destination.longitude - 0.0026),
+      destination,
+    ];
+  }
+  return stops;
+}

--- a/lib/map/pilgrimage_map_screen.dart
+++ b/lib/map/pilgrimage_map_screen.dart
@@ -319,6 +319,16 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
     return visiblePoints.map((point) => point.id).toSet();
   }
 
+  bool _shouldShowPointOnMap(PilgrimagePoint point) {
+    if (!point.hasCoordinate) {
+      return false;
+    }
+    if (!widget.settings.hideCompletedPointsOnMap) {
+      return true;
+    }
+    return _controller.statusFor(point) != VisitStatus.completed;
+  }
+
   void _moveToCurrentTarget() {
     final currentPoint = _controller.currentPoint;
     if (currentPoint == null) {
@@ -507,7 +517,7 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
         ? _controller.currentPoint
         : null;
     final positionedPoints = _controller.points
-        .where((point) => point.hasCoordinate)
+        .where(_shouldShowPointOnMap)
         .toList(growable: false);
     final initialFocusPoint = (selectedPoint?.hasCoordinate ?? false)
         ? selectedPoint
@@ -527,7 +537,7 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
     final overlapPoints = <PilgrimagePoint>[];
     for (final pointId in _overlapPointBrowser?.pointIds ?? const <String>[]) {
       final point = _controller.pointById(pointId);
-      if (point != null && point.hasCoordinate) {
+      if (point != null && _shouldShowPointOnMap(point)) {
         overlapPoints.add(point);
       }
     }
@@ -622,7 +632,8 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
                               position: point.position,
                             ),
                           if (activeOverlapPointIds.isNotEmpty &&
-                              selectedPoint != null)
+                              selectedPoint != null &&
+                              _shouldShowPointOnMap(selectedPoint))
                             MapMarkerCluster(
                               items: [selectedPoint],
                               position: selectedPoint.position,
@@ -630,7 +641,8 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
                         ];
                   if (clusteringEnabled &&
                       activeOverlapPointIds.isNotEmpty &&
-                      selectedPoint != null) {
+                      selectedPoint != null &&
+                      _shouldShowPointOnMap(selectedPoint)) {
                     markerClusters.add(
                       MapMarkerCluster(
                         items: [selectedPoint],

--- a/lib/map/pilgrimage_map_screen.dart
+++ b/lib/map/pilgrimage_map_screen.dart
@@ -1055,55 +1055,62 @@ class _PointCard extends StatelessWidget {
             ),
             const SizedBox(height: 6),
           ],
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _PointThumbnail(controller: controller, point: point),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        _StatusBadge(status: status),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: CopyableText(
-                            text: point.name,
-                            copyLabel: '点位名称',
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              fontSize: 17,
-                              fontWeight: FontWeight.w800,
-                              letterSpacing: 0,
+          GestureDetector(
+            key: ValueKey('map-point-card-content-${point.id}'),
+            behavior: HitTestBehavior.opaque,
+            onTap: onOpenDetail,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _PointThumbnail(controller: controller, point: point),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          _StatusBadge(status: status),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: CopyableText(
+                              text: point.name,
+                              copyLabel: '点位名称',
+                              onTap: onOpenDetail,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                fontSize: 17,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
+                              ),
                             ),
                           ),
-                        ),
-                        if (recordCount > 0) ...[
-                          const SizedBox(width: 8),
-                          _MapRecordBadge(count: recordCount),
+                          if (recordCount > 0) ...[
+                            const SizedBox(width: 8),
+                            _MapRecordBadge(count: recordCount),
+                          ],
                         ],
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    CopyableText(
-                      text: _metaText,
-                      copyText: _copySummary,
-                      copyLabel: '点位信息',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        color: AppColors.textSecondary,
-                        fontSize: 13,
-                        letterSpacing: 0,
                       ),
-                    ),
-                  ],
+                      const SizedBox(height: 4),
+                      CopyableText(
+                        text: _metaText,
+                        copyText: _copySummary,
+                        copyLabel: '点位信息',
+                        onTap: onOpenDetail,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 13,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
           const SizedBox(height: 12),
           Row(
@@ -1117,9 +1124,9 @@ class _PointCard extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               IconButton.outlined(
-                tooltip: '点位详情',
-                onPressed: onOpenDetail,
-                icon: const Icon(Icons.info_outline),
+                tooltip: '导航',
+                onPressed: onOpenNavigation,
+                icon: const Icon(Icons.near_me_outlined),
               ),
               const SizedBox(width: 4),
               IconButton.outlined(

--- a/lib/map/pilgrimage_map_screen.dart
+++ b/lib/map/pilgrimage_map_screen.dart
@@ -23,6 +23,7 @@ import '../widgets/image_viewer_screen.dart';
 import '../widgets/auto_caching_reference_thumbnail.dart';
 import '../widgets/image_load_limiter.dart';
 import '../widgets/map_thumbnail_marker.dart';
+import 'navigation_route_confirm_screen.dart';
 import 'map_navigation_launcher.dart';
 import 'map_marker_clustering.dart';
 import 'map_tile_config.dart';
@@ -122,12 +123,25 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
     }
   }
 
-  Future<void> _openNavigation(PilgrimagePoint point) async {
+  Future<void> _openExternalNavigation(PilgrimagePoint point) async {
     final app = widget.settings.navigationApp;
     final opened = await _navigationLauncher.openWalking(point, app);
     if (!opened) {
       _showSnackBar('无法打开${app.label}。');
     }
+  }
+
+  void _openInAppNavigation(PilgrimagePoint point) {
+    NavigationRouteConfirmScreen.openForPoint(
+      context,
+      point: point,
+      settings: widget.settings,
+      buckets: planGroupBuckets(
+        _controller.plan,
+        _controller.completedPointIds,
+      ),
+      planController: _controller,
+    );
   }
 
   void _selectPoint(
@@ -332,7 +346,7 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
   void _moveToCurrentTarget() {
     final currentPoint = _controller.currentPoint;
     if (currentPoint == null) {
-      _showSnackBar('当前计划还没有点位。');
+      _showSnackBar('当前计划还没有点位。', kind: AppStatusBannerKind.warning);
       return;
     }
 
@@ -380,13 +394,15 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
       onOpenRecord: _openRecordDetail,
       onEditPoint: () => _editPoint(point),
       navigationApp: widget.settings.navigationApp,
+      settings: widget.settings,
+      planController: _controller,
     );
   }
 
   Future<void> _editPoint(PilgrimagePoint point) async {
     final repository = _controller.repository;
     if (repository == null) {
-      _showSnackBar('当前环境无法编辑点位。');
+      _showSnackBar('当前环境无法编辑点位。', kind: AppStatusBannerKind.warning);
       return;
     }
     final updated = await EditPointScreen.open(
@@ -431,14 +447,15 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
     );
   }
 
-  void _showSnackBar(String message) {
+  void _showSnackBar(
+    String message, {
+    AppStatusBannerKind kind = AppStatusBannerKind.error,
+  }) {
     if (!mounted) {
       return;
     }
 
-    ScaffoldMessenger.of(
-      context,
-    ).showReplacingSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context).showStatusSnack(kind: kind, title: message);
   }
 
   Marker _buildPointMarker({
@@ -810,8 +827,11 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
                         ? () => _setCurrentPoint(selectedPoint)
                         : null,
                     onOpenDetail: () => _showPointDetail(selectedPoint),
-                    onOpenNavigation: selectedPoint.hasCoordinate
-                        ? () => _openNavigation(selectedPoint)
+                    onOpenInAppNavigation: selectedPoint.hasCoordinate
+                        ? () => _openInAppNavigation(selectedPoint)
+                        : null,
+                    onOpenExternalNavigation: selectedPoint.hasCoordinate
+                        ? () => _openExternalNavigation(selectedPoint)
                         : null,
                     onOpenCamera: () => _openCamera(selectedPoint),
                     onComplete: () =>
@@ -1009,7 +1029,8 @@ class _PointCard extends StatelessWidget {
     required this.recordCount,
     required this.onSetCurrent,
     required this.onOpenDetail,
-    required this.onOpenNavigation,
+    required this.onOpenInAppNavigation,
+    required this.onOpenExternalNavigation,
     required this.onOpenCamera,
     required this.onComplete,
     this.overlapPointIndex,
@@ -1024,7 +1045,8 @@ class _PointCard extends StatelessWidget {
   final int recordCount;
   final VoidCallback? onSetCurrent;
   final VoidCallback onOpenDetail;
-  final VoidCallback? onOpenNavigation;
+  final VoidCallback? onOpenInAppNavigation;
+  final VoidCallback? onOpenExternalNavigation;
   final VoidCallback onOpenCamera;
   final VoidCallback onComplete;
   final int? overlapPointIndex;
@@ -1060,7 +1082,7 @@ class _PointCard extends StatelessWidget {
               onPrevious: onPreviousOverlapPoint!,
               onNext: onNextOverlapPoint!,
             ),
-            const Divider(
+            Divider(
               key: ValueKey('map-overlap-point-divider'),
               height: 1,
               color: AppColors.border,
@@ -1098,10 +1120,6 @@ class _PointCard extends StatelessWidget {
                               ),
                             ),
                           ),
-                          if (recordCount > 0) ...[
-                            const SizedBox(width: 8),
-                            _MapRecordBadge(count: recordCount),
-                          ],
                         ],
                       ),
                       const SizedBox(height: 4),
@@ -1112,7 +1130,7 @@ class _PointCard extends StatelessWidget {
                         onTap: onOpenDetail,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textSecondary,
                           fontSize: 13,
                           letterSpacing: 0,
@@ -1129,22 +1147,39 @@ class _PointCard extends StatelessWidget {
             children: [
               Expanded(
                 child: FilledButton.icon(
-                  onPressed: onOpenNavigation,
+                  key: const ValueKey('map-in-app-navigation-button'),
+                  onPressed: onOpenInAppNavigation,
                   icon: const Icon(Icons.near_me_outlined, size: 18),
                   label: Text(point.hasCoordinate ? '导航' : '坐标待补充'),
                 ),
               ),
               const SizedBox(width: 8),
               IconButton.outlined(
-                tooltip: '导航',
-                onPressed: onOpenNavigation,
+                key: const ValueKey('map-external-navigation-button'),
+                tooltip: '打开外部地图',
+                onPressed: onOpenExternalNavigation,
                 icon: const Icon(Icons.near_me_outlined),
               ),
               const SizedBox(width: 4),
               IconButton.outlined(
                 tooltip: '拍摄参考',
                 onPressed: onOpenCamera,
-                icon: const Icon(Icons.photo_camera_outlined),
+                icon: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      const Center(child: Icon(Icons.photo_camera_outlined)),
+                      if (recordCount > 0)
+                        const Positioned(
+                          top: -5,
+                          right: -5,
+                          child: _MapRecordBadge(),
+                        ),
+                    ],
+                  ),
+                ),
               ),
               const SizedBox(width: 4),
               if (status == VisitStatus.completed)
@@ -1247,37 +1282,31 @@ class _PointThumbnail extends StatelessWidget {
 }
 
 class _MapRecordBadge extends StatelessWidget {
-  const _MapRecordBadge({required this.count});
-
-  final int count;
+  const _MapRecordBadge();
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 5),
+      key: const ValueKey('map-point-shot-badge'),
+      width: 16,
+      height: 16,
+      alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: AppColors.accent.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.photo_library_outlined,
-            size: 15,
-            color: AppColors.accentDark,
-          ),
-          const SizedBox(width: 5),
-          Text(
-            '已拍 $count',
-            style: TextStyle(
-              color: AppColors.accentDark,
-              fontSize: 12,
-              fontWeight: FontWeight.w800,
-              letterSpacing: 0,
-            ),
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: AppColors.accent.withValues(alpha: 0.42)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 2,
+            offset: const Offset(0, 1),
           ),
         ],
+      ),
+      child: Icon(
+        Icons.photo_library_outlined,
+        size: 10,
+        color: AppColors.accentDark,
       ),
     );
   }
@@ -1291,6 +1320,7 @@ class _EmptyMapCard extends StatelessWidget {
     final bottomInset = MediaQuery.paddingOf(context).bottom;
 
     return Container(
+      key: const ValueKey('map-empty-card'),
       margin: EdgeInsets.fromLTRB(16, 0, 16, 16 + bottomInset),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -1299,17 +1329,35 @@ class _EmptyMapCard extends StatelessWidget {
         border: Border.all(color: AppColors.border),
       ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Icon(Icons.map_outlined, color: AppColors.accent),
-          SizedBox(width: 10),
+          const SizedBox(width: 10),
           Expanded(
-            child: Text(
-              '当前计划还没有点位。添加点位后会在地图上显示标记。',
-              style: TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 14,
-                letterSpacing: 0,
-              ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '当前计划还没有点位',
+                  style: TextStyle(
+                    color: AppColors.accentDark,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '添加点位后会在地图上显示标记。',
+                  style: TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 13,
+                    height: 1.45,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ],
             ),
           ),
         ],

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -20,7 +20,6 @@ import '../widgets/reference_thumbnail_stub.dart'
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/app_scaled_route.dart';
 import '../widgets/app_back_button.dart';
-import '../widgets/input_dialog.dart';
 import 'anitabi_map_import_screen.dart';
 import 'coordinate_parser.dart';
 import 'pilgrimage_work_dropdown.dart';
@@ -47,6 +46,44 @@ InputDecoration stableInputDecoration({
 double _guideDialogHeight(BuildContext context, double contentHeight) {
   final viewportLimit = MediaQuery.sizeOf(context).height * 0.72;
   return viewportLimit < contentHeight ? viewportLimit : contentHeight;
+}
+
+Future<void> _pasteCoordinateFromClipboardInto({
+  required BuildContext context,
+  required TextEditingController latitudeController,
+  required TextEditingController longitudeController,
+  required VoidCallback onFilled,
+}) async {
+  LatLng? coordinate;
+  try {
+    coordinate = await parseClipboardCoordinate();
+  } on Object {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.warning,
+        title: '无法读取剪贴板。',
+      );
+    }
+    return;
+  }
+  if (!context.mounted) {
+    return;
+  }
+  if (coordinate == null) {
+    ScaffoldMessenger.of(context).showStatusSnack(
+      kind: AppStatusBannerKind.warning,
+      title: '剪贴板中没有有效坐标。',
+    );
+    return;
+  }
+  final parsed = coordinate;
+  latitudeController.text = parsed.latitude.toStringAsFixed(6);
+  longitudeController.text = parsed.longitude.toStringAsFixed(6);
+  onFilled();
+  ScaffoldMessenger.of(context).showStatusSnack(
+    kind: AppStatusBannerKind.success,
+    title: '已填入坐标。',
+  );
 }
 
 InputDecoration _boxedFormDecoration({
@@ -2254,22 +2291,13 @@ class _QuickManualPointFormScreenState
     });
   }
 
-  Future<void> _pasteCoordinateFromClipboard() async {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    if (!mounted) {
-      return;
-    }
-    final coordinate = parseCoordinateText(data?.text ?? '');
-    if (coordinate == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '剪贴板中没有有效坐标。');
-      return;
-    }
-    setState(() {
-      _latitudeController.text = coordinate.latitude.toStringAsFixed(6);
-      _longitudeController.text = coordinate.longitude.toStringAsFixed(6);
-    });
+  Future<void> _pasteCoordinateFromClipboard() {
+    return _pasteCoordinateFromClipboardInto(
+      context: context,
+      latitudeController: _latitudeController,
+      longitudeController: _longitudeController,
+      onFilled: () => setState(() {}),
+    );
   }
 
   Future<void> _showFillingGuide() {
@@ -2541,7 +2569,8 @@ class _QuickManualPointFormScreenState
                       width: 44,
                       height: 40,
                       child: IconButton.outlined(
-                        tooltip: '粘贴剪切板坐标',
+                        key: const ValueKey('quick-point-paste-coordinate'),
+                        tooltip: '粘贴剪贴板坐标',
                         onPressed: _pasteCoordinateFromClipboard,
                         style: IconButton.styleFrom(
                           foregroundColor: AppColors.textPrimary,
@@ -2946,91 +2975,13 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     });
   }
 
-  Future<void> _pasteCoordinateFromClipboard() async {
-    String clipboardText = '';
-    try {
-      final data = await Clipboard.getData(Clipboard.kTextPlain);
-      clipboardText = data?.text ?? '';
-    } on Object {
-      clipboardText = '';
-    }
-
-    var coordinate = parseCoordinateText(clipboardText);
-    if (coordinate == null && mounted) {
-      final manualText = await _showCoordinatePasteDialog();
-      if (!mounted || manualText == null) {
-        return;
-      }
-      coordinate = parseCoordinateText(manualText);
-    }
-
-    if (!mounted) {
-      return;
-    }
-    if (coordinate == null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '剪切板中没有可识别的坐标。');
-      return;
-    }
-    final parsedCoordinate = coordinate;
-
-    setState(() {
-      _latitudeController.text = parsedCoordinate.latitude.toStringAsFixed(6);
-      _longitudeController.text = parsedCoordinate.longitude.toStringAsFixed(6);
-    });
-    ScaffoldMessenger.of(
-      context,
-    ).showStatusSnack(kind: AppStatusBannerKind.success, title: '已填入坐标。');
-  }
-
-  Future<String?> _showCoordinatePasteDialog() async {
-    final controller = TextEditingController();
-    final formKey = GlobalKey<FormState>();
-    final result = await showDialog<String>(
+  Future<void> _pasteCoordinateFromClipboard() {
+    return _pasteCoordinateFromClipboardInto(
       context: context,
-      builder: (dialogContext) {
-        return AppInputDialog(
-          title: '粘贴坐标',
-          content: Form(
-            key: formKey,
-            child: AppDialogField(
-              label: '坐标文本',
-              child: TextFormField(
-                onTapOutside: dismissKeyboardOnTapOutside,
-                controller: controller,
-                autofocus: true,
-                minLines: 2,
-                maxLines: 3,
-                decoration: appDialogInputDecoration(
-                  hintText: '例如 35.712576, 139.722166',
-                ),
-                validator: (value) {
-                  if (parseCoordinateText(value ?? '') == null) {
-                    return '请输入可识别的坐标';
-                  }
-                  return null;
-                },
-                textInputAction: TextInputAction.done,
-                onFieldSubmitted: (_) {
-                  if (formKey.currentState?.validate() ?? false) {
-                    Navigator.of(dialogContext).pop(controller.text);
-                  }
-                },
-              ),
-            ),
-          ),
-          confirmLabel: '填入',
-          onConfirm: () {
-            if (formKey.currentState?.validate() ?? false) {
-              Navigator.of(dialogContext).pop(controller.text);
-            }
-          },
-        );
-      },
+      latitudeController: _latitudeController,
+      longitudeController: _longitudeController,
+      onFilled: () => setState(() {}),
     );
-    controller.dispose();
-    return result;
   }
 
   void _removeReferenceImage() {
@@ -3417,7 +3368,8 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                         width: 44,
                         height: 40,
                         child: IconButton.outlined(
-                          tooltip: '粘贴剪切板坐标',
+                          key: const ValueKey('point-form-paste-coordinate'),
+                          tooltip: '粘贴剪贴板坐标',
                           onPressed: _isSaving
                               ? null
                               : _pasteCoordinateFromClipboard,

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/app_scaled_route.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/input_dialog.dart';
 import 'anitabi_map_import_screen.dart';
 import 'coordinate_parser.dart';
@@ -153,7 +154,10 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
         Navigator.of(context).pop(_didUpdate);
       },
       child: Scaffold(
-        appBar: AppBar(title: const Text('添加内容')),
+        appBar: AppBar(
+          leading: appBackButtonIfCanPop(context),
+          title: const Text('添加内容'),
+        ),
         body: ListView(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
           children: [
@@ -549,7 +553,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('搜索 Bangumi'),
-          leading: BackButton(
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didAdd),
           ),
         ),
@@ -983,7 +987,10 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
   Widget build(BuildContext context) {
     final hasLinkText = _linkController.text.isNotEmpty;
     return Scaffold(
-      appBar: AppBar(title: const Text('Anitabi 链接导入')),
+      appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
+        title: const Text('Anitabi 链接导入'),
+      ),
       body: Form(
         key: _formKey,
         child: ListView(
@@ -1478,7 +1485,7 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('手动添加作品'),
-          leading: BackButton(
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didAdd),
           ),
           actions: [
@@ -2342,6 +2349,7 @@ class _QuickManualPointFormScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: const Text('快速手动添加点位'),
         actions: [
           TextButton.icon(
@@ -3105,7 +3113,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: Text(_isEditing ? '编辑点位' : '手动添加点位'),
-          leading: BackButton(
+          leading: AppBackButton(
             onPressed: () {
               if (!_didCommitPendingReference) {
                 unawaited(
@@ -3635,7 +3643,10 @@ class _ManualPointMapPickerScreenState
     final selectedPosition = _selectedPosition;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('选择点位坐标')),
+      appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
+        title: const Text('选择点位坐标'),
+      ),
       body: Stack(
         children: [
           FlutterMap(

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -64,7 +64,7 @@ InputDecoration _boxedFormDecoration({
     contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
     enabledBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(8),
-      borderSide: const BorderSide(color: AppColors.border),
+      borderSide: BorderSide(color: AppColors.border),
     ),
     focusedBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(8),
@@ -91,7 +91,7 @@ InputDecoration _workTypeDropdownDecoration() {
     contentPadding: const EdgeInsets.fromLTRB(14, 10, 4, 10),
     enabledBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(8),
-      borderSide: const BorderSide(color: AppColors.border, width: 1.4),
+      borderSide: BorderSide(color: AppColors.border, width: 1.4),
     ),
     focusedBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(8),
@@ -369,7 +369,7 @@ class _AddPointsScreenState extends State<AddPointsScreen> {
       if (context.mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showReplacingSnackBar(const SnackBar(content: Text('点位保存失败，请稍后重试。')));
+        ).showStatusSnack(kind: AppStatusBannerKind.error, title: '点位保存失败，请稍后重试。');
       }
       return;
     }
@@ -522,7 +522,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(SnackBar(content: Text('已添加「${work.title}」。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.success, title: '已添加「${work.title}」。');
     } catch (_) {
       if (!mounted) {
         return;
@@ -530,7 +530,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
 
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('作品添加失败，请稍后重试。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '作品添加失败，请稍后重试。');
     } finally {
       if (mounted) {
         setState(() {
@@ -704,11 +704,7 @@ class _BangumiTypeFilter extends StatelessWidget {
           for (var index = 0; index < _types.length; index++) ...[
             Expanded(child: _buildTypeItem(_types[index])),
             if (index < _types.length - 1)
-              const VerticalDivider(
-                width: 1,
-                thickness: 1,
-                color: AppColors.border,
-              ),
+              VerticalDivider(width: 1, thickness: 1, color: AppColors.border),
           ],
         ],
       ),
@@ -818,7 +814,7 @@ class _BangumiTypeFilterDisclosure extends StatelessWidget {
                   padding: const EdgeInsets.symmetric(horizontal: 12),
                   child: Row(
                     children: [
-                      const Expanded(
+                      Expanded(
                         child: Text(
                           '筛选作品类型',
                           style: TextStyle(
@@ -831,7 +827,7 @@ class _BangumiTypeFilterDisclosure extends StatelessWidget {
                       ),
                       Text(
                         '已选 ${selectedTypes.length} 项',
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textSecondary,
                           fontSize: 12,
                           letterSpacing: 0,
@@ -841,7 +837,7 @@ class _BangumiTypeFilterDisclosure extends StatelessWidget {
                       AnimatedRotation(
                         turns: expanded ? 0.5 : 0,
                         duration: const Duration(milliseconds: 160),
-                        child: const Icon(
+                        child: Icon(
                           Icons.keyboard_arrow_down_rounded,
                           size: 20,
                           color: AppColors.textSecondary,
@@ -960,8 +956,9 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
       data = await Clipboard.getData(Clipboard.kTextPlain);
     } catch (_) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showReplacingSnackBar(
-          const SnackBar(content: Text('无法读取剪贴板，请手动粘贴 Anitabi 链接。')),
+        ScaffoldMessenger.of(context).showStatusSnack(
+          kind: AppStatusBannerKind.warning,
+          title: '无法读取剪贴板，请手动粘贴 Anitabi 链接。',
         );
       }
       return;
@@ -971,8 +968,9 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
     }
     final text = data?.text?.trim() ?? '';
     if (text.isEmpty) {
-      ScaffoldMessenger.of(context).showReplacingSnackBar(
-        const SnackBar(content: Text('剪贴板中没有可用的 Anitabi 链接。')),
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.warning,
+        title: '剪贴板中没有可用的 Anitabi 链接。',
       );
       return;
     }
@@ -998,7 +996,7 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
           children: [
             Text(
               '加入到：${widget.plan.name}',
-              style: const TextStyle(
+              style: TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 14,
                 letterSpacing: 0,
@@ -1015,7 +1013,7 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const Text(
+                  Text(
                     'Anitabi 链接',
                     style: TextStyle(
                       color: AppColors.textPrimary,
@@ -1064,7 +1062,7 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
                       ),
                       enabledBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
-                        borderSide: const BorderSide(color: AppColors.border),
+                        borderSide: BorderSide(color: AppColors.border),
                       ),
                       focusedBorder: OutlineInputBorder(
                         borderRadius: BorderRadius.circular(8),
@@ -1163,7 +1161,7 @@ class _LinkExampleCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
+          Text(
             '有效链接示例',
             style: TextStyle(
               color: AppColors.textPrimary,
@@ -1175,7 +1173,7 @@ class _LinkExampleCard extends StatelessWidget {
           const SizedBox(height: 6),
           _ExampleLinkText(linkPrefix: '$siteBaseUrl/map?'),
           const SizedBox(height: 12),
-          const Text(
+          Text(
             '如果链接里包含作品 ID，会只加载对应作品；\n如果还包含点位 ID，会自动选中该点位。\n没有作品 ID 的链接需要先在 Anitabi 中进入对应作品后重新复制。',
             style: TextStyle(
               color: AppColors.textSecondary,
@@ -1197,7 +1195,7 @@ class _ExampleLinkText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const normalStyle = TextStyle(
+    final normalStyle = TextStyle(
       color: AppColors.textSecondary,
       fontSize: 13,
       fontFamily: 'monospace',
@@ -1213,7 +1211,7 @@ class _ExampleLinkText extends StatelessWidget {
           children: [
             _ExamplePlainText(text: linkPrefix, style: normalStyle),
             _highlight(_LinkExampleCard._bangumiId),
-            const _ExamplePlainText(
+            _ExamplePlainText(
               text: _LinkExampleCard._middle,
               style: normalStyle,
             ),
@@ -1227,7 +1225,7 @@ class _ExampleLinkText extends StatelessWidget {
           runSpacing: 4,
           children: [
             _highlight(_LinkExampleCard._pointId),
-            const _ExamplePlainText(
+            _ExamplePlainText(
               text: _LinkExampleCard._suffix,
               style: normalStyle,
             ),
@@ -1342,7 +1340,7 @@ class _ExampleNote extends StatelessWidget {
   const _ExampleNote({required this.text});
 
   static const horizontalPadding = 16.0;
-  static const textStyle = TextStyle(
+  static TextStyle get textStyle => TextStyle(
     color: AppColors.textSecondary,
     fontSize: 12,
     fontWeight: FontWeight.w700,
@@ -1435,7 +1433,7 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
       _cityController.clear();
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(SnackBar(content: Text('已添加「$title」。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.success, title: '已添加「$title」。');
     } catch (_) {
       if (!mounted) {
         return;
@@ -1443,7 +1441,7 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
 
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('作品保存失败，请稍后重试。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '作品保存失败，请稍后重试。');
     } finally {
       if (mounted) {
         setState(() {
@@ -1680,7 +1678,7 @@ class _ManualPointFillingGuideSheet extends StatelessWidget {
                   size: 24,
                 ),
                 const SizedBox(width: 10),
-                const Expanded(
+                Expanded(
                   child: Text(
                     '点位填写指南',
                     style: TextStyle(
@@ -1699,7 +1697,7 @@ class _ManualPointFillingGuideSheet extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 8),
-            const Text(
+            Text(
               '重点记录现场可识别的信息，方便到达后快速确认位置、场景和拍摄条件。',
               style: TextStyle(
                 color: AppColors.textSecondary,
@@ -1765,7 +1763,7 @@ class _ManualPointFillingGuideSheet extends StatelessWidget {
                     color: AppColors.accentDark,
                   ),
                   const SizedBox(width: 9),
-                  const Expanded(
+                  Expanded(
                     child: Text(
                       '保存前建议核对地图标记是否落在正确建筑或道路一侧；坐标偏差会直接影响导航和现场查找。',
                       style: TextStyle(
@@ -1819,7 +1817,7 @@ class _ManualWorkFillingGuideSheet extends StatelessWidget {
                   size: 24,
                 ),
                 const SizedBox(width: 10),
-                const Expanded(
+                Expanded(
                   child: Text(
                     '作品填写指南',
                     style: TextStyle(
@@ -1838,7 +1836,7 @@ class _ManualWorkFillingGuideSheet extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 8),
-            const Text(
+            Text(
               '填写作品本身的信息，点位名称、场景说明和具体地址请在添加点位时录入。',
               style: TextStyle(
                 color: AppColors.textSecondary,
@@ -1897,7 +1895,7 @@ class _ManualWorkFillingGuideSheet extends StatelessWidget {
                     color: AppColors.accentDark,
                   ),
                   const SizedBox(width: 9),
-                  const Expanded(
+                  Expanded(
                     child: Text(
                       '保存作品后，表单会清空以便继续添加。作品不会自动生成点位，可随后使用“手动添加点位”录入巡礼地点。',
                       style: TextStyle(
@@ -1993,7 +1991,7 @@ class _FillingGuideItem extends StatelessWidget {
                       Expanded(
                         child: Text(
                           title,
-                          style: const TextStyle(
+                          style: TextStyle(
                             color: AppColors.textPrimary,
                             fontSize: 15,
                             fontWeight: FontWeight.w900,
@@ -2029,7 +2027,7 @@ class _FillingGuideItem extends StatelessWidget {
                   const SizedBox(height: 5),
                   Text(
                     body,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 13,
                       height: 1.4,
@@ -2265,7 +2263,7 @@ class _QuickManualPointFormScreenState
     if (coordinate == null) {
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('剪贴板中没有有效坐标。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '剪贴板中没有有效坐标。');
       return;
     }
     setState(() {
@@ -2380,7 +2378,7 @@ class _QuickManualPointFormScreenState
           children: [
             Text(
               '加入到：${widget.plan.name}',
-              style: const TextStyle(
+              style: TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 13,
                 letterSpacing: 0,
@@ -2423,7 +2421,7 @@ class _QuickManualPointFormScreenState
               children: [
                 Row(
                   children: [
-                    const Expanded(
+                    Expanded(
                       child: Text(
                         '坐标位置',
                         style: TextStyle(
@@ -2459,7 +2457,7 @@ class _QuickManualPointFormScreenState
                           controller: _latitudeController,
                           focusNode: _latitudeFocusNode,
                           decoration: _coordinateDecoration('例如：35.712576'),
-                          style: const TextStyle(
+                          style: TextStyle(
                             color: AppColors.textPrimary,
                             fontSize: 15,
                             fontWeight: FontWeight.w500,
@@ -2487,7 +2485,7 @@ class _QuickManualPointFormScreenState
                           controller: _longitudeController,
                           focusNode: _longitudeFocusNode,
                           decoration: _coordinateDecoration('例如：139.722166'),
-                          style: const TextStyle(
+                          style: TextStyle(
                             color: AppColors.textPrimary,
                             fontSize: 15,
                             fontWeight: FontWeight.w500,
@@ -2547,7 +2545,7 @@ class _QuickManualPointFormScreenState
                         onPressed: _pasteCoordinateFromClipboard,
                         style: IconButton.styleFrom(
                           foregroundColor: AppColors.textPrimary,
-                          side: const BorderSide(color: AppColors.border),
+                          side: BorderSide(color: AppColors.border),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(8),
                           ),
@@ -2601,7 +2599,7 @@ class _QuickManualPointFillingGuideSheet extends StatelessWidget {
                   size: 24,
                 ),
                 const SizedBox(width: 10),
-                const Expanded(
+                Expanded(
                   child: Text(
                     '快速添加填写指南',
                     style: TextStyle(
@@ -2620,7 +2618,7 @@ class _QuickManualPointFillingGuideSheet extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 8),
-            const Text(
+            Text(
               '先录入最基本的信息，之后可从点位编辑页继续补充位置说明、场景标签、参考来源、备注和参考图。',
               style: TextStyle(
                 color: AppColors.textSecondary,
@@ -2864,7 +2862,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
 
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('点位保存失败，请稍后重试。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '点位保存失败，请稍后重试。');
     } finally {
       if (mounted) {
         setState(() {
@@ -2906,7 +2904,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
       }
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('参考图读取失败，请重新选择。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '参考图读取失败，请重新选择。');
       return;
     }
 
@@ -2972,7 +2970,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     if (coordinate == null) {
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('剪切板中没有可识别的坐标。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '剪切板中没有可识别的坐标。');
       return;
     }
     final parsedCoordinate = coordinate;
@@ -2983,7 +2981,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
     });
     ScaffoldMessenger.of(
       context,
-    ).showReplacingSnackBar(const SnackBar(content: Text('已填入坐标。')));
+    ).showStatusSnack(kind: AppStatusBannerKind.success, title: '已填入坐标。');
   }
 
   Future<String?> _showCoordinatePasteDialog() async {
@@ -3154,7 +3152,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                 _isEditing
                     ? '修改：${editingPoint!.name}'
                     : '加入到：${widget.plan.name}',
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 13,
                   letterSpacing: 0,
@@ -3307,7 +3305,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
               const SizedBox(height: 12),
               _FormSection(
                 children: [
-                  const Align(
+                  Align(
                     alignment: Alignment.centerLeft,
                     child: Text(
                       '坐标位置',
@@ -3335,7 +3333,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                             decoration: _coordinateInputDecoration(
                               hintText: '例如：35.712576',
                             ),
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: AppColors.textPrimary,
                               fontSize: 15,
                               fontWeight: FontWeight.w500,
@@ -3364,7 +3362,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                             decoration: _coordinateInputDecoration(
                               hintText: '例如：139.722166',
                             ),
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: AppColors.textPrimary,
                               fontSize: 15,
                               fontWeight: FontWeight.w500,
@@ -3425,7 +3423,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                               : _pasteCoordinateFromClipboard,
                           style: IconButton.styleFrom(
                             foregroundColor: AppColors.textPrimary,
-                            side: const BorderSide(color: AppColors.border),
+                            side: BorderSide(color: AppColors.border),
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(8),
                             ),
@@ -3600,7 +3598,7 @@ class _CoordinateLabeledField extends StatelessWidget {
                       ),
                   ],
                 ),
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 12,
                   fontWeight: FontWeight.w700,
@@ -3834,7 +3832,7 @@ class _ManualPointSelectionCard extends StatelessWidget {
                   subtitle,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 12,
                     letterSpacing: 0,
@@ -3904,7 +3902,7 @@ class _LinkedWorksPanel extends StatelessWidget {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              const Text(
+                              Text(
                                 '已关联作品',
                                 style: TextStyle(
                                   color: AppColors.textPrimary,
@@ -3916,7 +3914,7 @@ class _LinkedWorksPanel extends StatelessWidget {
                               const SizedBox(height: 2),
                               Text(
                                 '共 ${works.length} 部作品，$pointCount 个点位',
-                                style: const TextStyle(
+                                style: TextStyle(
                                   color: AppColors.textSecondary,
                                   fontSize: 13,
                                   letterSpacing: 0,
@@ -3961,7 +3959,7 @@ class _LinkedWorksPanel extends StatelessWidget {
                           color: AppColors.accent.withValues(alpha: 0.04),
                           borderRadius: BorderRadius.circular(6),
                         ),
-                        child: const Text(
+                        child: Text(
                           '还没有关联作品，可从 Bangumi 搜索或手动添加。',
                           style: TextStyle(
                             color: AppColors.textSecondary,
@@ -4053,7 +4051,7 @@ class _LinkedWorkPreview extends StatelessWidget {
             work.title,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textPrimary,
               fontSize: 12,
               letterSpacing: 0,
@@ -4137,7 +4135,7 @@ class _WorkCreationAction extends StatelessWidget {
                       title,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textPrimary,
                         fontSize: 15,
                         fontWeight: FontWeight.w800,
@@ -4149,7 +4147,7 @@ class _WorkCreationAction extends StatelessWidget {
                       subtitle,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textSecondary,
                         fontSize: 12,
                         letterSpacing: 0,
@@ -4221,7 +4219,7 @@ class _ManualReferenceImagePicker extends StatelessWidget {
                       localPath: localPath,
                       imageUrl: imageUrl,
                       fit: BoxFit.cover,
-                      placeholder: const Icon(
+                      placeholder: Icon(
                         Icons.image_outlined,
                         color: AppColors.textSecondary,
                       ),
@@ -4250,7 +4248,7 @@ class _ManualReferenceImagePicker extends StatelessWidget {
                         : hasExistingImage
                         ? '当前参考图，重新选择后需保存才会生效。'
                         : '可选，保存时会复制到 App 本地目录。',
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 12,
                       letterSpacing: 0,
@@ -4445,7 +4443,7 @@ class _InfoPill extends StatelessWidget {
       ),
       child: Text(
         label,
-        style: const TextStyle(
+        style: TextStyle(
           color: AppColors.textSecondary,
           fontSize: 11,
           fontWeight: FontWeight.w700,
@@ -4478,7 +4476,7 @@ class _MessageCard extends StatelessWidget {
           Expanded(
             child: Text(
               text,
-              style: const TextStyle(
+              style: TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 14,
                 letterSpacing: 0,
@@ -4508,7 +4506,7 @@ class _BangumiSearchHintContent extends StatelessWidget {
               size: 17,
             ),
             const SizedBox(width: 8),
-            const Text(
+            Text(
               '搜索说明',
               style: TextStyle(
                 color: AppColors.textPrimary,
@@ -4521,7 +4519,7 @@ class _BangumiSearchHintContent extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 8),
-        const Padding(
+        Padding(
           padding: EdgeInsets.only(left: 25),
           child: Text(
             '输入作品名后搜索，选择结果即可加入当前计划。',
@@ -4637,7 +4635,7 @@ class _QuickImportPanel extends StatelessWidget {
                             children: [
                               Row(
                                 children: [
-                                  const Text(
+                                  Text(
                                     '快速导入',
                                     style: TextStyle(
                                       color: AppColors.textPrimary,
@@ -4671,7 +4669,7 @@ class _QuickImportPanel extends StatelessWidget {
                                 ],
                               ),
                               const SizedBox(height: 3),
-                              const Text(
+                              Text(
                                 '在导入Anitabi点位的同时自动导入作品',
                                 style: TextStyle(
                                   color: AppColors.textSecondary,
@@ -4743,7 +4741,7 @@ class _AddPointPanel extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 9),
-                const Text(
+                Text(
                   '添加点位',
                   style: TextStyle(
                     color: AppColors.textPrimary,

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -28,6 +28,7 @@ import '../widgets/map_thumbnail_marker.dart';
 import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
 import '../widgets/app_scaled_route.dart';
+import '../widgets/app_back_button.dart';
 import '../utils/limited_concurrency.dart';
 import '../utils/selected_item_order.dart';
 import 'nearest_group_assign_screen.dart';
@@ -1431,6 +1432,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
+          leading: appBackButtonIfCanPop(context),
           title: const Text('从作品地图导入'),
           actions: [
             Tooltip(

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -170,8 +170,10 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
 
   Future<void> _refreshAnitabiData() async {
     widget.anitabiClient.clearStaticCache();
-    ScaffoldMessenger.of(context).showReplacingSnackBar(
-      const SnackBar(content: Text('正在清除缓存并重新加载 Anitabi 点位...')),
+    ScaffoldMessenger.of(context).showStatusSnack(
+      kind: AppStatusBannerKind.running,
+      title: '正在清除缓存并重新加载 Anitabi 点位...',
+      icon: Icons.cleaning_services_outlined,
     );
 
     final initialBangumiId = widget.initialBangumiId;
@@ -295,8 +297,9 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
   }
 
   void _showManualWorkMessage() {
-    ScaffoldMessenger.of(context).showReplacingSnackBar(
-      const SnackBar(content: Text('手动添加的作品没有 Bangumi ID，无法从 Anitabi 地图导入点位。')),
+    ScaffoldMessenger.of(context).showStatusSnack(
+      kind: AppStatusBannerKind.warning,
+      title: '手动添加的作品没有 Bangumi ID，无法从 Anitabi 地图导入点位。',
     );
   }
 
@@ -845,7 +848,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     if (points.isEmpty) {
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('框选范围内没有可添加点位')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '框选范围内没有可添加点位');
       return;
     }
 
@@ -896,8 +899,10 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     var shouldShowOrganizeGuide = false;
     try {
       final messenger = ScaffoldMessenger.of(context);
-      messenger.showReplacingSnackBar(
-        SnackBar(content: Text('正在导入 ${pilgrimagePoints.length} 个点位...')),
+      messenger.showStatusSnack(
+        kind: AppStatusBannerKind.running,
+        title: '正在导入 ${pilgrimagePoints.length} 个点位...',
+        icon: Icons.add_location_alt_outlined,
       );
       var importedPlan = pilgrimagePoints.length == 1
           ? await widget.repository.addPointToPlan(
@@ -984,13 +989,12 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                   const Duration(milliseconds: 450);
           if (shouldShowProgressSnackBar) {
             lastProgressSnackBarAt = now;
-            messenger.showReplacingSnackBar(
-              SnackBar(
-                duration: const Duration(milliseconds: 1200),
-                content: Text(
+            messenger.showStatusSnack(
+              kind: AppStatusBannerKind.running,
+              title:
                   '正在缓存缩略图 $processed/${pilgrimagePoints.length}，成功 $cached',
-                ),
-              ),
+              icon: Icons.photo_library_outlined,
+              duration: const Duration(milliseconds: 1200),
             );
           }
         },
@@ -1016,14 +1020,13 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
           _isBoxSelecting = false;
         }
       });
-      messenger.showReplacingSnackBar(
-        SnackBar(
-          content: Text(
-            cacheFailed == 0
-                ? successMessage
-                : '已导入 ${pilgrimagePoints.length} 个点位，缩略图缓存 $cached/${pilgrimagePoints.length}，其余稍后会自动补齐。',
-          ),
-        ),
+      messenger.showStatusSnack(
+        kind: cacheFailed == 0
+            ? AppStatusBannerKind.success
+            : AppStatusBannerKind.warning,
+        title: cacheFailed == 0
+            ? successMessage
+            : '已导入 ${pilgrimagePoints.length} 个点位，缩略图缓存 $cached/${pilgrimagePoints.length}，其余稍后会自动补齐。',
       );
       shouldShowOrganizeGuide = pilgrimagePoints.length > 1;
     } catch (error, stackTrace) {
@@ -1033,9 +1036,10 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
         return;
       }
 
-      ScaffoldMessenger.of(
-        context,
-      ).showReplacingSnackBar(SnackBar(content: Text(failureMessage)));
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.error,
+        title: failureMessage,
+      );
       return;
     } finally {
       if (mounted) {
@@ -1055,8 +1059,9 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       debugPrint('Failed to organize imported Anitabi points: $error');
       debugPrintStack(stackTrace: stackTrace);
       if (mounted) {
-        ScaffoldMessenger.of(context).showReplacingSnackBar(
-          const SnackBar(content: Text('点位已导入，但整理流程打开失败，可以稍后在计划中调整片区。')),
+        ScaffoldMessenger.of(context).showStatusSnack(
+          kind: AppStatusBannerKind.warning,
+          title: '点位已导入，但整理流程打开失败，可以稍后在计划中调整片区。',
         );
       }
     }
@@ -1153,14 +1158,15 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                     .map((group) => group.name)
                     .firstOrNull ??
                 '所选片区';
-      ScaffoldMessenger.of(context).showReplacingSnackBar(
-        SnackBar(content: Text('已将 ${pointIds.length} 个点位分配到「$groupName」')),
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.success,
+        title: '已将 ${pointIds.length} 个点位分配到「$groupName」',
       );
     } catch (_) {
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showReplacingSnackBar(const SnackBar(content: Text('点位分配失败，请稍后重试。')));
+        ).showStatusSnack(kind: AppStatusBannerKind.error, title: '点位分配失败，请稍后重试。');
       }
     }
   }
@@ -1207,7 +1213,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showReplacingSnackBar(const SnackBar(content: Text('片区创建失败，请稍后重试。')));
+        ).showStatusSnack(kind: AppStatusBannerKind.error, title: '片区创建失败，请稍后重试。');
       }
       return null;
     }
@@ -1890,7 +1896,7 @@ class _ImportOrganizeDialog extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              const Text(
+              Text(
                 '整理刚导入的点位',
                 style: TextStyle(
                   color: AppColors.textPrimary,
@@ -1906,7 +1912,7 @@ class _ImportOrganizeDialog extends StatelessWidget {
                   children: [
                     TextSpan(
                       text: '$importedCount 个点位',
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textPrimary,
                         fontWeight: FontWeight.w800,
                       ),
@@ -1914,7 +1920,7 @@ class _ImportOrganizeDialog extends StatelessWidget {
                     const TextSpan(text: '，并暂时放在未分组。可以直接分配到片区，或按最近关键点快速分配。'),
                   ],
                 ),
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 14,
                   height: 1.55,
@@ -2114,7 +2120,7 @@ class _ImportSummary extends StatelessWidget {
                       ? '正在加载 Anitabi 点位'
                       : importProgress?.label ??
                             '已导入 $importedCount / 当前显示 $totalCount${expected == null ? '' : ' / 共 $expected'}',
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 13,
                     fontWeight: FontWeight.w700,
@@ -2323,8 +2329,9 @@ class _AnitabiPointCard extends StatelessWidget {
         navigationApp,
       );
       if (!opened && context.mounted) {
-        ScaffoldMessenger.of(context).showReplacingSnackBar(
-          SnackBar(content: Text('无法打开${navigationApp.label}。')),
+        ScaffoldMessenger.of(context).showStatusSnack(
+          kind: AppStatusBannerKind.error,
+          title: '无法打开${navigationApp.label}。',
         );
       }
     }
@@ -2335,7 +2342,7 @@ class _AnitabiPointCard extends StatelessWidget {
         color: AppColors.surface,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8),
-          side: const BorderSide(color: AppColors.border),
+          side: BorderSide(color: AppColors.border),
         ),
         clipBehavior: Clip.antiAlias,
         child: Column(
@@ -2351,7 +2358,7 @@ class _AnitabiPointCard extends StatelessWidget {
                   onNext: onNextOverlapPoint!,
                 ),
               ),
-              const Divider(
+              Divider(
                 key: ValueKey('anitabi-import-overlap-point-divider'),
                 height: 1,
                 indent: 14,
@@ -2423,7 +2430,7 @@ class _AnitabiPointCard extends StatelessWidget {
                             onTap: openDetail,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: AppColors.textSecondary,
                               fontSize: 12,
                               letterSpacing: 0,
@@ -2436,7 +2443,7 @@ class _AnitabiPointCard extends StatelessWidget {
                             onTap: openDetail,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: AppColors.textSecondary,
                               fontSize: 12,
                               letterSpacing: 0,
@@ -2700,7 +2707,7 @@ class _AnitabiDetailInfoLine extends StatelessWidget {
           width: 38,
           child: Text(
             label,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 13,
               fontWeight: FontWeight.w700,
@@ -2713,7 +2720,7 @@ class _AnitabiDetailInfoLine extends StatelessWidget {
           child: CopyableText(
             text: value,
             copyLabel: label,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textPrimary,
               fontSize: 13,
               letterSpacing: 0,
@@ -2914,7 +2921,7 @@ class _ImportWorkGuideStep extends StatelessWidget {
                 children: [
                   Text(
                     title,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textPrimary,
                       fontSize: 16,
                       fontWeight: FontWeight.w800,
@@ -2924,7 +2931,7 @@ class _ImportWorkGuideStep extends StatelessWidget {
                   const SizedBox(height: 5),
                   Text(
                     body,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 13,
                       height: 1.35,
@@ -2946,7 +2953,7 @@ class _ManualWorkImportState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
+    return Center(
       child: Padding(
         padding: EdgeInsets.all(24),
         child: Text(
@@ -2977,7 +2984,7 @@ class _NoAnitabiPointsState extends StatelessWidget {
         child: Text(
           '「$workTitle」暂无可导入的 Anitabi 点位。',
           textAlign: TextAlign.center,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textSecondary,
             fontSize: 14,
             height: 1.45,
@@ -2994,7 +3001,7 @@ class _ImportLoadingState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
+    return Center(
       child: Padding(
         padding: EdgeInsets.all(24),
         child: Column(
@@ -3052,7 +3059,7 @@ class _ImportErrorState extends StatelessWidget {
             Text(
               detail,
               textAlign: TextAlign.center,
-              style: const TextStyle(
+              style: TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 13,
                 letterSpacing: 0,

--- a/lib/plan/clipboard_text_stub.dart
+++ b/lib/plan/clipboard_text_stub.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/services.dart';
+
+Future<String?> readClipboardText() async {
+  final data = await Clipboard.getData(Clipboard.kTextPlain);
+  return data?.text;
+}

--- a/lib/plan/clipboard_text_web.dart
+++ b/lib/plan/clipboard_text_web.dart
@@ -1,0 +1,14 @@
+import 'dart:js_interop';
+
+import 'package:flutter/services.dart';
+import 'package:web/web.dart' as web;
+
+Future<String?> readClipboardText() async {
+  try {
+    final text = await web.window.navigator.clipboard.readText().toDart;
+    return text.toDart;
+  } catch (_) {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    return data?.text;
+  }
+}

--- a/lib/plan/coordinate_input_dialog.dart
+++ b/lib/plan/coordinate_input_dialog.dart
@@ -54,7 +54,16 @@ class _CoordinateInputDialogState extends State<_CoordinateInputDialog> {
   }
 
   Future<void> _pasteFromClipboard() async {
-    final coordinate = await parseClipboardCoordinate();
+    LatLng? coordinate;
+    try {
+      coordinate = await parseClipboardCoordinate();
+    } on Object {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _errorText = '无法读取剪贴板。');
+      return;
+    }
     if (!mounted) {
       return;
     }
@@ -62,10 +71,11 @@ class _CoordinateInputDialogState extends State<_CoordinateInputDialog> {
       setState(() => _errorText = '剪贴板中没有可识别的坐标。');
       return;
     }
+    final parsed = coordinate;
     setState(() {
       _errorText = null;
-      _latitudeController.text = coordinate.latitude.toStringAsFixed(6);
-      _longitudeController.text = coordinate.longitude.toStringAsFixed(6);
+      _latitudeController.text = parsed.latitude.toStringAsFixed(6);
+      _longitudeController.text = parsed.longitude.toStringAsFixed(6);
     });
   }
 

--- a/lib/plan/coordinate_input_dialog.dart
+++ b/lib/plan/coordinate_input_dialog.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../app_theme.dart';
+import '../widgets/input_dialog.dart';
+import 'coordinate_parser.dart';
+
+Future<LatLng?> showCoordinateInputDialog({
+  required BuildContext context,
+  required LatLng current,
+}) {
+  return showDialog<LatLng>(
+    context: context,
+    builder: (_) => _CoordinateInputDialog(current: current),
+  );
+}
+
+class _CoordinateInputDialog extends StatefulWidget {
+  const _CoordinateInputDialog({required this.current});
+
+  final LatLng current;
+
+  @override
+  State<_CoordinateInputDialog> createState() => _CoordinateInputDialogState();
+}
+
+class _CoordinateInputDialogState extends State<_CoordinateInputDialog> {
+  late final TextEditingController _latitudeController;
+  late final TextEditingController _longitudeController;
+  String? _errorText;
+
+  @override
+  void initState() {
+    super.initState();
+    _latitudeController = TextEditingController(
+      text: widget.current.latitude.toStringAsFixed(6),
+    );
+    _longitudeController = TextEditingController(
+      text: widget.current.longitude.toStringAsFixed(6),
+    );
+  }
+
+  @override
+  void dispose() {
+    _latitudeController.dispose();
+    _longitudeController.dispose();
+    super.dispose();
+  }
+
+  void _clearError() {
+    if (_errorText != null) {
+      setState(() => _errorText = null);
+    }
+  }
+
+  Future<void> _pasteFromClipboard() async {
+    final coordinate = await parseClipboardCoordinate();
+    if (!mounted) {
+      return;
+    }
+    if (coordinate == null) {
+      setState(() => _errorText = '剪贴板中没有可识别的坐标。');
+      return;
+    }
+    setState(() {
+      _errorText = null;
+      _latitudeController.text = coordinate.latitude.toStringAsFixed(6);
+      _longitudeController.text = coordinate.longitude.toStringAsFixed(6);
+    });
+  }
+
+  void _submit() {
+    final latitude = double.tryParse(_latitudeController.text.trim());
+    final longitude = double.tryParse(_longitudeController.text.trim());
+    if (latitude == null ||
+        longitude == null ||
+        latitude < -90 ||
+        latitude > 90 ||
+        longitude < -180 ||
+        longitude > 180) {
+      setState(() => _errorText = '请输入有效经纬度');
+      return;
+    }
+    Navigator.of(context).pop(LatLng(latitude, longitude));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppInputDialog(
+      title: '输入经纬度',
+      errorText: _errorText,
+      titleTrailing: AppDialogPasteButton(onPressed: _pasteFromClipboard),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AppDialogField(
+            label: '纬度',
+            child: TextField(
+              onTapOutside: dismissKeyboardOnTapOutside,
+              controller: _latitudeController,
+              onChanged: (_) => _clearError(),
+              keyboardType: const TextInputType.numberWithOptions(
+                signed: true,
+                decimal: true,
+              ),
+              decoration: appDialogInputDecoration(),
+            ),
+          ),
+          const SizedBox(height: 14),
+          AppDialogField(
+            label: '经度',
+            child: TextField(
+              onTapOutside: dismissKeyboardOnTapOutside,
+              controller: _longitudeController,
+              onChanged: (_) => _clearError(),
+              keyboardType: const TextInputType.numberWithOptions(
+                signed: true,
+                decimal: true,
+              ),
+              decoration: appDialogInputDecoration(),
+            ),
+          ),
+        ],
+      ),
+      confirmLabel: '确定',
+      onConfirm: _submit,
+    );
+  }
+}

--- a/lib/plan/coordinate_parser.dart
+++ b/lib/plan/coordinate_parser.dart
@@ -1,5 +1,7 @@
-import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
+
+import 'clipboard_text_stub.dart'
+    if (dart.library.js_interop) 'clipboard_text_web.dart';
 
 LatLng? parseCoordinateText(String input) {
   final normalized = _normalizeCoordinateText(input);
@@ -16,12 +18,8 @@ LatLng? parseCoordinateText(String input) {
 }
 
 Future<LatLng?> parseClipboardCoordinate() async {
-  try {
-    final data = await Clipboard.getData(Clipboard.kTextPlain);
-    return parseCoordinateText(data?.text ?? '');
-  } on Object {
-    return null;
-  }
+  final text = await readClipboardText();
+  return parseCoordinateText(text ?? '');
 }
 
 String _normalizeCoordinateText(String input) {

--- a/lib/plan/coordinate_parser.dart
+++ b/lib/plan/coordinate_parser.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:latlong2/latlong.dart';
 
 LatLng? parseCoordinateText(String input) {
@@ -12,6 +13,15 @@ LatLng? parseCoordinateText(String input) {
   }
 
   return _parseDmsCoordinate(normalized);
+}
+
+Future<LatLng?> parseClipboardCoordinate() async {
+  try {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    return parseCoordinateText(data?.text ?? '');
+  } on Object {
+    return null;
+  }
 }
 
 String _normalizeCoordinateText(String input) {

--- a/lib/plan/group_anchor_picker_screen.dart
+++ b/lib/plan/group_anchor_picker_screen.dart
@@ -4,6 +4,7 @@ import 'package:latlong2/latlong.dart';
 
 import '../app_theme.dart';
 import '../widgets/input_dialog.dart';
+import '../widgets/app_back_button.dart';
 import '../map/map_tile_config.dart';
 import '../map/map_marker_scale.dart';
 import '../utils/selected_item_order.dart';
@@ -80,6 +81,7 @@ class _GroupAnchorPickerScreenState extends State<GroupAnchorPickerScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: const Text('选择关键点'),
         actions: [
           TextButton(

--- a/lib/plan/group_anchor_picker_screen.dart
+++ b/lib/plan/group_anchor_picker_screen.dart
@@ -3,11 +3,13 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../app_theme.dart';
-import '../widgets/input_dialog.dart';
 import '../widgets/app_back_button.dart';
+import '../widgets/clear_anchor_selection_button.dart';
+import '../widgets/confirm_action_dialog.dart';
 import '../map/map_tile_config.dart';
 import '../map/map_marker_scale.dart';
 import '../utils/selected_item_order.dart';
+import 'coordinate_input_dialog.dart';
 import 'pilgrimage_models.dart';
 
 class GroupAnchorSelection {
@@ -84,10 +86,10 @@ class _GroupAnchorPickerScreenState extends State<GroupAnchorPickerScreen> {
         leading: appBackButtonIfCanPop(context),
         title: const Text('选择关键点'),
         actions: [
-          TextButton(
-            onPressed: () =>
-                Navigator.of(context).pop(const GroupAnchorSelection.clear()),
-            child: const Text('清除'),
+          ClearAnchorSelectionButton(
+            onPressed: _selectedPoint == null && _manualPosition == null
+                ? null
+                : _confirmClearSelection,
           ),
         ],
       ),
@@ -224,6 +226,23 @@ class _GroupAnchorPickerScreenState extends State<GroupAnchorPickerScreen> {
     return LatLng(latitude, longitude);
   }
 
+  Future<void> _confirmClearSelection() async {
+    final confirmed = await showConfirmActionDialog(
+      context,
+      title: '清除选点',
+      message: '将清除当前选择的关键点，可继续在本页重新选择。',
+      confirmLabel: '清除选点',
+    );
+    if (!confirmed || !mounted) {
+      return;
+    }
+    setState(() {
+      _selectedPoint = null;
+      _manualPosition = null;
+      _manualPickMode = false;
+    });
+  }
+
   void _selectPoint(PilgrimagePoint point) {
     setState(() {
       _selectedPoint = point;
@@ -236,66 +255,10 @@ class _GroupAnchorPickerScreenState extends State<GroupAnchorPickerScreen> {
   Future<void> _showCoordinateInput() async {
     final current =
         _manualPosition ?? _selectedPoint?.position ?? _pointsCenter;
-    final latitudeController = TextEditingController(
-      text: current.latitude.toStringAsFixed(6),
-    );
-    final longitudeController = TextEditingController(
-      text: current.longitude.toStringAsFixed(6),
-    );
-    final result = await showDialog<LatLng>(
+    final result = await showCoordinateInputDialog(
       context: context,
-      builder: (context) {
-        return AppInputDialog(
-          title: '输入经纬度',
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppDialogField(
-                label: '纬度',
-                child: TextField(
-                  onTapOutside: dismissKeyboardOnTapOutside,
-                  controller: latitudeController,
-                  keyboardType: const TextInputType.numberWithOptions(
-                    signed: true,
-                    decimal: true,
-                  ),
-                  decoration: appDialogInputDecoration(),
-                ),
-              ),
-              const SizedBox(height: 14),
-              AppDialogField(
-                label: '经度',
-                child: TextField(
-                  onTapOutside: dismissKeyboardOnTapOutside,
-                  controller: longitudeController,
-                  keyboardType: const TextInputType.numberWithOptions(
-                    signed: true,
-                    decimal: true,
-                  ),
-                  decoration: appDialogInputDecoration(),
-                ),
-              ),
-            ],
-          ),
-          confirmLabel: '确定',
-          onConfirm: () {
-            final latitude = double.tryParse(latitudeController.text.trim());
-            final longitude = double.tryParse(longitudeController.text.trim());
-            if (latitude == null ||
-                longitude == null ||
-                latitude < -90 ||
-                latitude > 90 ||
-                longitude < -180 ||
-                longitude > 180) {
-              return;
-            }
-            Navigator.of(context).pop(LatLng(latitude, longitude));
-          },
-        );
-      },
+      current: current,
     );
-    latitudeController.dispose();
-    longitudeController.dispose();
     if (result == null || !mounted) {
       return;
     }
@@ -460,7 +423,7 @@ class _AnchorSelectionCard extends StatelessWidget {
                       : '$subtitle\n${position.latitude.toStringAsFixed(5)}, ${position.longitude.toStringAsFixed(5)}',
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 12,
                     letterSpacing: 0,

--- a/lib/plan/nearest_group_assign_screen.dart
+++ b/lib/plan/nearest_group_assign_screen.dart
@@ -15,6 +15,7 @@ import '../utils/selected_item_order.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'pilgrimage_models.dart';
 import 'plan_group_utils.dart';
 
@@ -93,10 +94,8 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: const Text('最近分配'),
         ),
@@ -506,10 +505,8 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: const Text('框选分配'),
         ),

--- a/lib/plan/nearest_group_assign_screen.dart
+++ b/lib/plan/nearest_group_assign_screen.dart
@@ -292,7 +292,7 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
     if (count == 0) {
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('当前距离内没有可分配点位')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '当前距离内没有可分配点位');
       return;
     }
     final confirmed = await showConfirmActionDialog(
@@ -333,7 +333,7 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(SnackBar(content: Text('已分配 $count 个点位')));
+      ).showStatusSnack(kind: AppStatusBannerKind.success, title: '已分配 $count 个点位');
     } catch (_) {
       if (!mounted) {
         return;
@@ -343,7 +343,7 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('最近分配失败')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '最近分配失败');
     }
   }
 
@@ -356,7 +356,7 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
       onOpenCamera: () {
         ScaffoldMessenger.of(
           context,
-        ).showReplacingSnackBar(const SnackBar(content: Text('请先完成片区分配')));
+        ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '请先完成片区分配');
       },
       onComplete: () {},
       onReplaceReference: _replaceReferenceImage,
@@ -365,6 +365,7 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
       groupBuckets: planGroupBuckets(_plan, _plan.completedPointIds),
       onMoveToGroup: _movePointToGroup,
       navigationApp: widget.settings.navigationApp,
+      settings: widget.settings,
     );
   }
 
@@ -729,7 +730,7 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('片区创建失败')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '片区创建失败');
     }
   }
 
@@ -742,13 +743,13 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
     if (targetGroup == null) {
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('请先创建片区')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '请先创建片区');
       return;
     }
     if (points.isEmpty) {
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('框选范围内没有未分组点位')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '框选范围内没有未分组点位');
       return;
     }
     final confirmed = await showConfirmActionDialog(
@@ -782,8 +783,9 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
         _didUpdate = true;
         _isSaving = false;
       });
-      ScaffoldMessenger.of(context).showReplacingSnackBar(
-        SnackBar(content: Text('已分配 ${points.length} 个点位')),
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.success,
+        title: '已分配 ${points.length} 个点位',
       );
     } catch (_) {
       if (!mounted) {
@@ -794,7 +796,7 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('框选分配失败')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '框选分配失败');
     }
   }
 
@@ -807,7 +809,7 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
       onOpenCamera: () {
         ScaffoldMessenger.of(
           context,
-        ).showReplacingSnackBar(const SnackBar(content: Text('请先完成片区分配')));
+        ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '请先完成片区分配');
       },
       onComplete: () {},
       onReplaceReference: _replaceReferenceImage,
@@ -816,6 +818,7 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
       groupBuckets: planGroupBuckets(_plan, _plan.completedPointIds),
       onMoveToGroup: _movePointToGroup,
       navigationApp: widget.settings.navigationApp,
+      settings: widget.settings,
     );
   }
 
@@ -896,14 +899,12 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
           alignmentOffset: const Offset(0, 2),
           style: MenuStyle(
             padding: const WidgetStatePropertyAll(EdgeInsets.zero),
-            backgroundColor: const WidgetStatePropertyAll(AppColors.surface),
+            backgroundColor: WidgetStatePropertyAll(AppColors.surface),
             elevation: const WidgetStatePropertyAll(8),
             shadowColor: WidgetStatePropertyAll(
               AppColors.textPrimary.withValues(alpha: 0.16),
             ),
-            side: const WidgetStatePropertyAll(
-              BorderSide(color: AppColors.border),
-            ),
+            side: WidgetStatePropertyAll(BorderSide(color: AppColors.border)),
             shape: const WidgetStatePropertyAll(
               RoundedRectangleBorder(
                 borderRadius: BorderRadius.vertical(
@@ -917,7 +918,7 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
             return Material(
               color: AppColors.surface,
               shape: RoundedRectangleBorder(
-                side: const BorderSide(color: AppColors.border),
+                side: BorderSide(color: AppColors.border),
                 borderRadius: BorderRadius.vertical(
                   top: const Radius.circular(8),
                   bottom: Radius.circular(_isOpen ? 4 : 8),
@@ -995,7 +996,7 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
                           ),
                           Text(
                             '共 ${widget.groups.length} 个片区',
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: AppColors.textSecondary,
                               fontSize: 12,
                               letterSpacing: 0,
@@ -1081,7 +1082,7 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
                         ),
                       ),
                     ),
-                    const Divider(
+                    Divider(
                       height: 1,
                       indent: 16,
                       endIndent: 16,
@@ -1271,7 +1272,7 @@ class _BoxAssignPanel extends StatelessWidget {
                     '已框选 $selectedCount / 待分配 $ungroupedCount',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 13,
                       fontWeight: FontWeight.w700,
@@ -1394,7 +1395,7 @@ class _NearestAssignPanel extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 4),
-            const Text(
+            Text(
               '未分组点位会分配到距离最近、且在最大距离范围内的片区关键点。',
               style: TextStyle(
                 color: AppColors.textSecondary,
@@ -1475,7 +1476,7 @@ class _NearestAssignPointCard extends StatelessWidget {
                           : '${nearestGroup!.name} · ${_formatDistance(distanceMeters ?? 0)}',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textSecondary,
                         fontSize: 13,
                         letterSpacing: 0,
@@ -1521,7 +1522,7 @@ class _NearestAssignHintCard extends StatelessWidget {
                 ? '请先在片区管理中设置关键点'
                 : '未分组 $ungroupedCount 个 · 点击地图点位查看详情',
             textAlign: TextAlign.center,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontWeight: FontWeight.w700,
               letterSpacing: 0,

--- a/lib/plan/pilgrimage_models.dart
+++ b/lib/plan/pilgrimage_models.dart
@@ -196,6 +196,7 @@ class AppSettings {
     this.mapThumbnailVisibleThreshold = 40,
     this.mapThumbnailConcurrentLoads = 10,
     this.showPlanGroupProgress = true,
+    this.dismissPlanActionsOnOutsideTap = true,
     this.mapMarkerClusteringEnabled = true,
     this.mapMarkerClusterRadius = 40,
     this.mapMarkerClusterMaxZoom = 21,
@@ -240,6 +241,7 @@ class AppSettings {
   final int mapThumbnailVisibleThreshold;
   final int mapThumbnailConcurrentLoads;
   final bool showPlanGroupProgress;
+  final bool dismissPlanActionsOnOutsideTap;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -284,6 +286,7 @@ class AppSettings {
     int? mapThumbnailVisibleThreshold,
     int? mapThumbnailConcurrentLoads,
     bool? showPlanGroupProgress,
+    bool? dismissPlanActionsOnOutsideTap,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -348,6 +351,8 @@ class AppSettings {
           mapThumbnailConcurrentLoads ?? this.mapThumbnailConcurrentLoads,
       showPlanGroupProgress:
           showPlanGroupProgress ?? this.showPlanGroupProgress,
+      dismissPlanActionsOnOutsideTap:
+          dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:

--- a/lib/plan/pilgrimage_models.dart
+++ b/lib/plan/pilgrimage_models.dart
@@ -197,6 +197,7 @@ class AppSettings {
     this.mapThumbnailConcurrentLoads = 10,
     this.showPlanGroupProgress = true,
     this.dismissPlanActionsOnOutsideTap = true,
+    this.hideCompletedPointsOnMap = true,
     this.mapMarkerClusteringEnabled = true,
     this.mapMarkerClusterRadius = 40,
     this.mapMarkerClusterMaxZoom = 21,
@@ -242,6 +243,7 @@ class AppSettings {
   final int mapThumbnailConcurrentLoads;
   final bool showPlanGroupProgress;
   final bool dismissPlanActionsOnOutsideTap;
+  final bool hideCompletedPointsOnMap;
   final bool mapMarkerClusteringEnabled;
   final int mapMarkerClusterRadius;
   final int mapMarkerClusterMaxZoom;
@@ -287,6 +289,7 @@ class AppSettings {
     int? mapThumbnailConcurrentLoads,
     bool? showPlanGroupProgress,
     bool? dismissPlanActionsOnOutsideTap,
+    bool? hideCompletedPointsOnMap,
     bool? mapMarkerClusteringEnabled,
     int? mapMarkerClusterRadius,
     int? mapMarkerClusterMaxZoom,
@@ -353,6 +356,8 @@ class AppSettings {
           showPlanGroupProgress ?? this.showPlanGroupProgress,
       dismissPlanActionsOnOutsideTap:
           dismissPlanActionsOnOutsideTap ?? this.dismissPlanActionsOnOutsideTap,
+      hideCompletedPointsOnMap:
+          hideCompletedPointsOnMap ?? this.hideCompletedPointsOnMap,
       mapMarkerClusteringEnabled:
           mapMarkerClusteringEnabled ?? this.mapMarkerClusteringEnabled,
       mapMarkerClusterRadius:

--- a/lib/plan/pilgrimage_models.dart
+++ b/lib/plan/pilgrimage_models.dart
@@ -96,7 +96,19 @@ enum AppThemePalette {
   }
 }
 
-enum AppThemeMode { light, dark, system }
+enum AppThemeMode {
+  light,
+  dark,
+  system;
+
+  String get label {
+    return switch (this) {
+      AppThemeMode.light => '浅色',
+      AppThemeMode.dark => '深色',
+      AppThemeMode.system => '跟随系统',
+    };
+  }
+}
 
 extension CameraPhotoAspectRatioLabel on CameraPhotoAspectRatio {
   String get label {

--- a/lib/plan/pilgrimage_work_cover.dart
+++ b/lib/plan/pilgrimage_work_cover.dart
@@ -42,7 +42,7 @@ class PilgrimageWorkCover extends StatelessWidget {
                 loadingBuilder: (context, child, progress) {
                   return progress == null
                       ? child
-                      : const ColoredBox(color: AppColors.surfaceMuted);
+                      : ColoredBox(color: AppColors.surfaceMuted);
                 },
                 errorBuilder: (context, error, stackTrace) {
                   return const _WorkCoverFallback();
@@ -58,7 +58,7 @@ class _WorkCoverFallback extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
+    return Center(
       child: Icon(
         Icons.movie_filter_outlined,
         size: 22,

--- a/lib/plan/pilgrimage_work_dropdown.dart
+++ b/lib/plan/pilgrimage_work_dropdown.dart
@@ -87,7 +87,7 @@ class PilgrimageWorkDropdown extends StatelessWidget {
       contentPadding: const EdgeInsets.fromLTRB(14, 10, 4, 10),
       enabledBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(8),
-        borderSide: const BorderSide(color: AppColors.border, width: 1.4),
+        borderSide: BorderSide(color: AppColors.border, width: 1.4),
       ),
       focusedBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(8),
@@ -190,7 +190,7 @@ class _WorkDropdownItemState extends State<_WorkDropdownItem> {
                   ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textPrimary,
                     fontSize: 14,
                     letterSpacing: 0,

--- a/lib/plan/plan_group_manager_screen.dart
+++ b/lib/plan/plan_group_manager_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/app_scaled_route.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
@@ -74,10 +75,8 @@ class _PlanGroupManagerScreenState extends State<PlanGroupManagerScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: const Text('片区管理'),
           actions: [

--- a/lib/plan/plan_group_manager_screen.dart
+++ b/lib/plan/plan_group_manager_screen.dart
@@ -71,12 +71,12 @@ class _PlanGroupManagerScreenState extends State<PlanGroupManagerScreen> {
         if (didPop) {
           return;
         }
-        Navigator.of(context).pop(_didUpdate);
+        Navigator.of(context).pop<String?>(null);
       },
       child: Scaffold(
         appBar: AppBar(
           leading: AppBackButton(
-            onPressed: () => Navigator.of(context).pop(_didUpdate),
+            onPressed: () => Navigator.of(context).pop<String?>(null),
           ),
           title: const Text('片区管理'),
           actions: [
@@ -91,49 +91,63 @@ class _PlanGroupManagerScreenState extends State<PlanGroupManagerScreen> {
               ),
           ],
         ),
-        floatingActionButton: FloatingActionButton.extended(
+        floatingActionButton: _CreateGroupFab(
           onPressed: _isSaving ? null : _createGroup,
-          icon: const Icon(Icons.add),
-          label: const Text('新建片区'),
         ),
-        body: ReorderableListView.builder(
-          padding: const EdgeInsets.fromLTRB(16, 8, 16, 96),
-          header: _PlanGroupManagerHeader(
-            plan: _plan,
-            groupCount: groups.length,
-          ),
-          itemCount: groups.length + 1,
-          buildDefaultDragHandles: false,
-          proxyDecorator: _cleanReorderProxy,
-          onReorderItem: _reorderGroups,
-          itemBuilder: (context, index) {
-            if (index == groups.length) {
-              return Padding(
-                key: const ValueKey('ungrouped'),
-                padding: const EdgeInsets.only(bottom: 8),
-                child: _UngroupedGroupCard(pointCount: _ungroupedCount),
-              );
-            }
-
-            final group = groups[index];
-            final pointCount = _plan.points
-                .where((point) => point.groupId == group.id)
-                .length;
-            return Padding(
-              key: ValueKey(group.id),
-              padding: const EdgeInsets.only(bottom: 8),
-              child: _PlanGroupCard(
-                index: index,
-                group: group,
-                pointCount: pointCount,
-                isBusy: _isSaving,
-                onRename: () => _renameGroup(group),
-                onSetAnchor: () => _setGroupAnchor(group),
-                onToggleOrderMode: () => _toggleOrderMode(group),
-                onDelete: () => _confirmDeleteGroup(group, pointCount),
+        body: CustomScrollView(
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+              sliver: SliverToBoxAdapter(
+                child: _PlanGroupManagerHeader(
+                  plan: _plan,
+                  groupCount: groups.length,
+                ),
               ),
-            );
-          },
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverReorderableList(
+                itemCount: groups.length,
+                onReorder: _reorderGroups,
+                proxyDecorator: _cleanReorderProxy,
+                itemBuilder: (context, index) {
+                  final group = groups[index];
+                  final pointCount = _plan.points
+                      .where((point) => point.groupId == group.id)
+                      .length;
+                  return Padding(
+                    key: ValueKey(group.id),
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: _PlanGroupCard(
+                      index: index,
+                      group: group,
+                      pointCount: pointCount,
+                      isBusy: _isSaving,
+                      onOpen: _isSaving
+                          ? null
+                          : () => Navigator.of(context).pop(group.id),
+                      onRename: () => _renameGroup(group),
+                      onSetAnchor: () => _setGroupAnchor(group),
+                      onToggleOrderMode: () => _toggleOrderMode(group),
+                      onDelete: () => _confirmDeleteGroup(group, pointCount),
+                    ),
+                  );
+                },
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+              sliver: SliverToBoxAdapter(
+                child: _UngroupedGroupCard(
+                  pointCount: _ungroupedCount,
+                  onOpen: _isSaving
+                      ? null
+                      : () => Navigator.of(context).pop('ungrouped'),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -284,11 +298,18 @@ class _PlanGroupManagerScreenState extends State<PlanGroupManagerScreen> {
 
   Future<void> _reorderGroups(int oldIndex, int newIndex) async {
     final groups = _groups;
-    if (_isSaving || oldIndex >= groups.length || newIndex > groups.length) {
+    if (_isSaving || oldIndex >= groups.length) {
+      return;
+    }
+    var targetIndex = newIndex;
+    if (targetIndex > oldIndex) {
+      targetIndex -= 1;
+    }
+    if (targetIndex < 0 || targetIndex > groups.length) {
       return;
     }
     final group = groups.removeAt(oldIndex);
-    groups.insert(newIndex, group);
+    groups.insert(targetIndex.clamp(0, groups.length), group);
 
     await _savePlanChange(
       action: () async {
@@ -335,7 +356,7 @@ class _PlanGroupManagerScreenState extends State<PlanGroupManagerScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(SnackBar(content: Text(failureMessage)));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: failureMessage);
     }
   }
 
@@ -448,6 +469,45 @@ class _CreatePlanGroupDialogState extends State<_CreatePlanGroupDialog> {
   }
 }
 
+class _CreateGroupFab extends StatelessWidget {
+  const _CreateGroupFab({required this.onPressed});
+
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Theme(
+      data: Theme.of(context).copyWith(
+        floatingActionButtonTheme: const FloatingActionButtonThemeData(
+          sizeConstraints: BoxConstraints.tightFor(width: 64, height: 64),
+          shape: CircleBorder(),
+        ),
+      ),
+      child: FloatingActionButton(
+        key: const ValueKey('plan-group-create-fab'),
+        onPressed: onPressed,
+        tooltip: '新建片区',
+        child: const Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.add, size: 24),
+            SizedBox(height: 2),
+            Text(
+              '新建',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+                height: 1,
+                letterSpacing: 0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _PlanGroupManagerHeader extends StatelessWidget {
   const _PlanGroupManagerHeader({required this.plan, required this.groupCount});
 
@@ -457,46 +517,32 @@ class _PlanGroupManagerHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
-      child: Container(
-        padding: const EdgeInsets.all(14),
-        decoration: BoxDecoration(
-          color: AppColors.surface,
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: AppColors.border),
-        ),
-        child: Row(
-          children: [
-            Icon(Icons.account_tree_outlined, color: AppColors.accent),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    plan.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w800,
-                      letterSpacing: 0,
-                    ),
-                  ),
-                  const SizedBox(height: 3),
-                  Text(
-                    '$groupCount 个片区 · ${plan.points.length} 个点位',
-                    style: const TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 13,
-                      letterSpacing: 0,
-                    ),
-                  ),
-                ],
-              ),
+      key: const ValueKey('plan-group-summary'),
+      padding: const EdgeInsets.fromLTRB(4, 4, 4, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            plan.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: AppColors.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
             ),
-          ],
-        ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '$groupCount 个片区 · ${plan.points.length} 个点位',
+            style: TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 13,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -508,6 +554,7 @@ class _PlanGroupCard extends StatelessWidget {
     required this.group,
     required this.pointCount,
     required this.isBusy,
+    required this.onOpen,
     required this.onRename,
     required this.onSetAnchor,
     required this.onToggleOrderMode,
@@ -518,6 +565,7 @@ class _PlanGroupCard extends StatelessWidget {
   final PilgrimagePlanGroup group;
   final int pointCount;
   final bool isBusy;
+  final VoidCallback? onOpen;
   final VoidCallback onRename;
   final VoidCallback onSetAnchor;
   final VoidCallback onToggleOrderMode;
@@ -525,140 +573,308 @@ class _PlanGroupCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isEmpty = pointCount == 0;
     final orderLabel = group.orderMode == PlanGroupOrderMode.manual
         ? '手动排序'
         : '无序';
-    final anchorLabel = group.anchorName ?? '未设置关键点';
+    final hasAnchor =
+        group.anchorName != null && group.anchorName!.trim().isNotEmpty;
+    final surface = isEmpty ? AppColors.surfaceMuted : AppColors.surface;
 
     return Material(
-      color: AppColors.surface,
+      color: surface,
       borderRadius: BorderRadius.circular(8),
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(8, 12, 6, 12),
-        decoration: BoxDecoration(
-          border: Border.all(color: AppColors.border),
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Row(
-          children: [
-            ReorderableDragStartListener(
-              index: index,
-              enabled: !isBusy,
-              child: const SizedBox(
-                width: 42,
-                child: Icon(
-                  Icons.drag_indicator,
-                  color: AppColors.textSecondary,
+      child: InkWell(
+        onTap: onOpen,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(8, 12, 6, 12),
+          decoration: BoxDecoration(
+            border: Border.all(color: AppColors.border),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            children: [
+              ReorderableDragStartListener(
+                index: index,
+                enabled: !isBusy,
+                child: SizedBox(
+                  width: 42,
+                  child: Icon(
+                    Icons.drag_indicator,
+                    color: AppColors.textSecondary,
+                  ),
                 ),
               ),
-            ),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    group.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w800,
-                      letterSpacing: 0,
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            group.name,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: 0,
+                              color: isEmpty
+                                  ? AppColors.textSecondary
+                                  : AppColors.textPrimary,
+                            ),
+                          ),
+                        ),
+                        if (isEmpty) ...[
+                          const SizedBox(width: 6),
+                          const _GroupMetaChip(label: '空', muted: true),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            hasAnchor
+                                ? '关键点 · ${group.anchorName}'
+                                : '未设置关键点',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: AppColors.textSecondary,
+                              fontSize: 12,
+                              letterSpacing: 0,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        _GroupMetaChip(
+                          label: orderLabel,
+                          accent:
+                              group.orderMode == PlanGroupOrderMode.manual,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              PopupMenuButton<String>(
+                key: ValueKey('plan-group-actions-${group.id}'),
+                tooltip: '片区操作',
+                enabled: !isBusy,
+                icon: const Icon(Icons.more_vert),
+                position: PopupMenuPosition.under,
+                offset: const Offset(0, 6),
+                elevation: 8,
+                shadowColor: Colors.black.withValues(alpha: 0.16),
+                color: AppColors.surface,
+                surfaceTintColor: Colors.transparent,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                  side: BorderSide(color: AppColors.border),
+                ),
+                constraints: const BoxConstraints(minWidth: 0, maxWidth: 148),
+                onSelected: (value) {
+                  switch (value) {
+                    case 'rename':
+                      onRename();
+                    case 'anchor':
+                      onSetAnchor();
+                    case 'order':
+                      onToggleOrderMode();
+                    case 'delete':
+                      onDelete();
+                  }
+                },
+                itemBuilder: (context) => [
+                  const PopupMenuItem(
+                    value: 'rename',
+                    height: 42,
+                    padding: EdgeInsets.symmetric(horizontal: 8),
+                    child: _GroupActionRow(
+                      icon: Icons.edit_outlined,
+                      label: '重命名',
                     ),
                   ),
-                  const SizedBox(height: 5),
-                  Text(
-                    '$pointCount 点位 · $anchorLabel · $orderLabel',
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 12,
-                      letterSpacing: 0,
+                  const PopupMenuItem(
+                    value: 'anchor',
+                    height: 42,
+                    padding: EdgeInsets.symmetric(horizontal: 8),
+                    child: _GroupActionRow(
+                      icon: Icons.flag_outlined,
+                      label: '设置关键点',
+                    ),
+                  ),
+                  PopupMenuItem(
+                    value: 'order',
+                    height: 42,
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    child: _GroupActionRow(
+                      icon: Icons.sort_outlined,
+                      label: group.orderMode == PlanGroupOrderMode.manual
+                          ? '切换为无序'
+                          : '切换为手动排序',
+                    ),
+                  ),
+                  const PopupMenuDivider(),
+                  const PopupMenuItem(
+                    value: 'delete',
+                    height: 42,
+                    padding: EdgeInsets.symmetric(horizontal: 8),
+                    child: _GroupActionRow(
+                      icon: Icons.delete_outline,
+                      label: '删除片区',
+                      destructive: true,
                     ),
                   ),
                 ],
               ),
-            ),
-            PopupMenuButton<String>(
-              tooltip: '片区操作',
-              enabled: !isBusy,
-              onSelected: (value) {
-                switch (value) {
-                  case 'rename':
-                    onRename();
-                  case 'anchor':
-                    onSetAnchor();
-                  case 'order':
-                    onToggleOrderMode();
-                  case 'delete':
-                    onDelete();
-                }
-              },
-              itemBuilder: (context) => [
-                const PopupMenuItem(value: 'rename', child: Text('重命名')),
-                const PopupMenuItem(value: 'anchor', child: Text('设置关键点')),
-                PopupMenuItem(
-                  value: 'order',
-                  child: Text(
-                    group.orderMode == PlanGroupOrderMode.manual
-                        ? '切换为无序'
-                        : '切换为手动排序',
-                  ),
-                ),
-                const PopupMenuItem(value: 'delete', child: Text('删除片区')),
-              ],
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class _UngroupedGroupCard extends StatelessWidget {
-  const _UngroupedGroupCard({required this.pointCount});
+class _GroupMetaChip extends StatelessWidget {
+  const _GroupMetaChip({
+    required this.label,
+    this.muted = false,
+    this.accent = false,
+  });
 
-  final int pointCount;
+  final String label;
+  final bool muted;
+  final bool accent;
 
   @override
   Widget build(BuildContext context) {
+    final color = accent
+        ? AppColors.accent
+        : muted
+        ? AppColors.textSecondary
+        : AppColors.textSecondary;
     return Container(
-      padding: const EdgeInsets.all(14),
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 2),
       decoration: BoxDecoration(
-        color: AppColors.surfaceMuted,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(6),
       ),
-      child: Row(
-        children: [
-          const Icon(Icons.inbox_outlined, color: AppColors.textSecondary),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  '未分配点位',
-                  style: TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: 0,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  '$pointCount 个点位等待整理',
-                  style: const TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 12,
-                    letterSpacing: 0,
-                  ),
-                ),
-              ],
-            ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w800,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+class _GroupActionRow extends StatelessWidget {
+  const _GroupActionRow({
+    required this.icon,
+    required this.label,
+    this.destructive = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = destructive ? AppColors.error : AppColors.textPrimary;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 6),
+        Text(
+          label,
+          style: TextStyle(
+            color: color,
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0,
           ),
-        ],
+        ),
+      ],
+    );
+  }
+}
+
+class _UngroupedGroupCard extends StatelessWidget {
+  const _UngroupedGroupCard({required this.pointCount, required this.onOpen});
+
+  final int pointCount;
+  final VoidCallback? onOpen;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasPoints = pointCount > 0;
+    return Material(
+      key: const ValueKey('ungrouped'),
+      color: AppColors.surfaceMuted,
+      borderRadius: BorderRadius.circular(8),
+      child: InkWell(
+        onTap: onOpen,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: AppColors.border),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.inbox_outlined, color: AppColors.textSecondary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '未分配点位',
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '$pointCount 个点位等待整理',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: hasPoints
+                            ? AppColors.accent
+                            : AppColors.textSecondary,
+                        fontSize: 12,
+                        fontWeight: hasPoints
+                            ? FontWeight.w800
+                            : FontWeight.w500,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 4),
+              Icon(
+                Icons.chevron_right,
+                color: AppColors.textSecondary,
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/plan/plan_group_picker_sheet.dart
+++ b/lib/plan/plan_group_picker_sheet.dart
@@ -51,7 +51,7 @@ Future<void> showPlanGroupPickerSheet({
                             const SizedBox(height: 3),
                             Text(
                               '共 ${pickerGroups.length} 个区域',
-                              style: const TextStyle(
+                              style: TextStyle(
                                 color: AppColors.textSecondary,
                                 fontSize: 12,
                                 fontWeight: FontWeight.w500,
@@ -253,7 +253,7 @@ class _PlanGroupPickerTile extends StatelessWidget {
                               group.name,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(
+                              style: TextStyle(
                                 color: AppColors.textPrimary,
                                 fontSize: 15,
                                 fontWeight: FontWeight.w700,
@@ -265,7 +265,7 @@ class _PlanGroupPickerTile extends StatelessWidget {
                               group.anchorLabel,
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
-                              style: const TextStyle(
+                              style: TextStyle(
                                 color: AppColors.textSecondary,
                                 fontSize: 12,
                                 letterSpacing: 0,
@@ -388,7 +388,7 @@ Future<String?> showPlanGroupSelectionSheet({
                         const SizedBox(height: 3),
                         Text(
                           subtitle,
-                          style: const TextStyle(
+                          style: TextStyle(
                             color: AppColors.textSecondary,
                             fontSize: 12,
                             fontWeight: FontWeight.w500,
@@ -414,7 +414,7 @@ Future<String?> showPlanGroupSelectionSheet({
                     ),
                   ),
                   if (onCreateOption != null) ...[
-                    const Divider(height: 1, color: AppColors.border),
+                    Divider(height: 1, color: AppColors.border),
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
                       child: Material(

--- a/lib/plan/plan_group_utils.dart
+++ b/lib/plan/plan_group_utils.dart
@@ -373,3 +373,82 @@ LatLng _worldPixelToLatLng(math.Point<double> point, double zoom) {
 double _sinh(double value) {
   return (math.exp(value) - math.exp(-value)) / 2;
 }
+
+class InAppNavigationTour {
+  const InAppNavigationTour({
+    required this.stops,
+    this.groupName,
+    this.startIndex = 0,
+  });
+
+  final List<PilgrimagePoint> stops;
+  final String? groupName;
+  final int startIndex;
+
+  List<PilgrimagePoint> get remainingStops {
+    if (stops.isEmpty) {
+      return const [];
+    }
+    final index = startIndex.clamp(0, stops.length - 1);
+    return stops.sublist(index);
+  }
+}
+
+int navigationStartIndex({
+  required PilgrimagePoint point,
+  required List<PilgrimagePoint> stops,
+}) {
+  final index = stops.indexWhere((stop) => stop.id == point.id);
+  return index < 0 ? 0 : index;
+}
+
+List<PilgrimagePoint> remainingNavigationStops({
+  required PilgrimagePoint point,
+  required List<PilgrimagePoint> stops,
+}) {
+  if (stops.isEmpty) {
+    return const [];
+  }
+  return stops.sublist(navigationStartIndex(point: point, stops: stops));
+}
+
+InAppNavigationTour inAppNavigationTourFor({
+  required PilgrimagePoint point,
+  List<PlanGroupBucket> buckets = const [],
+}) {
+  PlanGroupBucket? bucket;
+  for (final candidate in buckets) {
+    if (point.groupId == null) {
+      if (candidate.isUngrouped) {
+        bucket = candidate;
+        break;
+      }
+      continue;
+    }
+    if (!candidate.isUngrouped && candidate.id == point.groupId) {
+      bucket = candidate;
+      break;
+    }
+  }
+
+  if (bucket == null || bucket.isUngrouped) {
+    final stops = [if (point.hasCoordinate) point];
+    return InAppNavigationTour(stops: stops);
+  }
+
+  final stops = [
+    for (final stop in bucket.points)
+      if (stop.hasCoordinate) stop,
+  ];
+  if (stops.isEmpty) {
+    return InAppNavigationTour(
+      groupName: bucket.name,
+      stops: [if (point.hasCoordinate) point],
+    );
+  }
+  return InAppNavigationTour(
+    groupName: bucket.name,
+    stops: stops,
+    startIndex: navigationStartIndex(point: point, stops: stops),
+  );
+}

--- a/lib/plan/plan_manager_screen.dart
+++ b/lib/plan/plan_manager_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/copyable_text.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'pilgrimage_models.dart';
 
 Widget _cleanPlanReorderProxy(
@@ -290,6 +291,7 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: Text(_sorting ? '调整计划顺序' : '切换计划'),
         actions: [
           if (plans != null && plans.length > 1)

--- a/lib/plan/plan_manager_screen.dart
+++ b/lib/plan/plan_manager_screen.dart
@@ -96,7 +96,7 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showReplacingSnackBar(const SnackBar(content: Text('切换计划失败，请稍后重试。')));
+        ).showStatusSnack(kind: AppStatusBannerKind.error, title: '切换计划失败，请稍后重试。');
       }
     }
     if (!mounted) {
@@ -123,7 +123,7 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
     if (plans == null || plans.length <= 1) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('至少需要保留一个计划')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '至少需要保留一个计划');
       return;
     }
 
@@ -232,8 +232,9 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showReplacingSnackBar(
-        SnackBar(content: Text('已复制「${duplicatedPlan.name}」')),
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.success,
+        title: '已复制「${duplicatedPlan.name}」',
       );
     } catch (_) {
       if (!mounted) {
@@ -241,7 +242,7 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
       }
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('复制计划失败，请稍后重试。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '复制计划失败，请稍后重试。');
     }
   }
 
@@ -275,8 +276,9 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
         return;
       }
       setState(() => _plans = previousPlans);
-      ScaffoldMessenger.of(context).showReplacingSnackBar(
-        const SnackBar(content: Text('保存计划顺序失败，已恢复原来的顺序。')),
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.error,
+        title: '保存计划顺序失败，已恢复原来的顺序。',
       );
     } finally {
       if (mounted) {
@@ -433,7 +435,7 @@ class _PlanSectionLabel extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 7),
       child: Text(
         label,
-        style: const TextStyle(
+        style: TextStyle(
           color: AppColors.textSecondary,
           fontSize: 13,
           height: 1.15,
@@ -551,7 +553,7 @@ class _PlanCardState extends State<_PlanCard> {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         onTap: selected ? null : widget.onSwitch,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textPrimary,
                           fontSize: 17,
                           height: 1.15,
@@ -573,7 +575,7 @@ class _PlanCardState extends State<_PlanCard> {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         onTap: selected ? null : widget.onSwitch,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textSecondary,
                           fontSize: 12.5,
                           height: 1.15,
@@ -593,7 +595,7 @@ class _PlanCardState extends State<_PlanCard> {
                                 alignment: Alignment.centerLeft,
                                 child: Text(
                                   '暂无作品',
-                                  style: const TextStyle(
+                                  style: TextStyle(
                                     color: AppColors.textSecondary,
                                     fontSize: 11,
                                     height: 1,
@@ -866,7 +868,7 @@ class _PlanActionsMenuPanel extends StatelessWidget {
                     icon: Icons.copy_outlined,
                     onPressed: onDuplicate,
                   ),
-                  const Divider(height: 17, color: AppColors.border),
+                  Divider(height: 17, color: AppColors.border),
                   _PlanMenuActionItem(
                     actionKey: const ValueKey('plan-menu-action-delete'),
                     label: '删除计划',
@@ -1082,7 +1084,7 @@ class _PlanWorkTags extends StatelessWidget {
         if (remainingCount > 0)
           Text(
             '+$remainingCount',
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 11,
               height: 1,
@@ -1143,7 +1145,7 @@ class _PlanWorkTag extends StatelessWidget {
               work.title,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
+              style: TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 11,
                 height: 1,

--- a/lib/plan/plan_memo_screen.dart
+++ b/lib/plan/plan_memo_screen.dart
@@ -96,16 +96,6 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
     });
   }
 
-  Future<void> _cancelEditing() async {
-    if (!await _confirmDiscardChanges()) {
-      return;
-    }
-    setState(() {
-      _setMemoText(_savedMemo);
-      _isEditing = false;
-    });
-  }
-
   Future<void> _saveMemo() async {
     if (_isSaving) {
       return;
@@ -123,12 +113,12 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('计划备忘录已保存')));
+      ).showStatusSnack(kind: AppStatusBannerKind.success, title: '计划备忘录已保存');
     } catch (_) {
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showReplacingSnackBar(const SnackBar(content: Text('计划备忘录保存失败')));
+        ).showStatusSnack(kind: AppStatusBannerKind.error, title: '计划备忘录保存失败');
       }
     } finally {
       if (mounted) {
@@ -163,7 +153,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('待办状态保存失败')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '待办状态保存失败');
     } finally {
       if (mounted) {
         setState(() {
@@ -351,7 +341,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
     if (uri == null || !uri.hasScheme) {
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('链接格式不正确')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '链接格式不正确');
       return;
     }
     final opened = await launchUrl(uri, mode: LaunchMode.externalApplication);
@@ -360,7 +350,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
     }
     ScaffoldMessenger.of(
       context,
-    ).showReplacingSnackBar(const SnackBar(content: Text('无法打开链接')));
+    ).showStatusSnack(kind: AppStatusBannerKind.error, title: '无法打开链接');
   }
 
   @override
@@ -379,11 +369,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
           leading: AppBackButton(onPressed: _handleBack),
           title: const Text('计划备忘录'),
           actions: [
-            if (_isEditing) ...[
-              TextButton(
-                onPressed: _isSaving ? null : _cancelEditing,
-                child: const Text('取消'),
-              ),
+            if (_isEditing)
               Padding(
                 padding: const EdgeInsets.only(right: 8),
                 child: FilledButton.icon(
@@ -397,8 +383,8 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
                       : const Icon(Icons.save_outlined),
                   label: const Text('保存'),
                 ),
-              ),
-            ] else
+              )
+            else
               IconButton(
                 tooltip: '编辑',
                 onPressed: _startEditing,
@@ -416,21 +402,76 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
                         _MarkdownToolbar(onAction: _applyMarkdownAction),
                         const SizedBox(height: 12),
                         Expanded(
-                          child: TextField(
-                            onTapOutside: dismissKeyboardOnTapOutside,
-                            controller: _memoController,
-                            autofocus: true,
-                            expands: true,
-                            maxLines: null,
-                            minLines: null,
-                            keyboardType: TextInputType.multiline,
-                            textAlignVertical: TextAlignVertical.top,
-                            decoration: const InputDecoration(
-                              labelText: '备忘录内容',
-                              alignLabelWithHint: true,
-                              hintText: '可以记录交通、预约、补拍事项、同行安排等。',
-                              border: OutlineInputBorder(),
-                            ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '备忘录内容',
+                                style: TextStyle(
+                                  color: AppColors.textPrimary,
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w800,
+                                  letterSpacing: 0,
+                                ),
+                              ),
+                              const SizedBox(height: 10),
+                              Expanded(
+                                child: TextField(
+                                  key: const ValueKey('plan-memo-editor'),
+                                  onTapOutside: dismissKeyboardOnTapOutside,
+                                  controller: _memoController,
+                                  autofocus: true,
+                                  expands: true,
+                                  maxLines: null,
+                                  minLines: null,
+                                  keyboardType: TextInputType.multiline,
+                                  textAlignVertical: TextAlignVertical.top,
+                                  style: TextStyle(
+                                    color: AppColors.textPrimary,
+                                    fontSize: 15,
+                                    height: 1.5,
+                                    letterSpacing: 0,
+                                  ),
+                                  decoration: InputDecoration(
+                                    hintText: '可以记录交通、预约、补拍事项、同行安排等。',
+                                    hintStyle: TextStyle(
+                                      color: AppColors.textSecondary,
+                                      fontSize: 14,
+                                      height: 1.5,
+                                      fontWeight: FontWeight.w400,
+                                      letterSpacing: 0,
+                                    ),
+                                    filled: true,
+                                    fillColor: AppColors.surface,
+                                    contentPadding: const EdgeInsets.fromLTRB(
+                                      16,
+                                      16,
+                                      16,
+                                      16,
+                                    ),
+                                    border: OutlineInputBorder(
+                                      borderRadius: BorderRadius.circular(16),
+                                      borderSide: BorderSide(
+                                        color: AppColors.border,
+                                      ),
+                                    ),
+                                    enabledBorder: OutlineInputBorder(
+                                      borderRadius: BorderRadius.circular(16),
+                                      borderSide: BorderSide(
+                                        color: AppColors.border,
+                                      ),
+                                    ),
+                                    focusedBorder: OutlineInputBorder(
+                                      borderRadius: BorderRadius.circular(16),
+                                      borderSide: BorderSide(
+                                        color: AppColors.accent,
+                                        width: 1.5,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ],
@@ -605,7 +646,7 @@ class _PlanMemoMarkdownPreview extends StatelessWidget {
 
   static MarkdownStyleSheet _markdownStyleSheet(BuildContext context) {
     final base = MarkdownStyleSheet.fromTheme(Theme.of(context));
-    const paragraph = TextStyle(
+    final paragraph = TextStyle(
       color: AppColors.textPrimary,
       fontSize: 16,
       height: 1.55,
@@ -624,21 +665,21 @@ class _PlanMemoMarkdownPreview extends StatelessWidget {
       listBullet: paragraph.copyWith(fontSize: 18, fontWeight: FontWeight.w800),
       listBulletPadding: EdgeInsets.zero,
       checkbox: TextStyle(color: AppColors.accentDark, fontSize: 24),
-      h1: const TextStyle(
+      h1: TextStyle(
         color: AppColors.textPrimary,
         fontSize: 24,
         fontWeight: FontWeight.w800,
         height: 1.25,
         letterSpacing: 0,
       ),
-      h2: const TextStyle(
+      h2: TextStyle(
         color: AppColors.textPrimary,
         fontSize: 21,
         fontWeight: FontWeight.w800,
         height: 1.3,
         letterSpacing: 0,
       ),
-      h3: const TextStyle(
+      h3: TextStyle(
         color: AppColors.textPrimary,
         fontSize: 18,
         fontWeight: FontWeight.w800,
@@ -647,7 +688,7 @@ class _PlanMemoMarkdownPreview extends StatelessWidget {
       ),
       strong: const TextStyle(fontWeight: FontWeight.w800),
       blockSpacing: 10,
-      blockquote: const TextStyle(
+      blockquote: TextStyle(
         color: AppColors.textSecondary,
         fontSize: 16,
         height: 1.55,
@@ -659,7 +700,7 @@ class _PlanMemoMarkdownPreview extends StatelessWidget {
         border: Border(left: BorderSide(color: AppColors.accentDark, width: 4)),
         borderRadius: BorderRadius.circular(8),
       ),
-      code: const TextStyle(
+      code: TextStyle(
         color: AppColors.textPrimary,
         backgroundColor: AppColors.surfaceMuted,
         fontSize: 14,
@@ -672,7 +713,7 @@ class _PlanMemoMarkdownPreview extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      horizontalRuleDecoration: const BoxDecoration(
+      horizontalRuleDecoration: BoxDecoration(
         border: Border(top: BorderSide(color: AppColors.border, width: 1)),
       ),
     );
@@ -718,7 +759,7 @@ Widget _buildMarkdownBullet(MarkdownBulletParameters parameters) {
         child: Text(
           '${parameters.index + 1}.',
           textAlign: TextAlign.right,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textPrimary,
             fontSize: 16,
             fontWeight: FontWeight.w800,
@@ -731,7 +772,7 @@ Widget _buildMarkdownBullet(MarkdownBulletParameters parameters) {
   }
   return Transform.translate(
     offset: const Offset(0, 4),
-    child: const SizedBox(
+    child: SizedBox(
       width: 20,
       height: 20,
       child: Center(
@@ -775,7 +816,7 @@ class _UnsupportedMarkdownImage extends StatelessWidget {
               '备忘录不支持图片：$label',
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
+              style: TextStyle(
                 color: AppColors.textSecondary,
                 fontSize: 13,
                 fontWeight: FontWeight.w600,
@@ -844,7 +885,7 @@ class _EmptyPlanMemo extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 16),
-                const Text(
+                Text(
                   '还没有计划备忘',
                   style: TextStyle(
                     color: AppColors.textPrimary,
@@ -854,7 +895,7 @@ class _EmptyPlanMemo extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 8),
-                const Text(
+                Text(
                   '记录本次巡礼的重要事项',
                   textAlign: TextAlign.center,
                   style: TextStyle(
@@ -970,7 +1011,7 @@ class _MemoSuggestionItem extends StatelessWidget {
                 Text(
                   suggestion.label,
                   maxLines: 1,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textPrimary,
                     fontSize: 13,
                     fontWeight: FontWeight.w700,
@@ -982,7 +1023,7 @@ class _MemoSuggestionItem extends StatelessWidget {
                   suggestion.detail,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 11,
                     letterSpacing: 0,

--- a/lib/plan/plan_memo_screen.dart
+++ b/lib/plan/plan_memo_screen.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../app_theme.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'pilgrimage_plan_controller.dart';
 
 class PlanMemoScreen extends StatefulWidget {
@@ -375,11 +376,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
-            icon: const Icon(Icons.arrow_back),
-            onPressed: _handleBack,
-          ),
+          leading: AppBackButton(onPressed: _handleBack),
           title: const Text('计划备忘录'),
           actions: [
             if (_isEditing) ...[

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -308,6 +308,7 @@ class _PlanScreenState extends State<PlanScreen> {
     return Scaffold(
       appBar: AppBar(
         toolbarHeight: kToolbarHeight,
+        actionsPadding: EdgeInsets.zero,
         title: Text(
           plan.name,
           maxLines: 1,
@@ -365,7 +366,6 @@ class _PlanScreenState extends State<PlanScreen> {
                 ),
               )
             else ...[
-              if (!_showMap && !_showPlanActions) _PlanMetaStrip(plan: plan),
               _PlanActionsReveal(
                 expanded: _showPlanActions,
                 padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
@@ -402,10 +402,8 @@ class _PlanScreenState extends State<PlanScreen> {
                 onCreateGroup: () => _createGroupFromPointDetail(context),
               ),
               _PlanGroupControls(
-                plan: plan,
                 group: selectedGroup,
                 showMap: _showMap,
-                showGroupSummary: !_showPlanActions,
                 sortMode: _sortMode,
                 sortDescending: _sortDescending,
                 mapHeightRatio: _mapHeightRatio,
@@ -1017,10 +1015,8 @@ class _GroupSwitcher extends StatelessWidget {
 
 class _PlanGroupControls extends StatelessWidget {
   const _PlanGroupControls({
-    required this.plan,
     required this.group,
     required this.showMap,
-    required this.showGroupSummary,
     required this.sortMode,
     required this.sortDescending,
     required this.mapHeightRatio,
@@ -1038,10 +1034,8 @@ class _PlanGroupControls extends StatelessWidget {
     required this.onSelectPoint,
   });
 
-  final PilgrimagePlan plan;
   final PlanGroupBucket group;
   final bool showMap;
-  final bool showGroupSummary;
   final PointSortMode sortMode;
   final bool sortDescending;
   final double mapHeightRatio;
@@ -1078,10 +1072,6 @@ class _PlanGroupControls extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 2),
       child: Column(
         children: [
-          if (!showMap && showGroupSummary) ...[
-            _GroupSummary(group: group),
-            const SizedBox(height: 12),
-          ],
           Row(
             children: [
               Expanded(
@@ -1124,109 +1114,6 @@ class _PlanGroupControls extends StatelessWidget {
             ),
           ],
         ],
-      ),
-    );
-  }
-}
-
-class _GroupSummary extends StatelessWidget {
-  const _GroupSummary({required this.group});
-
-  final PlanGroupBucket group;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      key: const ValueKey('plan-group-summary'),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        border: Border.all(color: AppColors.border),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(10, 8, 10, 8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Icon(
-                  group.isUngrouped
-                      ? Icons.inventory_2_outlined
-                      : Icons.flag_outlined,
-                  color: AppColors.accentDark,
-                  size: 20,
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    group.anchorLabel,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 13,
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: 6),
-            Wrap(
-              spacing: 6,
-              runSpacing: 4,
-              children: [
-                _GroupMetric(label: '点位', value: '${group.points.length}'),
-                _GroupMetric(label: '完成', value: '${group.completedCount}'),
-                _GroupMetric(label: '模式', value: group.orderModeLabel),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _GroupMetric extends StatelessWidget {
-  const _GroupMetric({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: AppColors.surfaceMuted,
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              value,
-              style: const TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w800,
-                letterSpacing: 0,
-              ),
-            ),
-            const SizedBox(width: 4),
-            Text(
-              label,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0,
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }
@@ -1964,43 +1851,6 @@ class _WorkHeader extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-
-  String _workCountText(PilgrimagePlan plan) {
-    final count = plan.works.isNotEmpty
-        ? plan.works.length
-        : plan.points.map((point) => point.work.id).toSet().length;
-    return '$count 部作品';
-  }
-}
-
-class _PlanMetaStrip extends StatelessWidget {
-  const _PlanMetaStrip({required this.plan});
-
-  final PilgrimagePlan plan;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      key: const ValueKey('plan-meta-strip'),
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-      child: SizedBox(
-        width: double.infinity,
-        child: Text(
-          '${plan.area} / ${plan.points.length} 个点位 / ${_workCountText(plan)}',
-          key: const ValueKey('plan-meta-text'),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.left,
-          style: const TextStyle(
-            color: AppColors.textSecondary,
-            fontSize: 13,
-            fontWeight: FontWeight.w700,
-            letterSpacing: 0,
-          ),
-        ),
       ),
     );
   }

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -3,8 +3,11 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
+import '../widgets/auto_caching_reference_thumbnail.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
+import '../widgets/reference_thumbnail_stub.dart'
+    if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
 import '../widgets/snackbar_helper.dart';
 import '../camera_reference/camerawesome_reference_screen.dart';
 import '../point_detail/point_detail_sheet.dart';
@@ -20,7 +23,11 @@ import 'plan_group_utils.dart';
 import 'plan_memo_screen.dart';
 import 'pilgrimage_models.dart';
 import 'pilgrimage_plan_controller.dart';
+import 'reference_cache_progress_dialog.dart';
 import 'reference_full_cache_runner.dart';
+import 'reference_image_status.dart';
+
+const _planActionSubtitleMinPanelWidth = 380.0;
 
 class PlanScreen extends StatefulWidget {
   const PlanScreen({
@@ -59,7 +66,6 @@ class _PlanScreenState extends State<PlanScreen> {
   bool _showVirtualLocation = false;
   bool _isLocating = false;
   bool _isCachingFullReferences = false;
-  ReferenceFullCacheProgress? _fullReferenceCacheProgress;
   double _mapHeightRatio = 0.42;
   LatLng? _currentLocation;
   final _pointListController = ScrollController();
@@ -441,6 +447,7 @@ class _PlanScreenState extends State<PlanScreen> {
                     for (final point in displayPoints) ...[
                       _PlanPointTile(
                         key: _pointTileKey(point.id),
+                        controller: controller,
                         point: point,
                         status: controller.statusFor(point),
                         recordCount: controller
@@ -515,6 +522,8 @@ class _PlanScreenState extends State<PlanScreen> {
       onOpenRecord: (record) => _openRecordDetail(context, record),
       onEditPoint: () => _editPoint(context, point),
       navigationApp: settings.navigationApp,
+      settings: settings,
+      planController: controller,
     );
   }
 
@@ -609,13 +618,12 @@ class _PlanScreenState extends State<PlanScreen> {
 
   Future<void> _handleReferenceCachePressed() async {
     if (_isCachingFullReferences) {
-      _showSnackBar(_fullReferenceCacheProgress?.label ?? '正在缓存完整参考图...');
       return;
     }
 
     final points = pointsNeedingFullReferenceCache(controller.points);
     if (points.isEmpty) {
-      _showSnackBar('当前计划没有需要缓存的参考图');
+      _showSnackBar('当前计划没有需要缓存的参考图', kind: AppStatusBannerKind.warning);
       return;
     }
 
@@ -635,56 +643,44 @@ class _PlanScreenState extends State<PlanScreen> {
   }
 
   Future<void> _cacheFullReferenceImages() async {
-    final messenger = ScaffoldMessenger.of(context);
     if (_isCachingFullReferences) {
       return;
     }
     setState(() {
       _isCachingFullReferences = true;
-      _fullReferenceCacheProgress = null;
     });
-    messenger.showReplacingSnackBar(
-      const SnackBar(content: Text('已开始缓存完整参考图')),
-    );
     try {
-      await cacheFullReferenceImages(
-        plan: controller.plan,
-        repository: widget.repository,
-        onPlanUpdated: controller.replacePlan,
-        imageSource: settings.anitabiImageSource,
-        maxConcurrent: settings.mapThumbnailConcurrentLoads,
-        onProgress: (progress) {
-          if (!mounted) {
-            return;
-          }
-          setState(() {
-            _fullReferenceCacheProgress = progress;
-          });
+      await showReferenceCacheProgressDialog(
+        context: context,
+        run: (onProgress) {
+          return cacheFullReferenceImages(
+            plan: controller.plan,
+            repository: widget.repository,
+            onPlanUpdated: controller.replacePlan,
+            imageSource: settings.anitabiImageSource,
+            maxConcurrent: settings.mapThumbnailConcurrentLoads,
+            onProgress: onProgress,
+          );
         },
       );
     } finally {
       if (mounted) {
-        final progress = _fullReferenceCacheProgress;
         setState(() {
           _isCachingFullReferences = false;
         });
-        if (progress != null) {
-          messenger.showReplacingSnackBar(
-            SnackBar(content: Text(progress.label)),
-          );
-        }
       }
     }
   }
 
-  void _showSnackBar(String message) {
+  void _showSnackBar(
+    String message, {
+    AppStatusBannerKind kind = AppStatusBannerKind.error,
+  }) {
     if (!mounted) {
       return;
     }
 
-    ScaffoldMessenger.of(
-      context,
-    ).showReplacingSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context).showStatusSnack(kind: kind, title: message);
   }
 }
 
@@ -771,90 +767,112 @@ class _PlanActionsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      key: const ValueKey('plan-actions-panel'),
-      clipBehavior: Clip.antiAlias,
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Expanded(
-                  child: _PlanActionItem(
-                    key: const ValueKey('plan-action-add-points'),
-                    icon: const Icon(Icons.add_location_alt_outlined, size: 20),
-                    title: '添加点位',
-                    subtitle: '加入巡礼场景',
-                    onTap: onAddPoints,
-                  ),
-                ),
-                const _PlanActionDivider(),
-                Expanded(
-                  child: _PlanActionItem(
-                    key: const ValueKey('plan-action-manage-points'),
-                    icon: const Icon(Icons.tune_outlined, size: 20),
-                    title: '管理计划',
-                    subtitle: '整理片区点位',
-                    onTap: onManagePoints,
-                  ),
-                ),
-              ],
-            ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final showSubtitles =
+            constraints.maxWidth >= _planActionSubtitleMinPanelWidth;
+        return Container(
+          key: const ValueKey('plan-actions-panel'),
+          clipBehavior: Clip.antiAlias,
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: AppColors.border),
           ),
-          const Divider(height: 1, thickness: 1, color: AppColors.border),
-          IntrinsicHeight(
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Expanded(
-                  child: _PlanActionItem(
-                    key: const ValueKey('plan-action-cache-references'),
-                    icon: isCachingReferences
-                        ? const SizedBox.square(
-                            dimension: 19,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(
-                            Icons.download_for_offline_outlined,
-                            size: 20,
-                          ),
-                    title: '缓存参考图',
-                    subtitle: '保存完整图片',
-                    onTap: onCacheReferences,
-                  ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: _PlanActionItem(
+                        key: const ValueKey('plan-action-add-points'),
+                        icon: const Icon(
+                          Icons.add_location_alt_outlined,
+                          size: 20,
+                        ),
+                        title: '添加点位',
+                        subtitle: '加入巡礼场景',
+                        showSubtitle: showSubtitles,
+                        onTap: onAddPoints,
+                      ),
+                    ),
+                    const _PlanActionDivider(),
+                    Expanded(
+                      child: _PlanActionItem(
+                        key: const ValueKey('plan-action-manage-points'),
+                        icon: const Icon(Icons.tune_outlined, size: 20),
+                        title: '管理计划',
+                        subtitle: '整理片区点位',
+                        showSubtitle: showSubtitles,
+                        onTap: onManagePoints,
+                      ),
+                    ),
+                  ],
                 ),
-                const _PlanActionDivider(),
-                Expanded(
-                  child: _PlanActionItem(
-                    key: const ValueKey('plan-action-memo'),
-                    icon: const Icon(Icons.sticky_note_2_outlined, size: 20),
-                    title: '计划备忘录',
-                    subtitle: '记录行程要点',
-                    onTap: onOpenMemo,
-                  ),
+              ),
+              const AppHairline(),
+              IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: _PlanActionItem(
+                        key: const ValueKey('plan-action-cache-references'),
+                        icon: isCachingReferences
+                            ? const SizedBox.square(
+                                dimension: 19,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(
+                                Icons.download_for_offline_outlined,
+                                size: 20,
+                              ),
+                        title: '缓存参考图',
+                        subtitle: '保存完整图片',
+                        showSubtitle: showSubtitles,
+                        onTap: onCacheReferences,
+                      ),
+                    ),
+                    const _PlanActionDivider(),
+                    Expanded(
+                      child: _PlanActionItem(
+                        key: const ValueKey('plan-action-memo'),
+                        icon: const Icon(
+                          Icons.sticky_note_2_outlined,
+                          size: 20,
+                        ),
+                        title: '计划备忘录',
+                        subtitle: '记录行程要点',
+                        showSubtitle: showSubtitles,
+                        onTap: onOpenMemo,
+                      ),
+                    ),
+                    const _PlanActionDivider(),
+                    Expanded(
+                      child: _PlanActionItem(
+                        key: const ValueKey('plan-action-import-export'),
+                        icon: const Icon(
+                          Icons.import_export_outlined,
+                          size: 20,
+                        ),
+                        title: '导入导出',
+                        subtitle: '备份迁移计划',
+                        showSubtitle: showSubtitles,
+                        onTap: onImportExport,
+                      ),
+                    ),
+                  ],
                 ),
-                const _PlanActionDivider(),
-                Expanded(
-                  child: _PlanActionItem(
-                    key: const ValueKey('plan-action-import-export'),
-                    icon: const Icon(Icons.import_export_outlined, size: 20),
-                    title: '导入导出',
-                    subtitle: '备份迁移计划',
-                    onTap: onImportExport,
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }
@@ -864,6 +882,7 @@ class _PlanActionItem extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.subtitle,
+    required this.showSubtitle,
     required this.onTap,
     super.key,
   });
@@ -871,6 +890,7 @@ class _PlanActionItem extends StatelessWidget {
   final Widget icon;
   final String title;
   final String subtitle;
+  final bool showSubtitle;
   final VoidCallback onTap;
 
   @override
@@ -897,27 +917,29 @@ class _PlanActionItem extends StatelessWidget {
                     children: [
                       Text(
                         title,
-                        maxLines: 1,
+                        maxLines: showSubtitle ? 1 : 2,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textPrimary,
                           fontSize: 12,
                           fontWeight: FontWeight.w800,
                           letterSpacing: 0,
                         ),
                       ),
-                      const SizedBox(height: 2),
-                      Text(
-                        subtitle,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          color: AppColors.textSecondary,
-                          fontSize: 10,
-                          fontWeight: FontWeight.w500,
-                          letterSpacing: 0,
+                      if (showSubtitle) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          subtitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: AppColors.textSecondary,
+                            fontSize: 10,
+                            fontWeight: FontWeight.w500,
+                            letterSpacing: 0,
+                          ),
                         ),
-                      ),
+                      ],
                     ],
                   ),
                 ),
@@ -979,7 +1001,7 @@ class _GroupSwitcher extends StatelessWidget {
               style: FilledButton.styleFrom(
                 backgroundColor: AppColors.surface,
                 foregroundColor: AppColors.textPrimary,
-                side: const BorderSide(color: AppColors.border),
+                side: BorderSide(color: AppColors.border),
               ),
               child: Text(
                 group.name,
@@ -1196,7 +1218,7 @@ class _SortOrderControl extends StatelessWidget {
                 ],
               ),
             ),
-            const SizedBox(
+            SizedBox(
               height: 24,
               child: VerticalDivider(width: 1, color: AppColors.border),
             ),
@@ -1458,7 +1480,7 @@ class _MapCompactSummary extends StatelessWidget {
           '${group.anchorLabel} · ${group.completedCount}/${group.points.length} 完成 · ${group.orderModeLabel}',
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textSecondary,
             fontSize: 12,
             fontWeight: FontWeight.w700,
@@ -1762,7 +1784,7 @@ class _OnboardingStep extends StatelessWidget {
                       alignment: Alignment.centerLeft,
                       child: Text(
                         title,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textPrimary,
                           fontSize: 16,
                           fontWeight: FontWeight.w800,
@@ -1774,7 +1796,7 @@ class _OnboardingStep extends StatelessWidget {
                   const SizedBox(height: 4),
                   Text(
                     body,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 13,
                       height: 1.35,
@@ -1841,7 +1863,7 @@ class _WorkHeader extends StatelessWidget {
                   '${plan.area} / ${plan.points.length} 个点位 / ${_workCountText(plan)}',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 13,
                     letterSpacing: 0,
@@ -1865,6 +1887,7 @@ class _WorkHeader extends StatelessWidget {
 
 class _PlanPointTile extends StatelessWidget {
   const _PlanPointTile({
+    required this.controller,
     required this.point,
     required this.status,
     required this.recordCount,
@@ -1875,6 +1898,7 @@ class _PlanPointTile extends StatelessWidget {
     super.key,
   });
 
+  final PilgrimagePlanController controller;
   final PilgrimagePoint point;
   final VisitStatus status;
   final int recordCount;
@@ -1901,46 +1925,44 @@ class _PlanPointTile extends StatelessWidget {
           ),
           child: Row(
             children: [
-              Container(
-                width: 42,
-                height: 42,
-                decoration: BoxDecoration(
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Container(
+                  width: 42,
+                  height: 42,
                   color: colors.background,
-                  borderRadius: BorderRadius.circular(8),
+                  child: _PlanPointThumbnail(
+                    controller: controller,
+                    point: point,
+                    placeholder: Icon(
+                      colors.icon,
+                      color: colors.foreground,
+                      size: 22,
+                    ),
+                  ),
                 ),
-                child: Icon(colors.icon, color: colors.foreground, size: 22),
               ),
               const SizedBox(width: 12),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            point.name,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              fontSize: 15,
-                              fontWeight: FontWeight.w800,
-                              letterSpacing: 0,
-                            ),
-                          ),
-                        ),
-                        if (recordCount > 0) ...[
-                          const SizedBox(width: 8),
-                          _PointRecordBadge(count: recordCount),
-                        ],
-                      ],
-                    ),
-                    const SizedBox(height: 3),
                     Text(
-                      '${point.work.title} / ${point.subtitle} / ${point.displayEpisodeLabel}',
+                      point.name,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      point.work.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
                         color: AppColors.textSecondary,
                         fontSize: 12,
                         letterSpacing: 0,
@@ -1948,11 +1970,6 @@ class _PlanPointTile extends StatelessWidget {
                     ),
                   ],
                 ),
-              ),
-              IconButton(
-                tooltip: '拍摄参考',
-                onPressed: onOpenCamera,
-                icon: const Icon(Icons.photo_camera_outlined),
               ),
               IconButton(
                 tooltip: status == VisitStatus.completed ? '撤回打卡' : '完成',
@@ -1963,6 +1980,26 @@ class _PlanPointTile extends StatelessWidget {
                   status == VisitStatus.completed
                       ? Icons.restart_alt
                       : Icons.check_outlined,
+                ),
+              ),
+              IconButton(
+                tooltip: '拍摄参考',
+                onPressed: onOpenCamera,
+                icon: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      const Center(child: Icon(Icons.photo_camera_outlined)),
+                      if (recordCount > 0)
+                        const Positioned(
+                          top: -5,
+                          right: -5,
+                          child: _PointRecordBadge(),
+                        ),
+                    ],
+                  ),
                 ),
               ),
             ],
@@ -1996,38 +2033,66 @@ class _PlanPointTile extends StatelessWidget {
   }
 }
 
-class _PointRecordBadge extends StatelessWidget {
-  const _PointRecordBadge({required this.count});
+class _PlanPointThumbnail extends StatelessWidget {
+  const _PlanPointThumbnail({
+    required this.controller,
+    required this.point,
+    required this.placeholder,
+  });
 
-  final int count;
+  final PilgrimagePlanController controller;
+  final PilgrimagePoint point;
+  final Widget placeholder;
+
+  @override
+  Widget build(BuildContext context) {
+    final repository = controller.repository;
+    final remoteImageUrl = hasRemoteReferenceImage(point)
+        ? point.referenceImageUrl
+        : null;
+    if (repository == null) {
+      return ReferenceThumbnail(
+        localPath: point.referenceThumbnailPath,
+        imageUrl: remoteImageUrl,
+        placeholder: placeholder,
+      );
+    }
+    return AutoCachingReferenceThumbnail(
+      planId: controller.plan.id,
+      point: point,
+      repository: repository,
+      onPlanUpdated: controller.replacePlan,
+      placeholder: placeholder,
+    );
+  }
+}
+
+class _PointRecordBadge extends StatelessWidget {
+  const _PointRecordBadge();
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
+      key: const ValueKey('plan-point-shot-badge'),
+      width: 16,
+      height: 16,
+      alignment: Alignment.center,
       decoration: BoxDecoration(
-        color: AppColors.accent.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.photo_library_outlined,
-            size: 13,
-            color: AppColors.accentDark,
-          ),
-          const SizedBox(width: 4),
-          Text(
-            '已拍 $count',
-            style: TextStyle(
-              color: AppColors.accentDark,
-              fontSize: 11,
-              fontWeight: FontWeight.w800,
-              letterSpacing: 0,
-            ),
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: AppColors.accent.withValues(alpha: 0.42)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 2,
+            offset: const Offset(0, 1),
           ),
         ],
+      ),
+      child: Icon(
+        Icons.photo_library_outlined,
+        size: 10,
+        color: AppColors.accentDark,
       ),
     );
   }

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -55,6 +55,7 @@ class _PlanScreenState extends State<PlanScreen> {
   PointSortMode _sortMode = PointSortMode.plan;
   bool _sortDescending = false;
   bool _showMap = false;
+  bool _showPlanActions = false;
   bool _showVirtualLocation = false;
   bool _isLocating = false;
   bool _isCachingFullReferences = false;
@@ -63,6 +64,7 @@ class _PlanScreenState extends State<PlanScreen> {
   LatLng? _currentLocation;
   final _pointListController = ScrollController();
   final _pointTileKeys = <String, GlobalKey>{};
+  final _planActionsPanelRegionKey = GlobalKey();
 
   PilgrimagePlanController get controller => widget.controller;
 
@@ -202,6 +204,42 @@ class _PlanScreenState extends State<PlanScreen> {
     });
   }
 
+  void _togglePlanActions() {
+    setState(() {
+      _showPlanActions = !_showPlanActions;
+    });
+  }
+
+  void _collapsePlanActions() {
+    if (!_showPlanActions) {
+      return;
+    }
+    setState(() {
+      _showPlanActions = false;
+    });
+  }
+
+  void _openPlanAction(VoidCallback action) {
+    _collapsePlanActions();
+    action();
+  }
+
+  void _handlePlanBodyPointerDown(PointerDownEvent event) {
+    if (!_showPlanActions || !settings.dismissPlanActionsOnOutsideTap) {
+      return;
+    }
+    final renderBox =
+        _planActionsPanelRegionKey.currentContext?.findRenderObject()
+            as RenderBox?;
+    if (renderBox == null || !renderBox.hasSize) {
+      return;
+    }
+    final panelRect = renderBox.localToGlobal(Offset.zero) & renderBox.size;
+    if (!panelRect.contains(event.position)) {
+      _collapsePlanActions();
+    }
+  }
+
   Future<void> _toggleCurrentLocation() async {
     if (_showVirtualLocation && _currentLocation != null) {
       setState(() {
@@ -269,162 +307,163 @@ class _PlanScreenState extends State<PlanScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(plan.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+        toolbarHeight: kToolbarHeight,
+        title: Text(
+          plan.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(fontSize: 20, fontWeight: FontWeight.w900),
+        ),
         actions: [
-          _ReferenceCacheIconButton(
-            isCaching: _isCachingFullReferences,
-            progress: _fullReferenceCacheProgress,
-            onPressed: _handleReferenceCachePressed,
+          IconButton(
+            key: const ValueKey('plan-switch-button'),
+            tooltip: '切换计划',
+            onPressed: widget.onOpenPlanManager,
+            icon: const Icon(Icons.swap_horiz),
           ),
-          PopupMenuButton<_PlanMenuAction>(
-            tooltip: '计划操作',
-            icon: const Icon(Icons.more_horiz),
-            onSelected: (action) {
-              switch (action) {
-                case _PlanMenuAction.switchPlan:
-                  widget.onOpenPlanManager();
-                case _PlanMenuAction.addPoints:
-                  widget.onOpenAddPoints();
-                case _PlanMenuAction.managePoints:
-                  widget.onOpenPointManager();
-                case _PlanMenuAction.memo:
-                  _openPlanMemo();
-                case _PlanMenuAction.importExport:
-                  widget.onOpenImportExport();
-              }
-            },
-            itemBuilder: (context) => const [
-              PopupMenuItem(
-                value: _PlanMenuAction.switchPlan,
-                child: ListTile(
-                  leading: Icon(Icons.swap_horiz),
-                  title: Text('切换计划'),
-                ),
-              ),
-              PopupMenuItem(
-                value: _PlanMenuAction.addPoints,
-                child: ListTile(
-                  leading: Icon(Icons.add_location_alt_outlined),
-                  title: Text('添加点位'),
-                ),
-              ),
-              PopupMenuItem(
-                value: _PlanMenuAction.managePoints,
-                child: ListTile(
-                  leading: Icon(Icons.tune_outlined),
-                  title: Text('管理计划'),
-                ),
-              ),
-              PopupMenuItem(
-                value: _PlanMenuAction.memo,
-                child: ListTile(
-                  leading: Icon(Icons.sticky_note_2_outlined),
-                  title: Text('计划备忘录'),
-                ),
-              ),
-              PopupMenuItem(
-                value: _PlanMenuAction.importExport,
-                child: ListTile(
-                  leading: Icon(Icons.import_export_outlined),
-                  title: Text('导入导出'),
-                ),
-              ),
-            ],
+          IconButton(
+            key: const ValueKey('plan-actions-toggle'),
+            tooltip: _showPlanActions ? '收起计划操作' : '展开计划操作',
+            onPressed: _togglePlanActions,
+            icon: Icon(
+              _showPlanActions ? Icons.expand_less : Icons.expand_more,
+            ),
           ),
         ],
       ),
-      body: Column(
-        children: [
-          if (selectedGroup == null || controller.points.isEmpty)
-            Expanded(
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
-                children: [
-                  _WorkHeader(plan: plan),
-                  const SizedBox(height: 16),
-                  _EmptyPlanCard(onAddPoints: widget.onOpenAddPoints),
-                ],
-              ),
-            )
-          else ...[
-            if (!_showMap) _PlanMetaStrip(plan: plan),
-            _GroupSwitcher(
-              groups: groups,
-              selectedIndex: _selectedGroupIndex,
-              showProgressRing: widget.settings.showPlanGroupProgress,
-              onSelectGroup: (group) {
-                final currentGroups = planGroupBuckets(
-                  controller.plan,
-                  controller.completedPointIds,
-                );
-                final index = currentGroups.indexWhere(
-                  (candidate) => candidate.id == group.id,
-                );
-                if (index >= 0) {
-                  _selectGroup(index, currentGroups);
-                }
-              },
-              onCreateGroup: () => _createGroupFromPointDetail(context),
-            ),
-            _PlanGroupControls(
-              plan: plan,
-              group: selectedGroup,
-              showMap: _showMap,
-              sortMode: _sortMode,
-              sortDescending: _sortDescending,
-              mapHeightRatio: _mapHeightRatio,
-              settings: settings,
-              showVirtualLocation: _showVirtualLocation,
-              isLocating: _isLocating,
-              currentLocation: _currentLocation,
-              selectedPointId: controller.selectedPoint?.id,
-              onSetSortMode: (mode) {
-                setState(() {
-                  _sortMode = mode;
-                });
-              },
-              onToggleSortDirection: () {
-                setState(() {
-                  _sortDescending = !_sortDescending;
-                });
-              },
-              onToggleMap: () {
-                setState(() {
-                  _showMap = !_showMap;
-                });
-              },
-              onResizeMap: _resizeMap,
-              onToggleVirtualLocation: _toggleCurrentLocation,
-              onSelectPoint: (point) =>
-                  _handleMapPointTap(context, point, groups),
-              completedPointIds: controller.completedPointIds,
-            ),
-            Expanded(
-              child: ListView(
-                controller: _pointListController,
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-                children: [
-                  for (final point in displayPoints) ...[
-                    _PlanPointTile(
-                      key: _pointTileKey(point.id),
-                      point: point,
-                      status: controller.statusFor(point),
-                      recordCount: controller.recordsForPoint(point.id).length,
-                      onTap: () {
-                        _selectPoint(point, groups);
-                        _showPointDetail(context, point);
-                      },
-                      onOpenCamera: () => _openCamera(context, point),
-                      onComplete: () => controller.completePoint(point),
-                      onReopen: () => controller.reopenPoint(point),
+      body: Listener(
+        behavior: HitTestBehavior.translucent,
+        onPointerDown: _handlePlanBodyPointerDown,
+        child: Column(
+          children: [
+            if (selectedGroup == null || controller.points.isEmpty)
+              Expanded(
+                child: ListView(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
+                  children: [
+                    _WorkHeader(plan: plan),
+                    _PlanActionsReveal(
+                      expanded: _showPlanActions,
+                      child: KeyedSubtree(
+                        key: _planActionsPanelRegionKey,
+                        child: _PlanActionsPanel(
+                          isCachingReferences: _isCachingFullReferences,
+                          onCacheReferences: _handleReferenceCachePressed,
+                          onAddPoints: () =>
+                              _openPlanAction(widget.onOpenAddPoints),
+                          onManagePoints: () =>
+                              _openPlanAction(widget.onOpenPointManager),
+                          onOpenMemo: () => _openPlanAction(_openPlanMemo),
+                          onImportExport: () =>
+                              _openPlanAction(widget.onOpenImportExport),
+                        ),
+                      ),
                     ),
-                    const SizedBox(height: 8),
+                    const SizedBox(height: 16),
+                    _EmptyPlanCard(onAddPoints: widget.onOpenAddPoints),
                   ],
-                ],
+                ),
+              )
+            else ...[
+              if (!_showMap && !_showPlanActions) _PlanMetaStrip(plan: plan),
+              _PlanActionsReveal(
+                expanded: _showPlanActions,
+                padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+                child: KeyedSubtree(
+                  key: _planActionsPanelRegionKey,
+                  child: _PlanActionsPanel(
+                    isCachingReferences: _isCachingFullReferences,
+                    onCacheReferences: _handleReferenceCachePressed,
+                    onAddPoints: () => _openPlanAction(widget.onOpenAddPoints),
+                    onManagePoints: () =>
+                        _openPlanAction(widget.onOpenPointManager),
+                    onOpenMemo: () => _openPlanAction(_openPlanMemo),
+                    onImportExport: () =>
+                        _openPlanAction(widget.onOpenImportExport),
+                  ),
+                ),
               ),
-            ),
+              _GroupSwitcher(
+                groups: groups,
+                selectedIndex: _selectedGroupIndex,
+                showProgressRing: widget.settings.showPlanGroupProgress,
+                onSelectGroup: (group) {
+                  final currentGroups = planGroupBuckets(
+                    controller.plan,
+                    controller.completedPointIds,
+                  );
+                  final index = currentGroups.indexWhere(
+                    (candidate) => candidate.id == group.id,
+                  );
+                  if (index >= 0) {
+                    _selectGroup(index, currentGroups);
+                  }
+                },
+                onCreateGroup: () => _createGroupFromPointDetail(context),
+              ),
+              _PlanGroupControls(
+                plan: plan,
+                group: selectedGroup,
+                showMap: _showMap,
+                showGroupSummary: !_showPlanActions,
+                sortMode: _sortMode,
+                sortDescending: _sortDescending,
+                mapHeightRatio: _mapHeightRatio,
+                settings: settings,
+                showVirtualLocation: _showVirtualLocation,
+                isLocating: _isLocating,
+                currentLocation: _currentLocation,
+                selectedPointId: controller.selectedPoint?.id,
+                onSetSortMode: (mode) {
+                  setState(() {
+                    _sortMode = mode;
+                  });
+                },
+                onToggleSortDirection: () {
+                  setState(() {
+                    _sortDescending = !_sortDescending;
+                  });
+                },
+                onToggleMap: () {
+                  setState(() {
+                    _showMap = !_showMap;
+                  });
+                },
+                onResizeMap: _resizeMap,
+                onToggleVirtualLocation: _toggleCurrentLocation,
+                onSelectPoint: (point) =>
+                    _handleMapPointTap(context, point, groups),
+                completedPointIds: controller.completedPointIds,
+              ),
+              Expanded(
+                child: ListView(
+                  controller: _pointListController,
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                  children: [
+                    for (final point in displayPoints) ...[
+                      _PlanPointTile(
+                        key: _pointTileKey(point.id),
+                        point: point,
+                        status: controller.statusFor(point),
+                        recordCount: controller
+                            .recordsForPoint(point.id)
+                            .length,
+                        onTap: () {
+                          _selectPoint(point, groups);
+                          _showPointDetail(context, point);
+                        },
+                        onOpenCamera: () => _openCamera(context, point),
+                        onComplete: () => controller.completePoint(point),
+                        onReopen: () => controller.reopenPoint(point),
+                      ),
+                      const SizedBox(height: 8),
+                    ],
+                  ],
+                ),
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }
@@ -593,6 +632,7 @@ class _PlanScreenState extends State<PlanScreen> {
     if (!confirmed || !mounted) {
       return;
     }
+    _collapsePlanActions();
     await _cacheFullReferenceImages();
   }
 
@@ -690,32 +730,217 @@ class _PlanPointCreateGroupDialogState
   }
 }
 
-enum _PlanMenuAction { switchPlan, addPoints, managePoints, memo, importExport }
-
-class _ReferenceCacheIconButton extends StatelessWidget {
-  const _ReferenceCacheIconButton({
-    required this.isCaching,
-    required this.progress,
-    required this.onPressed,
+class _PlanActionsReveal extends StatelessWidget {
+  const _PlanActionsReveal({
+    required this.expanded,
+    required this.child,
+    this.padding = EdgeInsets.zero,
   });
 
-  final bool isCaching;
-  final ReferenceFullCacheProgress? progress;
-  final VoidCallback onPressed;
+  final bool expanded;
+  final Widget child;
+  final EdgeInsetsGeometry padding;
 
   @override
   Widget build(BuildContext context) {
-    final tooltip = isCaching ? progress?.label ?? '正在缓存完整参考图' : '缓存完整参考图';
-    return IconButton(
-      tooltip: tooltip,
-      onPressed: onPressed,
-      icon: isCaching
-          ? const SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
-          : const Icon(Icons.download_for_offline_outlined),
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 180),
+      curve: Curves.easeOutCubic,
+      alignment: Alignment.topCenter,
+      child: expanded
+          ? Padding(padding: padding, child: child)
+          : const SizedBox.shrink(),
+    );
+  }
+}
+
+class _PlanActionsPanel extends StatelessWidget {
+  const _PlanActionsPanel({
+    required this.isCachingReferences,
+    required this.onCacheReferences,
+    required this.onAddPoints,
+    required this.onManagePoints,
+    required this.onOpenMemo,
+    required this.onImportExport,
+  });
+
+  final bool isCachingReferences;
+  final VoidCallback onCacheReferences;
+  final VoidCallback onAddPoints;
+  final VoidCallback onManagePoints;
+  final VoidCallback onOpenMemo;
+  final VoidCallback onImportExport;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const ValueKey('plan-actions-panel'),
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-add-points'),
+                    icon: const Icon(Icons.add_location_alt_outlined, size: 20),
+                    title: '添加点位',
+                    subtitle: '加入巡礼场景',
+                    onTap: onAddPoints,
+                  ),
+                ),
+                const _PlanActionDivider(),
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-manage-points'),
+                    icon: const Icon(Icons.tune_outlined, size: 20),
+                    title: '管理计划',
+                    subtitle: '整理片区点位',
+                    onTap: onManagePoints,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1, thickness: 1, color: AppColors.border),
+          IntrinsicHeight(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-cache-references'),
+                    icon: isCachingReferences
+                        ? const SizedBox.square(
+                            dimension: 19,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(
+                            Icons.download_for_offline_outlined,
+                            size: 20,
+                          ),
+                    title: '缓存参考图',
+                    subtitle: '保存完整图片',
+                    onTap: onCacheReferences,
+                  ),
+                ),
+                const _PlanActionDivider(),
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-memo'),
+                    icon: const Icon(Icons.sticky_note_2_outlined, size: 20),
+                    title: '计划备忘录',
+                    subtitle: '记录行程要点',
+                    onTap: onOpenMemo,
+                  ),
+                ),
+                const _PlanActionDivider(),
+                Expanded(
+                  child: _PlanActionItem(
+                    key: const ValueKey('plan-action-import-export'),
+                    icon: const Icon(Icons.import_export_outlined, size: 20),
+                    title: '导入导出',
+                    subtitle: '备份迁移计划',
+                    onTap: onImportExport,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlanActionItem extends StatelessWidget {
+  const _PlanActionItem({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+    super.key,
+  });
+
+  final Widget icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 64),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
+            child: Row(
+              children: [
+                IconTheme(
+                  data: IconThemeData(color: AppColors.accentDark),
+                  child: icon,
+                ),
+                const SizedBox(width: 7),
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 10,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlanActionDivider extends StatelessWidget {
+  const _PlanActionDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      margin: const EdgeInsets.symmetric(vertical: 10),
+      color: AppColors.border,
     );
   }
 }
@@ -739,6 +964,7 @@ class _GroupSwitcher extends StatelessWidget {
   Widget build(BuildContext context) {
     final group = groups[selectedIndex];
     return Padding(
+      key: const ValueKey('plan-group-switcher'),
       padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
       child: Row(
         children: [
@@ -794,6 +1020,7 @@ class _PlanGroupControls extends StatelessWidget {
     required this.plan,
     required this.group,
     required this.showMap,
+    required this.showGroupSummary,
     required this.sortMode,
     required this.sortDescending,
     required this.mapHeightRatio,
@@ -814,6 +1041,7 @@ class _PlanGroupControls extends StatelessWidget {
   final PilgrimagePlan plan;
   final PlanGroupBucket group;
   final bool showMap;
+  final bool showGroupSummary;
   final PointSortMode sortMode;
   final bool sortDescending;
   final double mapHeightRatio;
@@ -850,7 +1078,7 @@ class _PlanGroupControls extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 2),
       child: Column(
         children: [
-          if (!showMap) ...[
+          if (!showMap && showGroupSummary) ...[
             _GroupSummary(group: group),
             const SizedBox(height: 12),
           ],
@@ -909,6 +1137,7 @@ class _GroupSummary extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DecoratedBox(
+      key: const ValueKey('plan-group-summary'),
       decoration: BoxDecoration(
         color: AppColors.surface,
         border: Border.all(color: AppColors.border),
@@ -1567,7 +1796,7 @@ class _OnboardingTimeline extends StatelessWidget {
         _OnboardingStep(
           number: 1,
           title: '加作品',
-          body: '点击右上角，选择“添加点位”，点击“作品管理”，在这里搜索你想要加入巡礼计划的作品并添加。',
+          body: '点击右上角展开计划操作，选择“添加点位”，再点击“作品管理”，搜索并添加想要加入巡礼计划的作品。',
         ),
         _OnboardingStep(
           number: 2,
@@ -1579,7 +1808,7 @@ class _OnboardingTimeline extends StatelessWidget {
           number: 3,
           title: '划片区',
           body:
-              '回到“计划”页，点击右上角，选择“管理计划”，在这里你可以对加入计划的点位进行更细致的管理。你可以创建片区，把距离接近的点位放到一起。',
+              '回到“计划”页，点击右上角展开计划操作，选择“管理计划”。在这里可以细致管理已加入计划的点位，创建片区并归纳距离接近的点位。',
           isLast: true,
         ),
       ],
@@ -1755,25 +1984,23 @@ class _PlanMetaStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 4, 16, 10),
-      child: Row(
-        children: [
-          Icon(Icons.movie_filter_outlined, color: AppColors.accentDark),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              '${plan.area} / ${plan.points.length} 个点位 / ${_workCountText(plan)}',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0,
-              ),
-            ),
+      key: const ValueKey('plan-meta-strip'),
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: SizedBox(
+        width: double.infinity,
+        child: Text(
+          '${plan.area} / ${plan.points.length} 个点位 / ${_workCountText(plan)}',
+          key: const ValueKey('plan-meta-text'),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.left,
+          style: const TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0,
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/plan/point_manager_screen.dart
+++ b/lib/plan/point_manager_screen.dart
@@ -15,6 +15,7 @@ import '../utils/selected_item_order.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'add_points_screen.dart';
 import 'nearest_group_assign_screen.dart';
 import 'pilgrimage_models.dart';
@@ -111,10 +112,8 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: Text(
             _selectionMode ? '已选 ${_selectedPointIds.length}' : '管理计划',
@@ -1831,6 +1830,7 @@ class _GroupAnchorMapPickerScreenState
 
     return Scaffold(
       appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
         title: const Text('选择关键点'),
         actions: [
           TextButton(

--- a/lib/plan/point_manager_screen.dart
+++ b/lib/plan/point_manager_screen.dart
@@ -16,12 +16,15 @@ import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/snackbar_helper.dart';
 import '../widgets/app_back_button.dart';
+import '../widgets/clear_anchor_selection_button.dart';
 import 'add_points_screen.dart';
 import 'nearest_group_assign_screen.dart';
 import 'pilgrimage_models.dart';
 import 'plan_group_picker_sheet.dart';
 import 'plan_group_manager_screen.dart';
 import 'plan_group_utils.dart';
+import 'coordinate_input_dialog.dart';
+import 'reference_cache_progress_dialog.dart';
 import 'reference_full_cache_runner.dart';
 import 'reference_image_status.dart';
 
@@ -72,17 +75,6 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
 
   List<PlanGroupBucket> get _groups =>
       planGroupBuckets(_plan, _plan.completedPointIds);
-
-  int get _actualGroupCount =>
-      _groups.where((group) => !group.isUngrouped).length;
-
-  int _actualGroupNumber(PlanGroupBucket group) {
-    if (group.isUngrouped) {
-      return 0;
-    }
-    final groups = _groups.where((group) => !group.isUngrouped).toList();
-    return groups.indexWhere((candidate) => candidate.id == group.id) + 1;
-  }
 
   PlanGroupBucket? get _selectedGroup {
     final groups = _groups;
@@ -187,7 +179,7 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
   }
 
   Widget _buildGroupPage(PlanGroupBucket group) {
-    final bottomPadding = _selectionMode ? 104.0 : 24.0;
+    final bottomPadding = _selectionMode ? 120.0 : 24.0;
     final canManualReorder =
         !group.isUngrouped &&
         group.group?.orderMode == PlanGroupOrderMode.manual &&
@@ -196,17 +188,14 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
     final header = Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
       child: _PlanManagerHeader(
-        plan: _plan,
         group: group,
         groupIndex: _selectedGroupIndex,
-        groupNumber: _actualGroupNumber(group),
-        groupCount: _actualGroupCount,
         selectionMode: _selectionMode,
         onPreviousGroup: _previousGroup,
         onNextGroup: _nextGroup,
         onGroupTap: () => _showGroupSheet(_groups),
         onAnchorTap: () => _showAnchorSheet(group),
-        onOrderTap: () => _showOrderModeSheet(group),
+        onOrderModeChanged: (mode) => _setGroupOrderMode(group, mode),
         onNearestAssign: _openNearestAssign,
         onBoxAssign: _openBoxAssign,
       ),
@@ -231,7 +220,6 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
                   child: _PointManagerTile(
                     index: index,
                     point: point,
-                    groupName: group.name,
                     status: _statusFor(point),
                     isBusy: _isSaving,
                     selectionMode: false,
@@ -268,7 +256,6 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
                 child: _PointManagerTile(
                   index: index,
                   point: point,
-                  groupName: group.name,
                   status: _statusFor(point),
                   isBusy: _isSaving,
                   selectionMode: _selectionMode,
@@ -346,7 +333,7 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
   }
 
   Future<void> _openGroupManager() async {
-    await Navigator.of(context).push<bool>(
+    final selectedGroupId = await Navigator.of(context).push<String?>(
       MaterialPageRoute(
         builder: (_) =>
             PlanGroupManagerScreen(plan: _plan, repository: widget.repository),
@@ -362,7 +349,12 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
     setState(() {
       _plan = updatedPlan;
       final groups = _groups;
-      if (_selectedGroupIndex >= groups.length) {
+      if (selectedGroupId != null) {
+        final index = groups.indexWhere((group) => group.id == selectedGroupId);
+        if (index >= 0) {
+          _selectedGroupIndex = index;
+        }
+      } else if (_selectedGroupIndex >= groups.length) {
         _selectedGroupIndex = groups.isEmpty ? 0 : groups.length - 1;
       }
       _didUpdate = true;
@@ -472,7 +464,7 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
           .firstOrNull;
     } catch (_) {
       if (mounted) {
-        _showInfo('片区创建失败，请稍后重试。');
+        _showInfo('片区创建失败，请稍后重试。', kind: AppStatusBannerKind.error);
       }
       return null;
     }
@@ -515,57 +507,19 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
     );
   }
 
-  Future<void> _showOrderModeSheet(PlanGroupBucket group) {
-    if (group.isUngrouped) {
+  Future<void> _setGroupOrderMode(
+    PlanGroupBucket group,
+    PlanGroupOrderMode mode,
+  ) async {
+    if (group.isUngrouped || group.group == null) {
       return _showInfo('未分配点位不需要排序方式。');
     }
-    if (group.group == null) {
-      return _showInfo('片区不存在。');
+    if (group.group!.orderMode == mode) {
+      return;
     }
-    return showModalBottomSheet<void>(
-      context: context,
-      showDragHandle: true,
-      builder: (context) {
-        final mode = group.group?.orderMode ?? PlanGroupOrderMode.unordered;
-        return SafeArea(
-          top: false,
-          child: ListView(
-            shrinkWrap: true,
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
-            children: [
-              const _SheetTitle(title: '片区内顺序'),
-              _OrderModeTile(
-                title: '无序',
-                selected: mode == PlanGroupOrderMode.unordered,
-                onTap: () async {
-                  Navigator.of(context).pop();
-                  await _updateGroup(
-                    _copyGroup(
-                      group.group!,
-                      orderMode: PlanGroupOrderMode.unordered,
-                    ),
-                    failureMessage: '排序方式保存失败',
-                  );
-                },
-              ),
-              _OrderModeTile(
-                title: '手动排序',
-                selected: mode == PlanGroupOrderMode.manual,
-                onTap: () async {
-                  Navigator.of(context).pop();
-                  await _updateGroup(
-                    _copyGroup(
-                      group.group!,
-                      orderMode: PlanGroupOrderMode.manual,
-                    ),
-                    failureMessage: '排序方式保存失败',
-                  );
-                },
-              ),
-            ],
-          ),
-        );
-      },
+    await _updateGroup(
+      _copyGroup(group.group!, orderMode: mode),
+      failureMessage: '排序方式保存失败',
     );
   }
 
@@ -678,6 +632,7 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       onCreateGroup: _createGroupFromPicker,
       onEditPoint: () => _editPoint(currentPoint),
       navigationApp: widget.settings.navigationApp,
+      settings: widget.settings,
     );
   }
 
@@ -847,8 +802,9 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       context,
       title: '删除点位',
       message: '将从计划中删除「${point.name}」。',
-      confirmLabel: '删除',
+      confirmLabel: '删除点位',
       destructive: true,
+      notice: '删除后无法撤销',
       emphasizedValues: [point.name],
     );
     if (!confirmed || !mounted) {
@@ -990,7 +946,7 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(SnackBar(content: Text(failureMessage)));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: failureMessage);
     }
   }
 
@@ -1026,12 +982,11 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       });
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(SnackBar(content: Text(failureMessage)));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: failureMessage);
     }
   }
 
   Future<void> _cacheFullReferenceImages() async {
-    final messenger = ScaffoldMessenger.of(context);
     if (_isCachingFullReferences) {
       return;
     }
@@ -1039,51 +994,48 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       _isCachingFullReferences = true;
       _fullReferenceCacheProgress = null;
     });
-    messenger.showReplacingSnackBar(
-      const SnackBar(content: Text('已开始缓存完整参考图')),
-    );
     try {
-      await cacheFullReferenceImages(
-        plan: _plan,
-        repository: widget.repository,
-        imageSource: widget.settings.anitabiImageSource,
-        maxConcurrent: widget.settings.mapThumbnailConcurrentLoads,
-        onPlanUpdated: (plan) {
-          if (!mounted) {
-            return;
-          }
-          setState(() {
-            _plan = plan;
-            _didUpdate = true;
-          });
-        },
-        onProgress: (progress) {
-          if (!mounted) {
-            return;
-          }
-          setState(() {
-            _fullReferenceCacheProgress = progress;
-          });
+      await showReferenceCacheProgressDialog(
+        context: context,
+        run: (onProgress) {
+          return cacheFullReferenceImages(
+            plan: _plan,
+            repository: widget.repository,
+            imageSource: widget.settings.anitabiImageSource,
+            maxConcurrent: widget.settings.mapThumbnailConcurrentLoads,
+            onPlanUpdated: (plan) {
+              if (!mounted) {
+                return;
+              }
+              setState(() {
+                _plan = plan;
+                _didUpdate = true;
+              });
+            },
+            onProgress: (progress) {
+              onProgress(progress);
+              if (!mounted) {
+                return;
+              }
+              setState(() {
+                _fullReferenceCacheProgress = progress;
+              });
+            },
+          );
         },
       );
     } finally {
       if (mounted) {
-        final progress = _fullReferenceCacheProgress;
         setState(() {
           _isCachingFullReferences = false;
         });
-        if (progress != null) {
-          messenger.showReplacingSnackBar(
-            SnackBar(content: Text(progress.label)),
-          );
-        }
       }
     }
   }
 
   Future<void> _handleReferenceCachePressed() async {
     if (_isCachingFullReferences) {
-      return _showInfo(_fullReferenceCacheProgress?.label ?? '正在缓存完整参考图...');
+      return;
     }
     final points = pointsNeedingFullReferenceCache(_plan.points);
     if (points.isEmpty) {
@@ -1102,13 +1054,14 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
     }
   }
 
-  Future<void> _showInfo(String message) async {
+  Future<void> _showInfo(
+    String message, {
+    AppStatusBannerKind kind = AppStatusBannerKind.warning,
+  }) async {
     if (!mounted) {
       return;
     }
-    ScaffoldMessenger.of(
-      context,
-    ).showReplacingSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(context).showStatusSnack(kind: kind, title: message);
   }
 }
 
@@ -1169,124 +1122,212 @@ class _PointManagerCreateGroupDialogState
 
 class _PlanManagerHeader extends StatelessWidget {
   const _PlanManagerHeader({
-    required this.plan,
     required this.group,
     required this.groupIndex,
-    required this.groupNumber,
-    required this.groupCount,
     required this.selectionMode,
     required this.onPreviousGroup,
     required this.onNextGroup,
     required this.onGroupTap,
     required this.onAnchorTap,
-    required this.onOrderTap,
+    required this.onOrderModeChanged,
     required this.onNearestAssign,
     required this.onBoxAssign,
   });
 
-  final PilgrimagePlan plan;
   final PlanGroupBucket group;
   final int groupIndex;
-  final int groupNumber;
-  final int groupCount;
   final bool selectionMode;
   final VoidCallback onPreviousGroup;
   final VoidCallback onNextGroup;
   final VoidCallback onGroupTap;
   final VoidCallback onAnchorTap;
-  final VoidCallback onOrderTap;
+  final ValueChanged<PlanGroupOrderMode> onOrderModeChanged;
   final Future<void> Function() onNearestAssign;
   final Future<void> Function() onBoxAssign;
 
   @override
   Widget build(BuildContext context) {
-    final orderLabel = group.group?.orderMode == PlanGroupOrderMode.manual
-        ? '手动排序'
-        : '无序';
-    final anchorLabel = group.group?.anchorName ?? '未设置';
+    final anchorName = group.group?.anchorName?.trim();
+    final hasAnchor = anchorName != null && anchorName.isNotEmpty;
+    final anchorText = hasAnchor ? '关键点：$anchorName' : '关键点：未设置';
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
-      child: Container(
-        padding: const EdgeInsets.all(14),
-        decoration: BoxDecoration(
-          color: AppColors.surface,
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: AppColors.border),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Row(
-              children: [
-                IconButton(
-                  tooltip: '上一个片区',
-                  onPressed: selectionMode ? null : onPreviousGroup,
-                  icon: const Icon(Icons.chevron_left),
-                ),
-                Expanded(
-                  child: FilledButton.tonalIcon(
-                    onPressed: selectionMode ? null : onGroupTap,
-                    icon: Icon(
-                      group.isUngrouped
-                          ? Icons.inbox_outlined
-                          : Icons.folder_outlined,
-                      size: 18,
-                    ),
-                    label: Text(
-                      group.name,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              IconButton(
+                tooltip: '上一个片区',
+                onPressed: selectionMode ? null : onPreviousGroup,
+                icon: const Icon(Icons.chevron_left),
+              ),
+              Expanded(
+                child: FilledButton.tonal(
+                  key: const ValueKey('point-manager-group-switcher'),
+                  onPressed: selectionMode ? null : onGroupTap,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.surface,
+                    foregroundColor: AppColors.textPrimary,
+                    side: BorderSide(color: AppColors.border),
+                  ),
+                  child: Text(
+                    group.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(fontWeight: FontWeight.w800),
                   ),
                 ),
-                IconButton(
-                  tooltip: '下一个片区',
-                  onPressed: selectionMode ? null : onNextGroup,
-                  icon: const Icon(Icons.chevron_right),
-                ),
+              ),
+              IconButton(
+                tooltip: '下一个片区',
+                onPressed: selectionMode ? null : onNextGroup,
+                icon: const Icon(Icons.chevron_right),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Material(
+            color: AppColors.surface,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: BorderSide(color: AppColors.border),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (!group.isUngrouped) ...[
+                  InkWell(
+                    key: const ValueKey('point-manager-anchor-row'),
+                    onTap: selectionMode ? null : onAnchorTap,
+                    child: SizedBox(
+                      height: 40,
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(12, 0, 8, 0),
+                        child: Row(
+                          children: [
+                            Icon(Icons.flag, size: 18, color: AppColors.accent),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                anchorText,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: AppColors.accent,
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w800,
+                                  letterSpacing: 0,
+                                ),
+                              ),
+                            ),
+                            Text(
+                              '更改',
+                              style: TextStyle(
+                                color: AppColors.textSecondary,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
+                              ),
+                            ),
+                            Icon(
+                              Icons.chevron_right,
+                              size: 18,
+                              color: AppColors.textSecondary,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 0, 12, 10),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        _HeaderCountChip(
+                          key: const ValueKey(
+                            'point-manager-count-chip-points',
+                          ),
+                          count: group.points.length,
+                          unit: '点位',
+                        ),
+                        const SizedBox(width: 6),
+                        _HeaderCountChip(
+                          key: const ValueKey(
+                            'point-manager-count-chip-completed',
+                          ),
+                          count: group.completedCount,
+                          unit: '完成',
+                        ),
+                        const SizedBox(width: 8),
+                        _GroupOrderModeButton(
+                          mode:
+                              group.group?.orderMode ??
+                              PlanGroupOrderMode.unordered,
+                          enabled: !selectionMode,
+                          onSelected: onOrderModeChanged,
+                        ),
+                      ],
+                    ),
+                  ),
+                ] else
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+                    child: Column(
+                      children: [
+                        _UngroupedWaitLabel(count: group.points.length),
+                        const SizedBox(height: 10),
+                        _UngroupedActionRow(
+                          onNearestAssign: onNearestAssign,
+                          onBoxAssign: onBoxAssign,
+                        ),
+                      ],
+                    ),
+                  ),
               ],
             ),
-            const SizedBox(height: 8),
-            Text(
-              group.isUngrouped
-                  ? '${group.points.length} 个点位等待整理'
-                  : '${group.points.length} 个点位 · 已完成 ${group.completedCount} · $groupNumber/$groupCount',
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w700,
-                letterSpacing: 0,
-              ),
-            ),
-            const SizedBox(height: 12),
-            if (group.isUngrouped)
-              _UngroupedActionRow(
-                onNearestAssign: onNearestAssign,
-                onBoxAssign: onBoxAssign,
-              )
-            else
-              Row(
-                children: [
-                  Expanded(
-                    child: _HeaderPillButton(
-                      icon: Icons.flag_outlined,
-                      label: '关键点：$anchorLabel',
-                      onTap: selectionMode ? null : onAnchorTap,
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  _HeaderPillButton(
-                    icon: Icons.sort_outlined,
-                    label: orderLabel,
-                    onTap: selectionMode ? null : onOrderTap,
-                  ),
-                ],
-              ),
-          ],
-        ),
+          ),
+        ],
       ),
+    );
+  }
+}
+
+class _UngroupedWaitLabel extends StatelessWidget {
+  const _UngroupedWaitLabel({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      key: const ValueKey('point-manager-ungrouped-wait'),
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Text(
+          '$count',
+          style: TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 16,
+            fontWeight: FontWeight.w800,
+            letterSpacing: 0,
+            height: 1,
+          ),
+        ),
+        Text(
+          ' 个点位等待整理',
+          style: TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0,
+            height: 1,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -1324,6 +1365,70 @@ class _UngroupedActionRow extends StatelessWidget {
   }
 }
 
+const _planManagerHeaderActionHeight = 32.0;
+
+ButtonStyle get _planManagerHeaderActionStyle {
+  return OutlinedButton.styleFrom(
+    padding: const EdgeInsets.symmetric(horizontal: 10),
+    minimumSize: const Size(0, _planManagerHeaderActionHeight),
+    maximumSize: const Size(double.infinity, _planManagerHeaderActionHeight),
+    fixedSize: const Size.fromHeight(_planManagerHeaderActionHeight),
+    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    visualDensity: VisualDensity.compact,
+  );
+}
+
+class _HeaderCountChip extends StatelessWidget {
+  const _HeaderCountChip({required this.count, required this.unit, super.key});
+
+  final int count;
+  final String unit;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: _planManagerHeaderActionHeight,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: AppColors.surfaceMuted,
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: AppColors.border),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                '$count',
+                style: TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w400,
+                  letterSpacing: 0,
+                  height: 1,
+                ),
+              ),
+              const SizedBox(width: 4),
+              Text(
+                unit,
+                style: TextStyle(
+                  color: AppColors.textPrimary,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: 0,
+                  height: 1,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _HeaderPillButton extends StatelessWidget {
   const _HeaderPillButton({
     required this.icon,
@@ -1337,14 +1442,191 @@ class _HeaderPillButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return OutlinedButton.icon(
+    return OutlinedButton(
       onPressed: onTap,
-      icon: Icon(icon, size: 17),
-      label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
-      style: OutlinedButton.styleFrom(
-        padding: const EdgeInsets.symmetric(horizontal: 10),
-        minimumSize: const Size(0, 38),
+      style: _planManagerHeaderActionStyle,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(icon, size: 16),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+          ),
+        ],
       ),
+    );
+  }
+}
+
+class _GroupOrderModeButton extends StatefulWidget {
+  const _GroupOrderModeButton({
+    required this.mode,
+    required this.enabled,
+    required this.onSelected,
+  });
+
+  final PlanGroupOrderMode mode;
+  final bool enabled;
+  final ValueChanged<PlanGroupOrderMode> onSelected;
+
+  @override
+  State<_GroupOrderModeButton> createState() => _GroupOrderModeButtonState();
+}
+
+class _GroupOrderModeButtonState extends State<_GroupOrderModeButton> {
+  var _isOpen = false;
+
+  static const _options = [
+    (PlanGroupOrderMode.unordered, '无序', 'unordered'),
+    (PlanGroupOrderMode.manual, '手动排序', 'manual'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final accentColor = Theme.of(context).colorScheme.primary;
+    final currentLabel = _options
+        .firstWhere((option) => option.$1 == widget.mode)
+        .$2;
+    return MenuAnchor(
+      key: const ValueKey('point-manager-order-menu-anchor'),
+      onOpen: () => setState(() => _isOpen = true),
+      onClose: () => setState(() => _isOpen = false),
+      alignmentOffset: const Offset(0, 4),
+      style: MenuStyle(
+        padding: const WidgetStatePropertyAll(EdgeInsets.zero),
+        backgroundColor: WidgetStatePropertyAll(AppColors.surface),
+        elevation: const WidgetStatePropertyAll(8),
+        shadowColor: WidgetStatePropertyAll(
+          AppColors.textPrimary.withValues(alpha: 0.14),
+        ),
+        side: WidgetStatePropertyAll(BorderSide(color: AppColors.border)),
+        minimumSize: const WidgetStatePropertyAll(Size.zero),
+        maximumSize: const WidgetStatePropertyAll(Size(124, double.infinity)),
+        shape: const WidgetStatePropertyAll(
+          RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(8)),
+          ),
+        ),
+      ),
+      builder: (context, controller, child) {
+        return Tooltip(
+          message: '片区内顺序',
+          child: OutlinedButton(
+            key: const ValueKey('point-manager-order-button'),
+            onPressed: widget.enabled
+                ? () {
+                    if (controller.isOpen) {
+                      controller.close();
+                    } else {
+                      controller.open();
+                    }
+                  }
+                : null,
+            style: _planManagerHeaderActionStyle,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.swap_vert,
+                  size: 16,
+                  color: widget.enabled
+                      ? AppColors.textPrimary
+                      : AppColors.textSecondary,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  currentLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(width: 2),
+                Icon(
+                  _isOpen ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
+                  size: 16,
+                  color: widget.enabled
+                      ? AppColors.textPrimary
+                      : AppColors.textSecondary,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+      menuChildren: [
+        SizedBox(
+          key: const ValueKey('point-manager-order-menu'),
+          width: 124,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(6, 0, 6, 6),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.fromLTRB(8, 10, 8, 6),
+                  child: Text(
+                    '片区内顺序',
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+                for (final option in _options)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 2),
+                    child: MenuItemButton(
+                      key: ValueKey('point-manager-order-option-${option.$3}'),
+                      onPressed: () => widget.onSelected(option.$1),
+                      leadingIcon: option.$1 == widget.mode
+                          ? Icon(Icons.check, color: accentColor, size: 18)
+                          : const SizedBox(width: 18),
+                      style: ButtonStyle(
+                        minimumSize: const WidgetStatePropertyAll(Size(0, 42)),
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        padding: const WidgetStatePropertyAll(
+                          EdgeInsets.symmetric(horizontal: 8),
+                        ),
+                        backgroundColor: WidgetStatePropertyAll(
+                          option.$1 == widget.mode
+                              ? accentColor.withValues(alpha: 0.09)
+                              : Colors.transparent,
+                        ),
+                        foregroundColor: WidgetStatePropertyAll(
+                          option.$1 == widget.mode
+                              ? accentColor
+                              : AppColors.textPrimary,
+                        ),
+                        overlayColor: WidgetStateProperty.resolveWith((states) {
+                          if (option.$1 == widget.mode) {
+                            return Colors.transparent;
+                          }
+                          return states.contains(WidgetState.hovered)
+                              ? accentColor.withValues(alpha: 0.035)
+                              : Colors.transparent;
+                        }),
+                        shape: WidgetStatePropertyAll(
+                          RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                        ),
+                      ),
+                      child: Text(
+                        option.$2,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -1353,7 +1635,6 @@ class _PointManagerTile extends StatelessWidget {
   const _PointManagerTile({
     required this.index,
     required this.point,
-    required this.groupName,
     required this.status,
     required this.isBusy,
     required this.selectionMode,
@@ -1371,7 +1652,6 @@ class _PointManagerTile extends StatelessWidget {
 
   final int index;
   final PilgrimagePoint point;
-  final String groupName;
   final VisitStatus status;
   final bool isBusy;
   final bool selectionMode;
@@ -1394,7 +1674,7 @@ class _PointManagerTile extends StatelessWidget {
       VisitStatus.pending => AppColors.accentDark,
     };
     final statusText = switch (status) {
-      VisitStatus.current => '当前',
+      VisitStatus.current => '当前目标',
       VisitStatus.completed => '已完成',
       VisitStatus.pending => '待访问',
     };
@@ -1437,7 +1717,7 @@ class _PointManagerTile extends StatelessWidget {
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
-                        fontSize: 15,
+                        fontSize: 17,
                         fontWeight: FontWeight.w800,
                         letterSpacing: 0,
                       ),
@@ -1447,7 +1727,7 @@ class _PointManagerTile extends StatelessWidget {
                       '${point.work.title} / ${point.subtitle}',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textSecondary,
                         fontSize: 12,
                         letterSpacing: 0,
@@ -1465,19 +1745,7 @@ class _PointManagerTile extends StatelessWidget {
                             letterSpacing: 0,
                           ),
                         ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            groupName,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              color: AppColors.textSecondary,
-                              fontSize: 12,
-                              letterSpacing: 0,
-                            ),
-                          ),
-                        ),
+                        const Spacer(),
                         _CacheStatusPill(point: point),
                       ],
                     ),
@@ -1489,6 +1757,18 @@ class _PointManagerTile extends StatelessWidget {
                   key: ValueKey('point-manager-actions-${point.id}'),
                   tooltip: '点位操作',
                   enabled: !isBusy,
+                  icon: const Icon(Icons.more_vert),
+                  position: PopupMenuPosition.under,
+                  offset: const Offset(0, 6),
+                  elevation: 8,
+                  shadowColor: Colors.black.withValues(alpha: 0.16),
+                  color: AppColors.surface,
+                  surfaceTintColor: Colors.transparent,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: BorderSide(color: AppColors.border),
+                  ),
+                  constraints: const BoxConstraints(minWidth: 0, maxWidth: 128),
                   onSelected: (value) {
                     switch (value) {
                       case 'move':
@@ -1504,25 +1784,88 @@ class _PointManagerTile extends StatelessWidget {
                     }
                   },
                   itemBuilder: (context) => [
-                    const PopupMenuItem(value: 'move', child: Text('移动到片区')),
+                    PopupMenuItem(
+                      value: 'move',
+                      height: 42,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: const _PointActionRow(
+                        icon: Icons.drive_file_move_outlined,
+                        label: '移动到片区',
+                      ),
+                    ),
                     if (status != VisitStatus.current)
-                      const PopupMenuItem(
+                      PopupMenuItem(
                         value: 'current',
-                        child: Text('设为当前'),
+                        height: 42,
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        child: const _PointActionRow(
+                          icon: Icons.flag_outlined,
+                          label: '设为当前目标',
+                        ),
                       ),
                     PopupMenuItem(
                       value: 'complete',
-                      child: Text(
-                        status == VisitStatus.completed ? '取消完成' : '标记完成',
+                      height: 42,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: _PointActionRow(
+                        icon: status == VisitStatus.completed
+                            ? Icons.restart_alt
+                            : Icons.check_outlined,
+                        label: status == VisitStatus.completed
+                            ? '取消完成'
+                            : '标记完成',
                       ),
                     ),
-                    const PopupMenuItem(value: 'delete', child: Text('删除点位')),
+                    const PopupMenuDivider(),
+                    PopupMenuItem(
+                      value: 'delete',
+                      height: 42,
+                      padding: const EdgeInsets.symmetric(horizontal: 8),
+                      child: const _PointActionRow(
+                        icon: Icons.delete_outline,
+                        label: '删除点位',
+                        destructive: true,
+                      ),
+                    ),
                   ],
                 ),
             ],
           ),
         ),
       ),
+    );
+  }
+}
+
+class _PointActionRow extends StatelessWidget {
+  const _PointActionRow({
+    required this.icon,
+    required this.label,
+    this.destructive = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool destructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = destructive ? AppColors.error : AppColors.textPrimary;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 6),
+        Text(
+          label,
+          style: TextStyle(
+            color: color,
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0,
+          ),
+        ),
+      ],
     );
   }
 }
@@ -1612,7 +1955,7 @@ class _PointLeadingControl extends StatelessWidget {
     return ReorderableDragStartListener(
       index: index,
       enabled: !isBusy,
-      child: const SizedBox(
+      child: SizedBox(
         width: 42,
         child: Center(
           child: Icon(Icons.drag_indicator, color: AppColors.textSecondary),
@@ -1650,110 +1993,112 @@ class _BatchActionBar extends StatelessWidget {
     final hasSelection = selectedCount > 0;
     return SafeArea(
       top: false,
-      child: Container(
-        margin: const EdgeInsets.all(12),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        decoration: BoxDecoration(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Material(
           color: AppColors.surface,
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: AppColors.border),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.08),
-              blurRadius: 16,
-              offset: const Offset(0, 6),
+          elevation: 8,
+          shadowColor: Colors.black.withValues(alpha: 0.16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+            side: BorderSide(color: AppColors.border),
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            child: Row(
+              children: [
+                IconButton(
+                  tooltip: allSelected ? '清空' : '全选',
+                  onPressed: isBusy
+                      ? null
+                      : allSelected
+                      ? onClear
+                      : onSelectAll,
+                  icon: Icon(
+                    allSelected
+                        ? Icons.check_box
+                        : Icons.check_box_outline_blank,
+                  ),
+                ),
+                Text(
+                  '$selectedCount',
+                  style: const TextStyle(fontWeight: FontWeight.w800),
+                ),
+                const Spacer(),
+                _BatchActionButton(
+                  icon: Icons.drive_file_move_outlined,
+                  label: '移动',
+                  onPressed: isBusy || !hasSelection ? null : onMove,
+                ),
+                _BatchActionButton(
+                  icon: Icons.check_outlined,
+                  label: '完成',
+                  onPressed: isBusy || !hasSelection ? null : onComplete,
+                ),
+                _BatchActionButton(
+                  icon: Icons.restart_alt,
+                  label: '重置',
+                  onPressed: isBusy || !hasSelection ? null : onReopen,
+                ),
+                _BatchActionButton(
+                  icon: Icons.delete_outline,
+                  label: '删除',
+                  color: AppColors.error,
+                  onPressed: isBusy || !hasSelection ? null : onDelete,
+                ),
+              ],
             ),
-          ],
-        ),
-        child: Row(
-          children: [
-            IconButton(
-              tooltip: allSelected ? '清空' : '全选',
-              onPressed: isBusy
-                  ? null
-                  : allSelected
-                  ? onClear
-                  : onSelectAll,
-              icon: Icon(
-                allSelected ? Icons.check_box : Icons.check_box_outline_blank,
-              ),
-            ),
-            Text(
-              '$selectedCount',
-              style: const TextStyle(fontWeight: FontWeight.w800),
-            ),
-            const Spacer(),
-            IconButton(
-              tooltip: '移动片区',
-              onPressed: isBusy || !hasSelection ? null : onMove,
-              icon: const Icon(Icons.drive_file_move_outlined),
-            ),
-            IconButton(
-              tooltip: '标记完成',
-              onPressed: isBusy || !hasSelection ? null : onComplete,
-              icon: const Icon(Icons.check_outlined),
-            ),
-            IconButton(
-              tooltip: '重置',
-              onPressed: isBusy || !hasSelection ? null : onReopen,
-              icon: const Icon(Icons.restart_alt),
-            ),
-            IconButton(
-              tooltip: '删除',
-              onPressed: isBusy || !hasSelection ? null : onDelete,
-              icon: const Icon(Icons.delete_outline),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _SheetTitle extends StatelessWidget {
-  const _SheetTitle({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: Text(
-        title,
-        style: const TextStyle(
-          fontSize: 18,
-          fontWeight: FontWeight.w800,
-          letterSpacing: 0,
+          ),
         ),
       ),
     );
   }
 }
 
-class _OrderModeTile extends StatelessWidget {
-  const _OrderModeTile({
-    required this.title,
-    required this.selected,
-    required this.onTap,
+class _BatchActionButton extends StatelessWidget {
+  const _BatchActionButton({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    this.color,
   });
 
-  final String title;
-  final bool selected;
-  final VoidCallback onTap;
+  final IconData icon;
+  final String label;
+  final VoidCallback? onPressed;
+  final Color? color;
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      child: ListTile(
-        contentPadding: EdgeInsets.zero,
-        leading: Icon(
-          selected ? Icons.radio_button_checked : Icons.radio_button_unchecked,
-          color: selected ? AppColors.accent : AppColors.textSecondary,
+    final enabled = onPressed != null;
+    final foreground = enabled
+        ? (color ?? AppColors.textPrimary)
+        : AppColors.textSecondary;
+    return Tooltip(
+      message: label,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 22, color: foreground),
+              const SizedBox(height: 2),
+              Text(
+                label,
+                style: TextStyle(
+                  color: foreground,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 0,
+                ),
+              ),
+            ],
+          ),
         ),
-        title: Text(title),
-        onTap: onTap,
       ),
     );
   }
@@ -1833,10 +2178,10 @@ class _GroupAnchorMapPickerScreenState
         leading: appBackButtonIfCanPop(context),
         title: const Text('选择关键点'),
         actions: [
-          TextButton(
-            onPressed: () =>
-                Navigator.of(context).pop(const _GroupAnchorSelection.clear()),
-            child: const Text('清除'),
+          ClearAnchorSelectionButton(
+            onPressed: _selectedPoint == null && _manualPosition == null
+                ? null
+                : _confirmClearSelection,
           ),
         ],
       ),
@@ -1973,6 +2318,23 @@ class _GroupAnchorMapPickerScreenState
     return LatLng(latitude, longitude);
   }
 
+  Future<void> _confirmClearSelection() async {
+    final confirmed = await showConfirmActionDialog(
+      context,
+      title: '清除选点',
+      message: '将清除当前选择的关键点，可继续在本页重新选择。',
+      confirmLabel: '清除选点',
+    );
+    if (!confirmed || !mounted) {
+      return;
+    }
+    setState(() {
+      _selectedPoint = null;
+      _manualPosition = null;
+      _manualPickMode = false;
+    });
+  }
+
   void _selectPoint(PilgrimagePoint point) {
     setState(() {
       _selectedPoint = point;
@@ -1985,66 +2347,10 @@ class _GroupAnchorMapPickerScreenState
   Future<void> _showCoordinateInput() async {
     final current =
         _manualPosition ?? _selectedPoint?.position ?? _pointsCenter;
-    final latitudeController = TextEditingController(
-      text: current.latitude.toStringAsFixed(6),
-    );
-    final longitudeController = TextEditingController(
-      text: current.longitude.toStringAsFixed(6),
-    );
-    final result = await showDialog<LatLng>(
+    final result = await showCoordinateInputDialog(
       context: context,
-      builder: (context) {
-        return AppInputDialog(
-          title: '输入经纬度',
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppDialogField(
-                label: '纬度',
-                child: TextField(
-                  onTapOutside: dismissKeyboardOnTapOutside,
-                  controller: latitudeController,
-                  keyboardType: const TextInputType.numberWithOptions(
-                    signed: true,
-                    decimal: true,
-                  ),
-                  decoration: appDialogInputDecoration(),
-                ),
-              ),
-              const SizedBox(height: 14),
-              AppDialogField(
-                label: '经度',
-                child: TextField(
-                  onTapOutside: dismissKeyboardOnTapOutside,
-                  controller: longitudeController,
-                  keyboardType: const TextInputType.numberWithOptions(
-                    signed: true,
-                    decimal: true,
-                  ),
-                  decoration: appDialogInputDecoration(),
-                ),
-              ),
-            ],
-          ),
-          confirmLabel: '确定',
-          onConfirm: () {
-            final latitude = double.tryParse(latitudeController.text.trim());
-            final longitude = double.tryParse(longitudeController.text.trim());
-            if (latitude == null ||
-                longitude == null ||
-                latitude < -90 ||
-                latitude > 90 ||
-                longitude < -180 ||
-                longitude > 180) {
-              return;
-            }
-            Navigator.of(context).pop(LatLng(latitude, longitude));
-          },
-        );
-      },
+      current: current,
     );
-    latitudeController.dispose();
-    longitudeController.dispose();
     if (result == null || !mounted) {
       return;
     }
@@ -2209,7 +2515,7 @@ class _AnchorSelectionCard extends StatelessWidget {
                       : '$subtitle\n${position.latitude.toStringAsFixed(5)}, ${position.longitude.toStringAsFixed(5)}',
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 12,
                     letterSpacing: 0,
@@ -2231,7 +2537,7 @@ class _EmptyPlanManager extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
+    return Center(
       child: Text(
         '还没有可以管理的点位',
         style: TextStyle(

--- a/lib/plan/reference_cache_progress_dialog.dart
+++ b/lib/plan/reference_cache_progress_dialog.dart
@@ -1,0 +1,313 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../app_theme.dart';
+import '../widgets/app_status_banner.dart';
+import 'reference_full_cache_runner.dart';
+
+Future<void> showReferenceCacheProgressDialog({
+  required BuildContext context,
+  required Future<void> Function(
+    void Function(ReferenceFullCacheProgress progress) onProgress,
+  )
+  run,
+}) async {
+  final runDone = Completer<void>();
+  var runStarted = false;
+
+  await showStatusBannerOverlay(
+    context: context,
+    builder: (dialogContext) {
+      return ReferenceCacheProgressDialog(
+        run: (onProgress) async {
+          runStarted = true;
+          try {
+            await run(onProgress);
+          } finally {
+            if (!runDone.isCompleted) {
+              runDone.complete();
+            }
+          }
+        },
+      );
+    },
+  );
+
+  if (runStarted) {
+    await runDone.future;
+  }
+}
+
+Future<void> showReferenceCacheBannerDebugPreview(BuildContext context) {
+  return showStatusBannerOverlay(
+    context: context,
+    builder: (dialogContext) {
+      return SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _CacheBannerCard(
+              bannerKey: const ValueKey('reference-cache-debug-running'),
+              status: _CacheDialogStatus.running,
+              total: 18,
+              processed: 8,
+              succeeded: 8,
+              failed: 0,
+            ),
+            const SizedBox(height: 8),
+            _CacheBannerCard(
+              bannerKey: const ValueKey('reference-cache-debug-success'),
+              status: _CacheDialogStatus.success,
+              total: 18,
+              processed: 18,
+              succeeded: 18,
+              failed: 0,
+            ),
+            const SizedBox(height: 8),
+            _CacheBannerCard(
+              bannerKey: const ValueKey('reference-cache-debug-partial'),
+              status: _CacheDialogStatus.partial,
+              total: 18,
+              processed: 18,
+              succeeded: 14,
+              failed: 4,
+            ),
+            const SizedBox(height: 8),
+            _CacheBannerCard(
+              bannerKey: const ValueKey('reference-cache-debug-failed'),
+              status: _CacheDialogStatus.failed,
+              total: 18,
+              processed: 18,
+              succeeded: 0,
+              failed: 18,
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+class ReferenceCacheProgressDialog extends StatefulWidget {
+  const ReferenceCacheProgressDialog({
+    required this.run,
+    super.key,
+  });
+
+  final Future<void> Function(
+    void Function(ReferenceFullCacheProgress progress) onProgress,
+  )
+  run;
+
+  @override
+  State<ReferenceCacheProgressDialog> createState() =>
+      _ReferenceCacheProgressDialogState();
+}
+
+enum _CacheDialogStatus { running, success, partial, failed }
+
+class _ReferenceCacheProgressDialogState
+    extends State<ReferenceCacheProgressDialog> {
+  var _isRunning = true;
+  ReferenceFullCacheProgress? _progress;
+
+  _CacheDialogStatus get _status {
+    final progress = _progress;
+    if (_isRunning || progress == null || !progress.done) {
+      return _CacheDialogStatus.running;
+    }
+    if (progress.failed == 0) {
+      return _CacheDialogStatus.success;
+    }
+    if (progress.succeeded == 0) {
+      return _CacheDialogStatus.failed;
+    }
+    return _CacheDialogStatus.partial;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        _start();
+      }
+    });
+  }
+
+  Future<void> _start() async {
+    setState(() {
+      _isRunning = true;
+      final previous = _progress;
+      if (previous != null && previous.done) {
+        _progress = ReferenceFullCacheProgress(total: previous.total);
+      }
+    });
+    try {
+      await widget.run((progress) {
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _progress = progress;
+        });
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      final current = _progress;
+      setState(() {
+        _progress = ReferenceFullCacheProgress(
+          total: current?.total ?? 0,
+          processed: current?.processed ?? 0,
+          succeeded: current?.succeeded ?? 0,
+          failed: (current?.failed ?? 0) > 0
+              ? current!.failed
+              : (current?.total ?? 0),
+          done: true,
+        );
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isRunning = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final status = _status;
+    final progress = _progress;
+    return _CacheBannerCard(
+      bannerKey: const ValueKey('reference-cache-progress-dialog'),
+      status: status,
+      total: progress?.total ?? 0,
+      processed: progress?.processed ?? 0,
+      succeeded: progress?.succeeded ?? 0,
+      failed: progress?.failed ?? 0,
+      onRetry:
+          status == _CacheDialogStatus.partial ||
+              status == _CacheDialogStatus.failed
+          ? _start
+          : null,
+    );
+  }
+}
+
+class _CacheBannerCard extends StatelessWidget {
+  const _CacheBannerCard({
+    required this.bannerKey,
+    required this.status,
+    required this.total,
+    required this.processed,
+    required this.succeeded,
+    required this.failed,
+    this.onRetry,
+  });
+
+  final Key bannerKey;
+  final _CacheDialogStatus status;
+  final int total;
+  final int processed;
+  final int succeeded;
+  final int failed;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final fraction = total == 0 ? 0.0 : (processed / total).clamp(0.0, 1.0);
+    final percent = (fraction * 100).round();
+    final kind = switch (status) {
+      _CacheDialogStatus.running => AppStatusBannerKind.running,
+      _CacheDialogStatus.success => AppStatusBannerKind.success,
+      _CacheDialogStatus.partial => AppStatusBannerKind.warning,
+      _CacheDialogStatus.failed => AppStatusBannerKind.error,
+    };
+    final retryLabel = switch (status) {
+      _CacheDialogStatus.failed => '重试全部',
+      _CacheDialogStatus.partial => '重试失败',
+      _ => null,
+    };
+
+    return AppStatusBanner(
+      key: bannerKey,
+      kind: kind,
+      icon: status == _CacheDialogStatus.running
+          ? Icons.cached_outlined
+          : null,
+      title: _titleFor(status),
+      subtitle: status == _CacheDialogStatus.running
+          ? null
+          : _subtitleFor(
+              status: status,
+              total: total,
+              succeeded: succeeded,
+              failed: failed,
+            ),
+      subtitleWidget: status == _CacheDialogStatus.running
+          ? AppStatusBannerProgressLine(
+              countLabel: '$processed / $total',
+              percentLabel: '$percent%',
+              value: fraction,
+              barKey: const ValueKey('reference-cache-progress-bar'),
+            )
+          : null,
+      actionLabel: retryLabel,
+      onAction: onRetry,
+      actionKey: retryLabel == null
+          ? null
+          : const ValueKey('reference-cache-retry'),
+      footer: status == _CacheDialogStatus.running
+          ? Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  Icons.info_outline,
+                  size: 15,
+                  color: AppColors.textSecondary,
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    '提示：缓存过程中请保持网络连接，避免切换页面或锁屏。',
+                    style: TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 11,
+                      height: 1.3,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                ),
+              ],
+            )
+          : null,
+    );
+  }
+}
+
+String _titleFor(_CacheDialogStatus status) {
+  return switch (status) {
+    _CacheDialogStatus.running => '正在缓存参考图...',
+    _CacheDialogStatus.success => '参考图缓存完成',
+    _CacheDialogStatus.partial => '参考图缓存完成',
+    _CacheDialogStatus.failed => '参考图缓存失败',
+  };
+}
+
+String _subtitleFor({
+  required _CacheDialogStatus status,
+  required int total,
+  required int succeeded,
+  required int failed,
+}) {
+  return switch (status) {
+    _CacheDialogStatus.running => '$succeeded / $total',
+    _CacheDialogStatus.success => '$succeeded / $total 张成功，已保存到本地',
+    _CacheDialogStatus.partial ||
+    _CacheDialogStatus.failed => '$succeeded / $total 张成功 · $failed 张失败',
+  };
+}

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -7,6 +7,7 @@ import '../widgets/copyable_text.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/snackbar_helper.dart';
 import '../widgets/app_scaled_route.dart';
+import '../widgets/app_back_button.dart';
 import 'add_points_screen.dart';
 import 'pilgrimage_models.dart';
 import 'pilgrimage_work_cover.dart';
@@ -49,10 +50,8 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
+          leading: AppBackButton(
             onPressed: () => Navigator.of(context).pop(_didUpdate),
-            icon: const Icon(Icons.arrow_back),
           ),
           title: const Text('作品管理'),
         ),
@@ -116,7 +115,7 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
     }
   }
 
-  Future<void> _confirmDeleteWork(PilgrimageWork work) async {
+  Future<bool> _confirmDeleteWork(PilgrimageWork work) async {
     final pointCount = _plan.points
         .where((point) => point.work.id == work.id)
         .length;
@@ -131,7 +130,7 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
       emphasizedValues: [work.title],
     );
     if (!confirmed || !mounted) {
-      return;
+      return false;
     }
 
     setState(() => _isSaving = true);
@@ -141,7 +140,7 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
         workId: work.id,
       );
       if (!mounted) {
-        return;
+        return false;
       }
 
       setState(() {
@@ -149,15 +148,17 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
         _didUpdate = true;
         _isSaving = false;
       });
+      return true;
     } catch (_) {
       if (!mounted) {
-        return;
+        return false;
       }
 
       setState(() => _isSaving = false);
       ScaffoldMessenger.of(
         context,
       ).showReplacingSnackBar(const SnackBar(content: Text('作品删除失败')));
+      return false;
     }
   }
 
@@ -338,7 +339,6 @@ class _WorkManageCardState extends State<_WorkManageCard> {
         !subtitle.startsWith('Bangumi #') &&
         subtitle != 'Manual Work' &&
         subtitle != '暂无作品原名';
-    final isBangumiWork = work.bangumiId != null;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
@@ -392,40 +392,99 @@ class _WorkManageCardState extends State<_WorkManageCard> {
                   ),
                 ),
                 const SizedBox(height: 6),
-                Wrap(
-                  spacing: 6,
-                  runSpacing: 4,
-                  crossAxisAlignment: WrapCrossAlignment.center,
-                  children: [
-                    if (work.displayBangumiSubjectType != null)
-                      _WorkManageBadge(
-                        label: work.displayBangumiSubjectType!.label,
-                      ),
-                    _WorkManageBadge(
-                      label: isBangumiWork ? 'Bangumi' : '手动添加',
-                      emphasized: isBangumiWork,
-                    ),
-                    _WorkManageBadge(label: '$pointCount 个点位'),
-                  ],
+                _WorkBadges(
+                  key: ValueKey('work-manage-badges-${work.id}'),
+                  work: work,
+                  pointCount: pointCount,
                 ),
               ],
             ),
           ),
           const SizedBox(width: 12),
-          OutlinedButton(
-            onPressed: widget.disabled ? null : widget.onDelete,
-            style: OutlinedButton.styleFrom(
-              minimumSize: const Size(88, 40),
-              padding: const EdgeInsets.symmetric(horizontal: 14),
-              foregroundColor: Colors.redAccent,
-              side: BorderSide(
-                color: widget.disabled
-                    ? AppColors.border
-                    : Colors.redAccent.withValues(alpha: 0.65),
+          PopupMenuButton<String>(
+            key: ValueKey('work-manage-more-${work.id}'),
+            tooltip: '更多操作',
+            enabled: !widget.disabled,
+            icon: const Icon(Icons.more_horiz),
+            iconSize: 20,
+            padding: EdgeInsets.zero,
+            position: PopupMenuPosition.under,
+            offset: const Offset(0, 6),
+            elevation: 8,
+            shadowColor: Colors.black.withValues(alpha: 0.16),
+            color: AppColors.surface,
+            surfaceTintColor: Colors.transparent,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: const BorderSide(color: AppColors.border),
+            ),
+            constraints: const BoxConstraints(minWidth: 148, maxWidth: 180),
+            style: IconButton.styleFrom(
+              minimumSize: const Size.square(34),
+              maximumSize: const Size.square(34),
+              padding: EdgeInsets.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(6),
               ),
             ),
-            child: const Text('删除'),
+            onSelected: (_) => widget.onDelete(),
+            itemBuilder: (context) => [
+              const PopupMenuItem<String>(
+                key: ValueKey('work-action-delete'),
+                value: 'delete',
+                height: 44,
+                padding: EdgeInsets.symmetric(horizontal: 12),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.delete_outline,
+                      size: 18,
+                      color: AppColors.error,
+                    ),
+                    SizedBox(width: 9),
+                    Text(
+                      '删除作品',
+                      style: TextStyle(
+                        color: AppColors.error,
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkBadges extends StatelessWidget {
+  const _WorkBadges({required this.work, required this.pointCount, super.key});
+
+  final PilgrimageWork work;
+  final int pointCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final isBangumiWork = work.bangumiId != null;
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          if (work.displayBangumiSubjectType != null) ...[
+            _WorkManageBadge(label: work.displayBangumiSubjectType!.label),
+            const SizedBox(width: 6),
+          ],
+          _WorkManageBadge(
+            label: isBangumiWork ? 'Bangumi' : '手动添加',
+            emphasized: isBangumiWork,
+          ),
+          const SizedBox(width: 6),
+          _WorkManageBadge(label: '$pointCount 个点位'),
         ],
       ),
     );
@@ -455,6 +514,8 @@ class _WorkManageBadge extends StatelessWidget {
       ),
       child: Text(
         label,
+        maxLines: 1,
+        softWrap: false,
         style: TextStyle(
           color: emphasized ? AppColors.accentDark : AppColors.textSecondary,
           fontSize: 11,

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -157,7 +157,7 @@ class _WorkManagerScreenState extends State<WorkManagerScreen> {
       setState(() => _isSaving = false);
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('作品删除失败')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '作品删除失败');
       return false;
     }
   }
@@ -217,7 +217,7 @@ class _AddWorkPanel extends StatelessWidget {
                 onTap: onBangumi,
               ),
             ),
-            const VerticalDivider(
+            VerticalDivider(
               width: 9,
               indent: 8,
               endIndent: 8,
@@ -290,7 +290,7 @@ class _AddWorkAction extends StatelessWidget {
                         subtitle,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textSecondary,
                           fontSize: 11,
                           letterSpacing: 0,
@@ -416,7 +416,7 @@ class _WorkManageCardState extends State<_WorkManageCard> {
             surfaceTintColor: Colors.transparent,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: AppColors.border),
+              side: BorderSide(color: AppColors.border),
             ),
             constraints: const BoxConstraints(minWidth: 148, maxWidth: 180),
             style: IconButton.styleFrom(
@@ -430,11 +430,11 @@ class _WorkManageCardState extends State<_WorkManageCard> {
             ),
             onSelected: (_) => widget.onDelete(),
             itemBuilder: (context) => [
-              const PopupMenuItem<String>(
-                key: ValueKey('work-action-delete'),
+              PopupMenuItem<String>(
+                key: const ValueKey('work-action-delete'),
                 value: 'delete',
                 height: 44,
-                padding: EdgeInsets.symmetric(horizontal: 12),
+                padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: Row(
                   children: [
                     Icon(
@@ -442,7 +442,7 @@ class _WorkManageCardState extends State<_WorkManageCard> {
                       size: 18,
                       color: AppColors.error,
                     ),
-                    SizedBox(width: 9),
+                    const SizedBox(width: 9),
                     Text(
                       '删除作品',
                       style: TextStyle(
@@ -640,7 +640,7 @@ class _WorkOnboardingStep extends StatelessWidget {
                 children: [
                   Text(
                     title,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textPrimary,
                       fontSize: 16,
                       fontWeight: FontWeight.w800,
@@ -650,7 +650,7 @@ class _WorkOnboardingStep extends StatelessWidget {
                   const SizedBox(height: 5),
                   Text(
                     body,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 13,
                       height: 1.35,

--- a/lib/plan_transfer/import_export_screen.dart
+++ b/lib/plan_transfer/import_export_screen.dart
@@ -154,7 +154,13 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
     if (_exporting) {
       _exportGeneration++;
       setState(() => _exporting = false);
-      messenger.showReplacingSnackBar(const SnackBar(content: Text('已取消导出')));
+      messenger.showReplacingSnackBar(
+        appStatusSnackBar(
+          kind: AppStatusBannerKind.running,
+          title: '已取消导出',
+          icon: Icons.cancel_outlined,
+        ),
+      );
     }
     Navigator.of(context).pop();
   }
@@ -211,8 +217,9 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
       if (!mounted) {
         return;
       }
-      messenger.showReplacingSnackBar(
-        const SnackBar(content: Text('导入文件读取失败')),
+      messenger.showStatusSnack(
+        kind: AppStatusBannerKind.error,
+        title: '导入文件读取失败',
       );
     } finally {
       if (mounted) {
@@ -222,21 +229,12 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
   }
 
   Future<void> _showExternalIosImportHelp() async {
-    await showDialog<void>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('从其他 App 打开 .sjhplan'),
-        content: const Text(
+    await showInfoActionDialog(
+      context,
+      title: '从其他 App 打开 .sjhplan',
+      message:
           '请在文件、聊天、浏览器下载页、网盘或其他保存位置找到 .sjhplan 文件，然后点开文件，或使用分享/更多菜单选择 MiriaGo。\n\n'
           'MiriaGo 收到文件后会自动进入导入预览页面。若列表里没有 MiriaGo，可以先把文件保存到“文件”App，再长按文件选择分享或打开方式。',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('知道了'),
-          ),
-        ],
-      ),
     );
   }
 
@@ -408,24 +406,40 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
     final messenger = ScaffoldMessenger.of(context);
     final generation = ++_exportGeneration;
     setState(() => _exporting = true);
-    messenger.showReplacingSnackBar(const SnackBar(content: Text('正在导出...')));
+    messenger.showReplacingSnackBar(
+      appStatusSnackBar(
+        kind: AppStatusBannerKind.running,
+        title: '正在导出...',
+        icon: Icons.ios_share_outlined,
+      ),
+    );
     try {
       final result = await action(generation);
       if (!_isCurrentExport(generation)) {
         return;
       }
       if (result.delivery.action == PlanExportDeliveryAction.canceled) {
-        messenger.showReplacingSnackBar(const SnackBar(content: Text('已取消导出')));
+        messenger.showReplacingSnackBar(
+          appStatusSnackBar(
+            kind: AppStatusBannerKind.running,
+            title: '已取消导出',
+            icon: Icons.cancel_outlined,
+          ),
+        );
         return;
       }
-      messenger.showReplacingSnackBar(
-        SnackBar(content: Text(result.successMessage(successMessage))),
-      );
+      messenger.showReplacingSnackBar(result.statusSnackBar(successMessage));
     } on PlanExportCanceledException {
       if (!_isCurrentExport(generation)) {
         return;
       }
-      messenger.showReplacingSnackBar(const SnackBar(content: Text('已取消导出')));
+      messenger.showReplacingSnackBar(
+        appStatusSnackBar(
+          kind: AppStatusBannerKind.running,
+          title: '已取消导出',
+          icon: Icons.cancel_outlined,
+        ),
+      );
     } on _ExportAbortedException {
       return;
     } catch (error, stackTrace) {
@@ -434,7 +448,13 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
       if (!_isCurrentExport(generation)) {
         return;
       }
-      messenger.showReplacingSnackBar(const SnackBar(content: Text('导出失败')));
+      messenger.showReplacingSnackBar(
+        appStatusSnackBar(
+          kind: AppStatusBannerKind.error,
+          title: '导出失败',
+          subtitle: '请稍后重试',
+        ),
+      );
     } finally {
       if (_isCurrentExport(generation)) {
         setState(() => _exporting = false);
@@ -462,15 +482,24 @@ class _PlanExportRunResult {
   final List<String> warnings;
   final Map<String, int> warningCounts;
 
-  String successMessage(String fallback) {
+  SnackBar statusSnackBar(String title) {
     if (warnings.isEmpty) {
-      return fallback;
+      return appStatusSnackBar(
+        kind: AppStatusBannerKind.success,
+        title: title,
+        subtitle: switch (delivery.action) {
+          PlanExportDeliveryAction.saved => '已保存到本地',
+          PlanExportDeliveryAction.shared => '已通过系统分享送出',
+          PlanExportDeliveryAction.canceled => null,
+        },
+      );
     }
     final summary = _warningSummary(warningCounts);
-    if (summary.isEmpty) {
-      return '$fallback，部分资源未能加入';
-    }
-    return '$fallback，$summary';
+    return appStatusSnackBar(
+      kind: AppStatusBannerKind.warning,
+      title: title,
+      subtitle: summary.isEmpty ? '部分资源未能加入' : summary,
+    );
   }
 }
 
@@ -541,7 +570,7 @@ class _PlanExportSummary extends StatelessWidget {
                 const SizedBox(height: 3),
                 Text(
                   '${plan.groups.length} 个片区 / ${plan.points.length} 个点位',
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 13,
                     letterSpacing: 0,
@@ -589,7 +618,7 @@ class _SectionTitle extends StatelessWidget {
               const SizedBox(height: 2),
               Text(
                 subtitle,
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 12,
                   letterSpacing: 0,
@@ -717,7 +746,7 @@ class _ExportSizeEstimateRow extends StatelessWidget {
         Expanded(
           child: Text(
             estimating ? '正在估算数据包大小...' : estimate?.label ?? '预计数据包大小：暂时无法估算',
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 12,
               fontWeight: FontWeight.w700,
@@ -783,7 +812,7 @@ class _ActionTile extends StatelessWidget {
                     const SizedBox(height: 2),
                     Text(
                       subtitle,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textSecondary,
                         fontSize: 12,
                         letterSpacing: 0,

--- a/lib/plan_transfer/import_export_screen.dart
+++ b/lib/plan_transfer/import_export_screen.dart
@@ -8,6 +8,7 @@ import '../platform/platform_flags_stub.dart'
 import '../plan/pilgrimage_models.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/app_back_button.dart';
 import 'my_maps_csv_export.dart';
 import 'plan_export_delivery.dart';
 import 'plan_export_delivery_result.dart';
@@ -68,11 +69,7 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: IconButton(
-            tooltip: '返回',
-            onPressed: _handleBack,
-            icon: const Icon(Icons.arrow_back),
-          ),
+          leading: AppBackButton(onPressed: _handleBack),
           title: const Text('导入导出'),
         ),
         body: ListView(

--- a/lib/plan_transfer/plan_import_preview_screen.dart
+++ b/lib/plan_transfer/plan_import_preview_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
 import '../widgets/app_back_button.dart';
+import '../widgets/snackbar_helper.dart';
 import 'plan_import_asset_restore.dart';
 import 'plan_import_package.dart';
 
@@ -96,7 +97,7 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
                 padding: const EdgeInsets.only(bottom: 6),
                 child: Text(
                   warning,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 12,
                     letterSpacing: 0,
@@ -143,14 +144,13 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            restored.warnings.isEmpty
-                ? '已导入计划「${importedPlan.name}」'
-                : '已导入计划「${importedPlan.name}」，部分资源未恢复',
-          ),
-        ),
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: restored.warnings.isEmpty
+            ? AppStatusBannerKind.success
+            : AppStatusBannerKind.warning,
+        title: restored.warnings.isEmpty
+            ? '已导入计划「${importedPlan.name}」'
+            : '已导入计划「${importedPlan.name}」，部分资源未恢复',
       );
       Navigator.of(context).pop(true);
     } catch (_) {
@@ -159,7 +159,7 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
       }
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('导入失败')));
+      ).showStatusSnack(kind: AppStatusBannerKind.error, title: '导入失败');
     } finally {
       if (mounted) {
         setState(() => _importing = false);
@@ -229,7 +229,7 @@ class _PackageHeader extends StatelessWidget {
                   '${importPackage.versionLabel} / ${importPackage.sourceName}',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 12,
                     letterSpacing: 0,
@@ -290,7 +290,7 @@ class _StatChip extends StatelessWidget {
       ),
       child: Text(
         '$label $value',
-        style: const TextStyle(
+        style: TextStyle(
           color: AppColors.textPrimary,
           fontWeight: FontWeight.w700,
           fontSize: 12,
@@ -334,7 +334,7 @@ class _SectionTitle extends StatelessWidget {
               const SizedBox(height: 2),
               Text(
                 subtitle,
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 12,
                   letterSpacing: 0,
@@ -395,7 +395,7 @@ class _ImportOptionTile extends StatelessWidget {
                 const SizedBox(height: 2),
                 Text(
                   subtitle,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 12,
                     letterSpacing: 0,

--- a/lib/plan_transfer/plan_import_preview_screen.dart
+++ b/lib/plan_transfer/plan_import_preview_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
+import '../widgets/app_back_button.dart';
 import 'plan_import_asset_restore.dart';
 import 'plan_import_package.dart';
 
@@ -32,7 +33,10 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('导入内容')),
+      appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
+        title: const Text('导入内容'),
+      ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         children: [

--- a/lib/point_detail/point_detail_sheet.dart
+++ b/lib/point_detail/point_detail_sheet.dart
@@ -4,9 +4,11 @@ import 'package:image_picker/image_picker.dart';
 import '../app_theme.dart';
 import '../data/user_reference_image_stub.dart'
     if (dart.library.io) '../data/user_reference_image_io.dart';
+import '../map/navigation_route_confirm_screen.dart';
 import '../widgets/snackbar_helper.dart';
 import '../map/map_navigation_launcher.dart';
 import '../plan/pilgrimage_models.dart';
+import '../plan/pilgrimage_plan_controller.dart';
 import '../plan/plan_group_picker_sheet.dart';
 import '../plan/plan_group_utils.dart';
 import '../records/visit_record_photo_stub.dart'
@@ -38,6 +40,8 @@ class PointDetailSheet extends StatelessWidget {
     this.onEditPoint,
     this.navigationApp = NavigationApp.googleMaps,
     this.navigationLauncher = const MapNavigationLauncher(),
+    this.settings = const AppSettings(),
+    this.planController,
     super.key,
   });
 
@@ -63,6 +67,8 @@ class PointDetailSheet extends StatelessWidget {
   final VoidCallback? onEditPoint;
   final NavigationApp navigationApp;
   final MapNavigationLauncher navigationLauncher;
+  final AppSettings settings;
+  final PilgrimagePlanController? planController;
 
   static Future<void> show(
     BuildContext context, {
@@ -87,6 +93,8 @@ class PointDetailSheet extends StatelessWidget {
     ValueChanged<PilgrimageVisitRecord>? onOpenRecord,
     VoidCallback? onEditPoint,
     NavigationApp navigationApp = NavigationApp.googleMaps,
+    AppSettings settings = const AppSettings(),
+    PilgrimagePlanController? planController,
   }) {
     return showModalBottomSheet<void>(
       context: context,
@@ -111,6 +119,8 @@ class PointDetailSheet extends StatelessWidget {
           onOpenRecord: onOpenRecord,
           onEditPoint: onEditPoint,
           navigationApp: navigationApp,
+          settings: settings,
+          planController: planController,
         );
       },
     );
@@ -124,16 +134,19 @@ class PointDetailSheet extends StatelessWidget {
       return;
     }
 
-    messenger.showReplacingSnackBar(
-      const SnackBar(content: Text('正在替换参考图...')),
+    messenger.showStatusSnack(
+      kind: AppStatusBannerKind.running,
+      title: '正在替换参考图...',
+      icon: Icons.swap_horiz_outlined,
     );
     final stored = await storeUserReferenceImage(
       sourcePath: picked.path,
       pointId: point.id,
     );
     if (stored == null || !context.mounted) {
-      messenger.showReplacingSnackBar(
-        const SnackBar(content: Text('参考图替换失败，请稍后重试。')),
+      messenger.showStatusSnack(
+        kind: AppStatusBannerKind.error,
+        title: '参考图替换失败，请稍后重试。',
       );
       return;
     }
@@ -143,17 +156,25 @@ class PointDetailSheet extends StatelessWidget {
       return;
     }
 
-    messenger.showReplacingSnackBar(const SnackBar(content: Text('已替换参考图')));
+    messenger.showStatusSnack(kind: AppStatusBannerKind.success, title: '已替换参考图');
     navigator.pop();
   }
 
-  Future<void> _openNavigation(BuildContext context) async {
-    final opened = await navigationLauncher.openWalking(point, navigationApp);
-    if (!opened && context.mounted) {
-      ScaffoldMessenger.of(context).showReplacingSnackBar(
-        SnackBar(content: Text('无法打开${navigationApp.label}。')),
-      );
+  Future<void> _openInAppNavigation(BuildContext context) async {
+    if (!point.hasCoordinate) {
+      return;
     }
+    final navigator = Navigator.of(context);
+    final tour = inAppNavigationTourFor(point: point, buckets: groupBuckets);
+    final route = NavigationRouteConfirmScreen.route(
+      point: point,
+      settings: settings,
+      groupName: tour.groupName,
+      stops: tour.stops,
+      planController: planController,
+    );
+    navigator.pop();
+    await navigator.push<void>(route);
   }
 
   Future<void> _showMoveGroupSheet(BuildContext context) async {
@@ -252,7 +273,7 @@ class PointDetailSheet extends StatelessWidget {
                             '${point.work.title} / ${point.subtitle}',
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: AppColors.textSecondary,
                               fontSize: 13,
                               letterSpacing: 0,
@@ -350,7 +371,7 @@ class PointDetailSheet extends StatelessWidget {
                   scope: actionScope,
                   status: status,
                   onOpenNavigation: point.hasCoordinate
-                      ? () => _openNavigation(context)
+                      ? () => _openInAppNavigation(context)
                       : null,
                   onOpenCamera: onOpenCamera == null
                       ? null
@@ -463,6 +484,7 @@ class _PointDetailActions extends StatelessWidget {
     final primaryActions = <Widget>[
       Expanded(
         child: FilledButton.icon(
+          key: const ValueKey('point-detail-in-app-navigation-button'),
           onPressed: onOpenNavigation,
           icon: const Icon(Icons.near_me_outlined, size: 18),
           label: Text(onOpenNavigation == null ? '坐标待补充' : '导航'),
@@ -633,13 +655,13 @@ class _GroupInfoRow extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Icon(
+        Icon(
           Icons.grid_view_outlined,
           color: AppColors.textSecondary,
           size: 19,
         ),
         const SizedBox(width: 8),
-        const SizedBox(
+        SizedBox(
           width: 42,
           child: Text(
             '片区',
@@ -659,7 +681,7 @@ class _GroupInfoRow extends StatelessWidget {
               CopyableText(
                 text: groupName,
                 copyLabel: '片区',
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textPrimary,
                   fontSize: 13,
                   letterSpacing: 0,
@@ -669,7 +691,7 @@ class _GroupInfoRow extends StatelessWidget {
               CopyableText(
                 text: anchorLabel,
                 copyLabel: '片区关键点',
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 12,
                   letterSpacing: 0,
@@ -761,7 +783,7 @@ class _InfoRow extends StatelessWidget {
           width: 42,
           child: Text(
             label,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 13,
               fontWeight: FontWeight.w700,
@@ -774,7 +796,7 @@ class _InfoRow extends StatelessWidget {
           child: CopyableText(
             text: value,
             copyLabel: label,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textPrimary,
               fontSize: 13,
               letterSpacing: 0,
@@ -806,7 +828,7 @@ class _PointRecordsPreview extends StatelessWidget {
       children: [
         Row(
           children: [
-            const Icon(
+            Icon(
               Icons.collections_bookmark_outlined,
               color: AppColors.textSecondary,
               size: 18,
@@ -857,7 +879,7 @@ class _PointRecordsPreview extends StatelessWidget {
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           textAlign: TextAlign.center,
-                          style: const TextStyle(
+                          style: TextStyle(
                             color: AppColors.textSecondary,
                             fontSize: 11,
                             fontWeight: FontWeight.w700,

--- a/lib/records/comparison_export_config_editor.dart
+++ b/lib/records/comparison_export_config_editor.dart
@@ -237,7 +237,7 @@ class _SummaryChip extends StatelessWidget {
       ),
       child: Text(
         label,
-        style: const TextStyle(
+        style: TextStyle(
           color: AppColors.textSecondary,
           fontSize: 12,
           fontWeight: FontWeight.w600,
@@ -266,7 +266,7 @@ class _ValueCapsule extends StatelessWidget {
       ),
       child: Text(
         label,
-        style: const TextStyle(
+        style: TextStyle(
           color: AppColors.textPrimary,
           fontSize: 13,
           fontWeight: FontWeight.w700,
@@ -317,7 +317,7 @@ class _OutputWidthSelector extends StatelessWidget {
               ),
             ),
             if (index < _fixedWidths.length - 1)
-              const VerticalDivider(
+              VerticalDivider(
                 width: 1,
                 thickness: 1,
                 color: AppColors.surfaceMuted,
@@ -420,7 +420,7 @@ class _ToggleSetting extends StatelessWidget {
             children: [
               Text(
                 title,
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textPrimary,
                   fontSize: 14,
                   fontWeight: FontWeight.w700,
@@ -430,7 +430,7 @@ class _ToggleSetting extends StatelessWidget {
               const SizedBox(height: 3),
               Text(
                 subtitle,
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 12,
                   letterSpacing: 0,
@@ -626,7 +626,7 @@ InputDecoration _comparisonTextFieldDecoration({
     contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
     enabledBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(8),
-      borderSide: const BorderSide(color: AppColors.border),
+      borderSide: BorderSide(color: AppColors.border),
     ),
     disabledBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(8),
@@ -756,11 +756,7 @@ class _SectionDivider extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Divider(
-      height: 1,
-      thickness: 1,
-      color: AppColors.surfaceMuted,
-    );
+    return Divider(height: 1, thickness: 1, color: AppColors.surfaceMuted);
   }
 }
 
@@ -773,7 +769,7 @@ class _FieldLabel extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       label,
-      style: const TextStyle(
+      style: TextStyle(
         color: AppColors.textPrimary,
         fontSize: 14,
         fontWeight: FontWeight.w700,

--- a/lib/records/comparison_export_sheet.dart
+++ b/lib/records/comparison_export_sheet.dart
@@ -4,6 +4,7 @@ import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
 import '../plan/pilgrimage_models.dart';
 import '../widgets/image_viewer_screen.dart';
+import '../widgets/snackbar_helper.dart';
 import 'comparison_export_config.dart';
 import 'comparison_export_config_editor.dart';
 import 'comparison_exporter_stub.dart'
@@ -162,7 +163,10 @@ class _ComparisonExportSheetState extends State<ComparisonExportSheet> {
       setState(() => _exporting = false);
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(SnackBar(content: Text(_failureMessage(result))));
+      ).showStatusSnack(
+        kind: AppStatusBannerKind.error,
+        title: _failureMessage(result),
+      );
     }
   }
 
@@ -222,7 +226,7 @@ class _SheetFooter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DecoratedBox(
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         color: AppColors.surface,
         border: Border(top: BorderSide(color: AppColors.border)),
       ),

--- a/lib/records/point_visit_records_screen.dart
+++ b/lib/records/point_visit_records_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../app_theme.dart';
 import '../plan/pilgrimage_models.dart';
 import '../plan/pilgrimage_plan_controller.dart';
+import '../widgets/app_back_button.dart';
 import 'visit_record_detail_screen.dart';
 import 'visit_record_photo_stub.dart'
     if (dart.library.io) 'visit_record_photo_io.dart';
@@ -34,7 +35,11 @@ class PointVisitRecordsScreen extends StatelessWidget {
             final records = controller.recordsForPoint(point.id);
 
             return Scaffold(
-              appBar: AppBar(title: const Text('点位拍摄记录')),
+              appBar: AppBar(
+                toolbarHeight: 44,
+                leading: appBackButtonIfCanPop(context),
+                title: const Text('点位拍摄记录'),
+              ),
               body: ListView(
                 padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
                 children: [

--- a/lib/records/point_visit_records_screen.dart
+++ b/lib/records/point_visit_records_screen.dart
@@ -138,7 +138,7 @@ class _PointRecordsHeader extends StatelessWidget {
                   '${point.work.title} / ${point.displayEpisodeLabel}',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 13,
                     letterSpacing: 0,
@@ -192,7 +192,7 @@ class _EmptyPointRecords extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.border),
       ),
-      child: const Column(
+      child: Column(
         children: [
           Icon(
             Icons.photo_library_outlined,
@@ -225,7 +225,7 @@ class _PointRecordsListLabel extends StatelessWidget {
         children: [
           Icon(Icons.schedule, color: AppColors.accent, size: 15),
           const SizedBox(width: 6),
-          const Text(
+          Text(
             '拍摄记录',
             style: TextStyle(
               color: AppColors.textPrimary,
@@ -275,7 +275,7 @@ class _RecordCapturedAtText extends StatelessWidget {
             value.date,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 12,
               fontWeight: FontWeight.w600,
@@ -301,7 +301,7 @@ class _PointVisitRecordCard extends StatelessWidget {
       color: AppColors.surface,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(8),
-        side: const BorderSide(color: AppColors.border),
+        side: BorderSide(color: AppColors.border),
       ),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
@@ -338,7 +338,7 @@ class _PointVisitRecordCard extends StatelessWidget {
                   ),
                 ),
               ),
-              const Padding(
+              Padding(
                 padding: EdgeInsets.only(right: 10),
                 child: Icon(
                   Icons.chevron_right,
@@ -376,7 +376,7 @@ class _RecordMetaChip extends StatelessWidget {
           const SizedBox(width: 4),
           Text(
             label,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 12,
               fontWeight: FontWeight.w700,

--- a/lib/records/point_visit_records_screen.dart
+++ b/lib/records/point_visit_records_screen.dart
@@ -36,7 +36,6 @@ class PointVisitRecordsScreen extends StatelessWidget {
 
             return Scaffold(
               appBar: AppBar(
-                toolbarHeight: 44,
                 leading: appBackButtonIfCanPop(context),
                 title: const Text('点位拍摄记录'),
               ),

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -505,7 +505,7 @@ class _RecordFilters extends StatelessWidget {
               onPressed: onOpenScopeFilters,
               style: IconButton.styleFrom(
                 backgroundColor: AppColors.surface,
-                side: const BorderSide(color: AppColors.border),
+                side: BorderSide(color: AppColors.border),
               ),
               icon: const Icon(Icons.tune),
             ),
@@ -635,7 +635,7 @@ class _RecordScopeFilterSheetState extends State<_RecordScopeFilterSheet> {
               Text(
                 '已选：作品 ${_workIds?.length ?? 0} · 片区 ${_groupIds?.length ?? 0}',
                 key: const ValueKey('records-scope-summary'),
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textSecondary,
                   fontSize: 12,
                   fontWeight: FontWeight.w500,
@@ -703,7 +703,7 @@ class _RecordScopeEntry extends StatelessWidget {
       color: AppColors.surface,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(8),
-        side: const BorderSide(color: AppColors.border),
+        side: BorderSide(color: AppColors.border),
       ),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
@@ -728,7 +728,7 @@ class _RecordScopeEntry extends StatelessWidget {
                     ),
                   ),
                 ),
-                const Icon(Icons.chevron_right, color: AppColors.textSecondary),
+                Icon(Icons.chevron_right, color: AppColors.textSecondary),
               ],
             ),
           ),
@@ -852,7 +852,7 @@ class _RecordScopeOptionSheetState extends State<_RecordScopeOptionSheet> {
             ),
             Expanded(
               child: widget.options.isEmpty
-                  ? const Center(
+                  ? Center(
                       child: Text(
                         '暂无可筛选项',
                         style: TextStyle(color: AppColors.textSecondary),
@@ -1039,7 +1039,7 @@ class _RecordScopeOptionTileState extends State<_RecordScopeOptionTile> {
                             widget.option.label,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: AppColors.textPrimary,
                               fontSize: 14,
                               letterSpacing: 0,
@@ -1052,10 +1052,7 @@ class _RecordScopeOptionTileState extends State<_RecordScopeOptionTile> {
                           onChanged: (value) =>
                               widget.onChanged(value ?? false),
                           shape: const CircleBorder(),
-                          side: const BorderSide(
-                            color: AppColors.border,
-                            width: 1.5,
-                          ),
+                          side: BorderSide(color: AppColors.border, width: 1.5),
                           visualDensity: VisualDensity.compact,
                           materialTapTargetSize:
                               MaterialTapTargetSize.shrinkWrap,
@@ -1108,12 +1105,12 @@ class _RecordStatusPickerState extends State<_RecordStatusPicker> {
       alignmentOffset: const Offset(0, 4),
       style: MenuStyle(
         padding: const WidgetStatePropertyAll(EdgeInsets.zero),
-        backgroundColor: const WidgetStatePropertyAll(AppColors.surface),
+        backgroundColor: WidgetStatePropertyAll(AppColors.surface),
         elevation: const WidgetStatePropertyAll(8),
         shadowColor: WidgetStatePropertyAll(
           AppColors.textPrimary.withValues(alpha: 0.14),
         ),
-        side: const WidgetStatePropertyAll(BorderSide(color: AppColors.border)),
+        side: WidgetStatePropertyAll(BorderSide(color: AppColors.border)),
         shape: const WidgetStatePropertyAll(
           RoundedRectangleBorder(
             borderRadius: BorderRadius.all(Radius.circular(8)),
@@ -1128,7 +1125,7 @@ class _RecordStatusPickerState extends State<_RecordStatusPicker> {
             color: AppColors.surface,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(8),
-              side: const BorderSide(color: AppColors.border),
+              side: BorderSide(color: AppColors.border),
             ),
             clipBehavior: Clip.antiAlias,
             child: InkWell(
@@ -1413,7 +1410,7 @@ class _RecordsSectionHeader extends StatelessWidget {
         ),
         Text(
           suffix,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textSecondary,
             fontSize: 13,
             fontWeight: FontWeight.w700,
@@ -1529,7 +1526,7 @@ class _RecordGroupHeaderState extends State<_RecordGroupHeader> {
                                 section.subtitle,
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
+                                style: TextStyle(
                                   color: AppColors.textSecondary,
                                   fontSize: 12,
                                   fontWeight: FontWeight.w500,
@@ -1576,15 +1573,6 @@ class _RecordGroupHeaderState extends State<_RecordGroupHeader> {
                           size: 24,
                         ),
                       ],
-                    ),
-                  ),
-                  const Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 8),
-                    child: Divider(
-                      key: ValueKey('records-group-divider'),
-                      color: AppColors.border,
-                      height: 1,
-                      thickness: 1,
                     ),
                   ),
                 ],
@@ -1649,7 +1637,7 @@ class _RecordsSummary extends StatelessWidget {
                       children: [
                         TextSpan(
                           text: ' / ${controller.totalCount}',
-                          style: const TextStyle(
+                          style: TextStyle(
                             color: AppColors.textSecondary,
                             fontSize: 12,
                             fontWeight: FontWeight.w500,
@@ -1709,7 +1697,7 @@ class _RecordsDashboardMetric extends StatelessWidget {
       children: [
         Text.rich(
           value,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textPrimary,
             fontSize: 20,
             height: 1,
@@ -1720,7 +1708,7 @@ class _RecordsDashboardMetric extends StatelessWidget {
         const SizedBox(height: 6),
         Text(
           label,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textSecondary,
             fontSize: 12,
             height: 1,
@@ -1762,9 +1750,10 @@ class _VisitRecordCard extends StatelessWidget {
     return Material(
       key: ValueKey('record-card-${record.id}'),
       color: AppColors.surface,
-      borderRadius: BorderRadius.circular(8),
-      elevation: 1,
-      shadowColor: Colors.black.withValues(alpha: 0.12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(color: AppColors.border),
+      ),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
@@ -1804,7 +1793,7 @@ class _VisitRecordCard extends StatelessWidget {
                         key: ValueKey('record-meta-text-${record.id}'),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textSecondary,
                           fontSize: 12,
                           height: 1,
@@ -1816,7 +1805,7 @@ class _VisitRecordCard extends StatelessWidget {
                       Row(
                         key: ValueKey('record-captured-row-${record.id}'),
                         children: [
-                          const Icon(
+                          Icon(
                             Icons.schedule_outlined,
                             size: 15,
                             color: AppColors.textSecondary,
@@ -1824,7 +1813,7 @@ class _VisitRecordCard extends StatelessWidget {
                           const SizedBox(width: 5),
                           Text(
                             _formatCapturedAt(record.capturedAt),
-                            style: const TextStyle(
+                            style: TextStyle(
                               color: AppColors.textSecondary,
                               fontSize: 12,
                               fontWeight: FontWeight.w500,
@@ -1836,7 +1825,7 @@ class _VisitRecordCard extends StatelessWidget {
                     ],
                   ),
                 ),
-                const Icon(
+                Icon(
                   Icons.chevron_right,
                   color: AppColors.textSecondary,
                   size: 25,
@@ -1905,7 +1894,7 @@ class _EmptyRecords extends StatelessWidget {
                   title,
                   key: const ValueKey('records-empty-title'),
                   textAlign: TextAlign.center,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textPrimary,
                     fontSize: 17,
                     fontWeight: FontWeight.w800,
@@ -1917,7 +1906,7 @@ class _EmptyRecords extends StatelessWidget {
                   description,
                   key: const ValueKey('records-empty-description'),
                   textAlign: TextAlign.center,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textSecondary,
                     fontSize: 13,
                     height: 1.5,

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -59,7 +59,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
     return Scaffold(
       appBar: AppBar(
         key: const ValueKey('records-app-bar'),
-        toolbarHeight: kToolbarHeight,
+        toolbarHeight: AppTheme.appBarHeight,
         title: const Text(
           '记录',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -43,6 +43,11 @@ class _RecordsScreenState extends State<RecordsScreen> {
     _synchronizeScopeFilters(controller.plan);
     final records = _filteredRecords(controller);
     final sections = _groupedRecords(controller, records);
+    final trimmedSearchQuery = _searchQuery.trim();
+    final hasActiveFilters =
+        _statusFilter != _RecordStatusFilter.all ||
+        _selectedWorkIds != null ||
+        _selectedGroupFilterIds != null;
     if (!_expandedSectionsInitialized && sections.isNotEmpty) {
       _expandedSectionIds.addAll(sections.map((section) => section.id));
       _expandedSectionsInitialized = true;
@@ -54,6 +59,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
     return Scaffold(
       appBar: AppBar(
         key: const ValueKey('records-app-bar'),
+        toolbarHeight: kToolbarHeight,
         title: const Text(
           '记录',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
@@ -79,7 +85,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
               allSectionsExpanded ? Icons.unfold_less : Icons.unfold_more,
             ),
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: 16),
         ],
       ),
       body: CustomScrollView(
@@ -121,9 +127,17 @@ class _RecordsScreenState extends State<RecordsScreen> {
             ),
           ),
           if (records.isEmpty)
-            const SliverPadding(
-              padding: EdgeInsets.fromLTRB(16, 4, 16, 0),
-              sliver: SliverToBoxAdapter(child: _EmptyRecords()),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+              sliver: SliverToBoxAdapter(
+                child: _EmptyRecords(
+                  hasAnyRecords: controller.visitRecords.isNotEmpty,
+                  searchQuery: trimmedSearchQuery,
+                  hasActiveFilters: hasActiveFilters,
+                  onClearSearch: _clearSearch,
+                  onResetFilters: _resetFilters,
+                ),
+              ),
             )
           else
             for (final section in sections)
@@ -183,6 +197,22 @@ class _RecordsScreenState extends State<RecordsScreen> {
         ),
       ),
     );
+  }
+
+  void _clearSearch() {
+    setState(() {
+      _searchQuery = '';
+      _resetExpandedSections();
+    });
+  }
+
+  void _resetFilters() {
+    setState(() {
+      _statusFilter = _RecordStatusFilter.all;
+      _selectedWorkIds = null;
+      _selectedGroupFilterIds = null;
+      _resetExpandedSections();
+    });
   }
 
   void _resetExpandedSections() {
@@ -1821,32 +1851,107 @@ class _VisitRecordCard extends StatelessWidget {
 }
 
 class _EmptyRecords extends StatelessWidget {
-  const _EmptyRecords();
+  const _EmptyRecords({
+    required this.hasAnyRecords,
+    required this.searchQuery,
+    required this.hasActiveFilters,
+    required this.onClearSearch,
+    required this.onResetFilters,
+  });
+
+  final bool hasAnyRecords;
+  final String searchQuery;
+  final bool hasActiveFilters;
+  final VoidCallback onClearSearch;
+  final VoidCallback onResetFilters;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(18),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Row(
-        children: [
-          Icon(Icons.info_outline, color: AppColors.textSecondary),
-          SizedBox(width: 10),
-          Expanded(
-            child: Text(
-              '还没有巡礼记录。拍摄成功后会自动出现在这里。',
-              style: TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 14,
-                letterSpacing: 0,
-              ),
+    final hasSearchQuery = hasAnyRecords && searchQuery.isNotEmpty;
+    final hasFilterResult =
+        hasAnyRecords && !hasSearchQuery && hasActiveFilters;
+    final icon = hasSearchQuery
+        ? Icons.search_off_rounded
+        : hasFilterResult
+        ? Icons.filter_alt_off_rounded
+        : Icons.photo_library_outlined;
+    final title = hasSearchQuery
+        ? '没有找到相关记录'
+        : hasFilterResult
+        ? '没有符合筛选条件的记录'
+        : '还没有巡礼记录';
+    final description = hasSearchQuery
+        ? hasActiveFilters
+              ? '没有与当前关键词和筛选条件同时匹配的点位、作品或场景。试试更换关键词，或重置筛选条件。'
+              : '没有与当前关键词匹配的点位、作品或场景。试试更换关键词，或清除搜索查看全部记录。'
+        : hasFilterResult
+        ? '调整状态、作品或片区筛选条件后再试。'
+        : '完成一次点位拍摄后，记录会自动汇总到这里。';
+
+    return Semantics(
+      liveRegion: true,
+      child: Padding(
+        key: const ValueKey('records-empty-state'),
+        padding: const EdgeInsets.fromLTRB(16, 28, 16, 36),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 380),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, color: AppColors.accent, size: 42),
+                const SizedBox(height: 14),
+                Text(
+                  title,
+                  key: const ValueKey('records-empty-title'),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 17,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 7),
+                Text(
+                  description,
+                  key: const ValueKey('records-empty-description'),
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 13,
+                    height: 1.5,
+                    letterSpacing: 0,
+                  ),
+                ),
+                if (hasSearchQuery || hasFilterResult) ...[
+                  const SizedBox(height: 14),
+                  Wrap(
+                    alignment: WrapAlignment.center,
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      if (hasSearchQuery)
+                        TextButton.icon(
+                          key: const ValueKey('records-empty-clear-search'),
+                          onPressed: onClearSearch,
+                          icon: const Icon(Icons.close, size: 18),
+                          label: const Text('清除搜索'),
+                        ),
+                      if (hasActiveFilters)
+                        TextButton.icon(
+                          key: const ValueKey('records-empty-reset-filters'),
+                          onPressed: onResetFilters,
+                          icon: const Icon(Icons.filter_alt_off, size: 18),
+                          label: const Text('重置筛选'),
+                        ),
+                    ],
+                  ),
+                ],
+              ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/records/visit_record_detail_screen.dart
+++ b/lib/records/visit_record_detail_screen.dart
@@ -15,6 +15,7 @@ import '../plan/reference_image_status.dart';
 import '../point_detail/point_detail_sheet.dart';
 import '../widgets/copyable_text.dart';
 import '../widgets/confirm_action_dialog.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/anitabi_network_image.dart';
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/reference_image_placeholder.dart';
@@ -61,6 +62,11 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        toolbarHeight: 44,
+        leading: AppBackButton(
+          key: const ValueKey('record-detail-back-button'),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
         title: const Text('记录详情'),
         actions: [
           IconButton(

--- a/lib/records/visit_record_detail_screen.dart
+++ b/lib/records/visit_record_detail_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/confirm_action_dialog.dart';
 import '../widgets/app_back_button.dart';
 import '../widgets/anitabi_network_image.dart';
 import '../widgets/image_viewer_screen.dart';
+import '../widgets/snackbar_helper.dart';
 import '../widgets/reference_image_placeholder.dart';
 import '../widgets/reference_image_source_stub.dart'
     if (dart.library.io) '../widgets/reference_image_source_io.dart';
@@ -62,6 +63,7 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        toolbarHeight: AppTheme.appBarHeight,
         leading: AppBackButton(
           key: const ValueKey('record-detail-back-button'),
           onPressed: () => Navigator.of(context).maybePop(),
@@ -156,6 +158,7 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
       onOpenRecords: () => _openPointRecords(point),
       onOpenRecord: _openRelatedRecord,
       navigationApp: widget.settings.navigationApp,
+      settings: widget.settings,
     );
   }
 
@@ -232,17 +235,14 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
                             ? ConfirmActionDialog.dangerColor
                             : Colors.transparent;
                       }),
-                      side: const BorderSide(
-                        color: AppColors.border,
-                        width: 1.5,
-                      ),
+                      side: BorderSide(color: AppColors.border, width: 1.5),
                       onChanged: (value) =>
                           setState(() => deleteFiles = value ?? false),
                       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                       visualDensity: VisualDensity.compact,
                     ),
                     const SizedBox(width: 4),
-                    const Text(
+                    Text(
                       '同时删除照片文件',
                       style: TextStyle(
                         color: AppColors.textPrimary,
@@ -288,7 +288,7 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
     if (capturedPath == null) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('巡礼图不可用，无法导出对比图片。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '巡礼图不可用，无法导出对比图片。');
       return;
     }
 
@@ -320,7 +320,7 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
     if (repository == null) {
       ScaffoldMessenger.of(
         context,
-      ).showSnackBar(const SnackBar(content: Text('当前平台暂不支持保存导出偏好。')));
+      ).showStatusSnack(kind: AppStatusBannerKind.warning, title: '当前平台暂不支持保存导出偏好。');
       return;
     }
 
@@ -521,7 +521,7 @@ class _RecordImageTile extends StatelessWidget {
         Text(
           label,
           textAlign: TextAlign.center,
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textSecondary,
             fontSize: 12,
             fontWeight: FontWeight.w800,
@@ -592,7 +592,7 @@ class _OrphanRecordNotice extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: AppColors.warning.withValues(alpha: 0.35)),
       ),
-      child: const Row(
+      child: Row(
         children: [
           Icon(Icons.link_off_outlined, color: AppColors.warning, size: 19),
           SizedBox(width: 8),
@@ -658,7 +658,7 @@ class _RecordInfoDashboard extends StatelessWidget {
                         const SizedBox(height: 6),
                         Text(
                           subtitle,
-                          style: const TextStyle(
+                          style: TextStyle(
                             color: AppColors.textSecondary,
                             fontSize: 14,
                             letterSpacing: 0,
@@ -669,7 +669,7 @@ class _RecordInfoDashboard extends StatelessWidget {
                   ),
                   if (onHeaderTap != null) ...[
                     const SizedBox(width: 12),
-                    const Icon(
+                    Icon(
                       Icons.chevron_right,
                       color: AppColors.textSecondary,
                       size: 24,
@@ -743,7 +743,7 @@ class _RecordActionPanel extends StatelessWidget {
                 onTap: onColorGrading,
               ),
             ),
-            const VerticalDivider(
+            VerticalDivider(
               width: 9,
               indent: 8,
               endIndent: 8,
@@ -802,7 +802,7 @@ class _RecordAction extends StatelessWidget {
                         title,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textPrimary,
                           fontSize: 14,
                           fontWeight: FontWeight.w800,
@@ -814,7 +814,7 @@ class _RecordAction extends StatelessWidget {
                         subtitle,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
+                        style: TextStyle(
                           color: AppColors.textSecondary,
                           fontSize: 11,
                           letterSpacing: 0,
@@ -854,7 +854,7 @@ class _DetailRow extends StatelessWidget {
           width: 70,
           child: Text(
             label,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textSecondary,
               fontSize: 13,
               fontWeight: FontWeight.w700,
@@ -867,7 +867,7 @@ class _DetailRow extends StatelessWidget {
           child: CopyableText(
             text: value,
             copyLabel: label,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textPrimary,
               fontSize: 13,
               letterSpacing: 0,

--- a/lib/records/visit_record_detail_screen.dart
+++ b/lib/records/visit_record_detail_screen.dart
@@ -62,7 +62,6 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: 44,
         leading: AppBackButton(
           key: const ValueKey('record-detail-back-button'),
           onPressed: () => Navigator.of(context).maybePop(),

--- a/lib/records/visit_record_photo_stub.dart
+++ b/lib/records/visit_record_photo_stub.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../app_theme.dart';
 import '../desktop/desktop_asset_image.dart';
 import '../plan/pilgrimage_models.dart';
 
@@ -74,9 +75,9 @@ class _PhotoPlaceholder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const ColoredBox(
-      color: Color(0xFFEEF1F4),
-      child: Center(child: Icon(Icons.photo_outlined)),
+    return ColoredBox(
+      color: AppColors.surfaceMuted,
+      child: const Center(child: Icon(Icons.photo_outlined)),
     );
   }
 }

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -16,14 +16,18 @@ import '../records/comparison_export_config.dart';
 import '../records/comparison_export_config_editor.dart';
 import '../records/comparison_export_config_storage_stub.dart'
     if (dart.library.io) '../records/comparison_export_config_storage_io.dart';
-import '../widgets/copyable_text.dart';
-import '../widgets/confirm_action_dialog.dart';
 import '../widgets/app_back_button.dart';
+import '../widgets/app_scaled_route.dart';
+import '../widgets/app_status_banner.dart';
+import '../widgets/confirm_action_dialog.dart';
+import '../widgets/copyable_text.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/snackbar_helper.dart';
+import '../widgets/status_snack_samples.dart';
 
-bool get _showFutureThemeModeSettings => false;
 bool get _showFutureCacheCleanupSettings => false;
+bool get _showSnackDebugSettings => false;
+bool get _showDebugPhotoLocationSettings => false;
 bool get _shouldShowMobileGallerySettings {
   if (kIsWeb) {
     return false;
@@ -31,6 +35,11 @@ bool get _shouldShowMobileGallerySettings {
   return defaultTargetPlatform == TargetPlatform.android ||
       defaultTargetPlatform == TargetPlatform.iOS;
 }
+
+bool get _shouldShowPhotoLocationSettings =>
+    kDebugMode ||
+    _showDebugPhotoLocationSettings ||
+    _shouldShowMobileGallerySettings;
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({
@@ -103,6 +112,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final settings = widget.settings;
 
     return Scaffold(
+      backgroundColor: AppColors.background,
       appBar: AppBar(
         key: const ValueKey('settings-app-bar'),
         toolbarHeight: AppTheme.appBarHeight,
@@ -128,7 +138,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             header: _SettingsCardHeader(
               icon: Icons.palette_outlined,
               title: '外观设置',
-              subtitle: '主题色、缩放、显示等',
+              subtitle: '主题色、深浅色、缩放、显示等',
               onTap: () => _pushDetail(
                 _AppearanceSettingsPage(
                   settings: settings,
@@ -155,9 +165,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     ),
                   ),
                   _SummaryTile(
-                    icon: Icons.zoom_out_map_outlined,
-                    title: '页面缩放',
-                    value: '${(settings.uiScale * 100).round()}%',
+                    icon: Icons.dark_mode_outlined,
+                    title: '主题模式',
+                    value: settings.themeMode.label,
                     onTap: () => _pushDetail(
                       _AppearanceSettingsPage(
                         settings: settings,
@@ -213,8 +223,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   ),
                 ],
               ),
-              if (_shouldShowMobileGallerySettings) ...[
-                const _SettingsDivider(),
+              if (_shouldShowMobileGallerySettings)
                 _SummarySwitchTile(
                   icon: Icons.cloud_upload_outlined,
                   title: '照片备份',
@@ -226,7 +235,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     );
                   },
                 ),
-              ],
             ],
           ),
           const SizedBox(height: 12),
@@ -322,6 +330,18 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
             ),
           ),
+          if (_showSnackDebugSettings) ...[
+            const SizedBox(height: 12),
+            _SettingsCard(
+              key: const ValueKey('settings-snack-debug-card'),
+              header: _SettingsCardHeader(
+                icon: Icons.notifications_outlined,
+                title: 'Snack 调试',
+                subtitle: '预览当前全部提示条',
+                onTap: () => _pushDetail(const _SnackDebugSettingsPage()),
+              ),
+            ),
+          ],
         ],
       ),
     );
@@ -362,7 +382,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (mounted) {
       ScaffoldMessenger.of(
         context,
-      ).showReplacingSnackBar(const SnackBar(content: Text('已恢复初始设置')));
+      ).showStatusSnack(kind: AppStatusBannerKind.success, title: '已恢复初始设置');
     }
     await clearComparisonExportConfig();
   }
@@ -463,6 +483,10 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
   }
 
   void _update(AppSettings settings) {
+    applyAppColorsFromSettings(
+      settings,
+      platformBrightness: MediaQuery.platformBrightnessOf(context),
+    );
     setState(() {
       _settings = settings;
     });
@@ -499,13 +523,15 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
     final settings = _settings;
     final uiScale = settings.uiScale.clamp(0.8, 1.0);
     final fontScale = settings.fontScale.clamp(0.8, 1.2);
-    AppColors.palette = settings.themePalette;
-    AppColors.customAccentValue = settings.customThemeColorValue;
+    applyAppColorsFromSettings(
+      settings,
+      platformBrightness: MediaQuery.platformBrightnessOf(context),
+    );
 
     return Theme(
-      data: AppTheme.light(
-        palette: settings.themePalette,
-        customAccentValue: settings.customThemeColorValue,
+      data: appThemeFor(
+        settings,
+        platformBrightness: MediaQuery.platformBrightnessOf(context),
       ),
       child: _ScaledDetailScaffold(
         title: '\u5916\u89c2\u8bbe\u7f6e',
@@ -517,9 +543,57 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const _InlineSectionTitle(
-                  title: '\u4e3b\u9898\u8272',
-                  subtitle: '\u5f71\u54cd\u5e94\u7528\u6574\u4f53\u914d\u8272',
+                  title: '主题模式',
+                  subtitle: '影响应用整体浅色或深色显示',
                 ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Expanded(
+                      child: _ModeButton(
+                        key: const ValueKey('appearance-theme-mode-light'),
+                        icon: Icons.wb_sunny_outlined,
+                        label: '浅色',
+                        selected: settings.themeMode == AppThemeMode.light,
+                        onTap: () {
+                          _update(
+                            settings.copyWith(themeMode: AppThemeMode.light),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: _ModeButton(
+                        key: const ValueKey('appearance-theme-mode-dark'),
+                        icon: Icons.dark_mode_outlined,
+                        label: '深色',
+                        selected: settings.themeMode == AppThemeMode.dark,
+                        onTap: () {
+                          _update(
+                            settings.copyWith(themeMode: AppThemeMode.dark),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: _ModeButton(
+                        key: const ValueKey('appearance-theme-mode-system'),
+                        icon: Icons.phone_iphone_outlined,
+                        label: '跟随系统',
+                        selected: settings.themeMode == AppThemeMode.system,
+                        onTap: () {
+                          _update(
+                            settings.copyWith(themeMode: AppThemeMode.system),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 22),
+                const _InlineSectionTitle(title: '主题色', subtitle: '影响应用整体配色'),
                 const SizedBox(height: 16),
                 SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
@@ -571,56 +645,6 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                     ],
                   ),
                 ),
-                if (_showFutureThemeModeSettings) ...[
-                  const SizedBox(height: 22),
-                  const Text(
-                    '\u4e3b\u9898\u6a21\u5f0f',
-                    style: _titleTextStyle,
-                  ),
-                  const SizedBox(height: 10),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: _ModeButton(
-                          icon: Icons.wb_sunny_outlined,
-                          label: '\u6d45\u8272\u6a21\u5f0f',
-                          selected: settings.themeMode == AppThemeMode.light,
-                          onTap: () {
-                            _update(
-                              settings.copyWith(themeMode: AppThemeMode.light),
-                            );
-                          },
-                        ),
-                      ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: _ModeButton(
-                          icon: Icons.dark_mode_outlined,
-                          label: '\u6df1\u8272\u6a21\u5f0f',
-                          selected: settings.themeMode == AppThemeMode.dark,
-                          onTap: () {
-                            _update(
-                              settings.copyWith(themeMode: AppThemeMode.dark),
-                            );
-                          },
-                        ),
-                      ),
-                      const SizedBox(width: 10),
-                      Expanded(
-                        child: _ModeButton(
-                          icon: Icons.phone_iphone_outlined,
-                          label: '\u8ddf\u968f\u7cfb\u7edf',
-                          selected: settings.themeMode == AppThemeMode.system,
-                          onTap: () {
-                            _update(
-                              settings.copyWith(themeMode: AppThemeMode.system),
-                            );
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
               ],
             ),
           ),
@@ -631,13 +655,13 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
               children: [
                 Row(
                   children: [
-                    const Icon(
+                    Icon(
                       Icons.fit_screen_outlined,
                       color: AppColors.textSecondary,
                       size: 20,
                     ),
                     const SizedBox(width: 8),
-                    const Expanded(
+                    Expanded(
                       child: Text(
                         '\u9875\u9762\u7f29\u653e',
                         style: _titleTextStyle,
@@ -655,8 +679,8 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                   ],
                 ),
                 const SizedBox(height: 4),
-                const Padding(
-                  padding: EdgeInsets.only(left: 28, right: 8),
+                Padding(
+                  padding: const EdgeInsets.only(left: 28, right: 8),
                   child: Text(
                     '\u8c03\u6574\u754c\u9762\u6574\u4f53\u5927\u5c0f\uff08\u4e0d\u5f71\u54cd\u53c2\u8003\u56fe\uff09',
                     style: _captionTextStyle,
@@ -677,7 +701,7 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                 const SizedBox(height: 18),
                 Row(
                   children: [
-                    const Text('Aa', style: _titleTextStyle),
+                    Text('Aa', style: _titleTextStyle),
                     const SizedBox(width: 12),
                     Expanded(
                       child: Row(
@@ -724,12 +748,12 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
               child: SwitchListTile(
                 key: const ValueKey('plan-group-progress-toggle'),
                 contentPadding: EdgeInsets.zero,
-                secondary: const Icon(
+                secondary: Icon(
                   Icons.linear_scale_outlined,
                   color: AppColors.textSecondary,
                 ),
-                title: const Text('显示片区进度条', style: _titleTextStyle),
-                subtitle: const Text(
+                title: Text('显示片区进度条', style: _titleTextStyle),
+                subtitle: Text(
                   '在片区选择弹窗中显示未完成片区的进度背景；完成后仅显示对勾。',
                   style: _secondaryTextStyle,
                 ),
@@ -749,12 +773,12 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                   'dismiss-plan-actions-on-outside-tap-toggle',
                 ),
                 contentPadding: EdgeInsets.zero,
-                secondary: const Icon(
+                secondary: Icon(
                   Icons.touch_app_outlined,
                   color: AppColors.textSecondary,
                 ),
-                title: const Text('点击空白收回计划操作', style: _titleTextStyle),
-                subtitle: const Text(
+                title: Text('点击空白收回计划操作', style: _titleTextStyle),
+                subtitle: Text(
                   '展开计划操作后，点击面板外的空白区域自动收回',
                   style: _secondaryTextStyle,
                 ),
@@ -866,7 +890,7 @@ class _CameraSettingsPageState extends State<_CameraSettingsPage> {
           title: '\u62cd\u6444\u56fe\u7247\u6bd4\u4f8b',
           titleSpacing: 6,
           children: [
-            const Text(
+            Text(
               '\u81ea\u52a8\u4f1a\u4f18\u5148\u8ddf\u968f\u53c2\u8003\u56fe\u6bd4\u4f8b\uff1b\u9009\u62e9\u56fa\u5b9a\u6bd4\u4f8b\u540e\u4f1a\u6309\u8be5\u6bd4\u4f8b\u62cd\u6444\u3002',
               style: _secondaryTextStyle,
             ),
@@ -901,7 +925,7 @@ class _CameraSettingsPageState extends State<_CameraSettingsPage> {
           title: '\u65e0\u53c2\u8003\u56fe\u65f6\u6bd4\u4f8b',
           titleSpacing: 6,
           children: [
-            const Text(
+            Text(
               '\u62cd\u6444\u56fe\u7247\u6bd4\u4f8b\u4e3a\u81ea\u52a8\u3001\u4e14\u6ca1\u6709\u53c2\u8003\u56fe\u53ef\u5bf9\u9f50\u65f6\u4f7f\u7528\u3002',
               style: _secondaryTextStyle,
             ),
@@ -995,26 +1019,15 @@ class _CameraSettingsPageState extends State<_CameraSettingsPage> {
             ),
           ],
         ),
-        if (_shouldShowMobileGallerySettings) ...[
+        if (_shouldShowPhotoLocationSettings) ...[
           const SizedBox(height: 12),
           _SettingsSection(
             title: '照片定位信息',
+            titleSpacing: 6,
             children: [
-              DropdownButtonFormField<PhotoLocationStrategy>(
-                initialValue: settings.photoLocationStrategy,
-                isExpanded: true,
-                decoration: const InputDecoration(
-                  prefixIcon: Icon(Icons.location_on_outlined),
-                  labelText: '定位写入策略',
-                ),
-                items: PhotoLocationStrategy.values
-                    .map(
-                      (strategy) => DropdownMenuItem(
-                        value: strategy,
-                        child: Text(strategy.label),
-                      ),
-                    )
-                    .toList(growable: false),
+              _PhotoLocationStrategyDropdown(
+                value: settings.photoLocationStrategy,
+                settings: settings,
                 onChanged: (strategy) {
                   if (strategy != null) {
                     _update(settings.copyWith(photoLocationStrategy: strategy));
@@ -1030,21 +1043,20 @@ class _CameraSettingsPageState extends State<_CameraSettingsPage> {
               ),
             ],
           ),
+        ],
+        if (_shouldShowMobileGallerySettings) ...[
           const SizedBox(height: 12),
           _SettingsSection(
             title: '照片备份',
             children: [
               SwitchListTile(
                 contentPadding: EdgeInsets.zero,
-                secondary: const Icon(
+                secondary: Icon(
                   Icons.cloud_upload_outlined,
                   color: AppColors.textSecondary,
                 ),
-                title: const Text('保存巡礼照片到相册', style: _titleTextStyle),
-                subtitle: const Text(
-                  '保存记录时同时备份一张巡礼照片。',
-                  style: _secondaryTextStyle,
-                ),
+                title: Text('保存巡礼照片到相册', style: _titleTextStyle),
+                subtitle: Text('保存记录时同时备份一张巡礼照片。', style: _secondaryTextStyle),
                 value: settings.saveVisitPhotoToGallery,
                 onChanged: (value) {
                   _update(settings.copyWith(saveVisitPhotoToGallery: value));
@@ -1066,6 +1078,251 @@ String _photoLocationStrategyDescription(PhotoLocationStrategy strategy) {
       '拍摄时优先使用设备最近的有效定位；没有可用定位时尝试获取一次。',
     PhotoLocationStrategy.waitOnConfirmation => '拍摄后在确认记录页面获取新定位，完成或失败后再允许保存。',
   };
+}
+
+String _photoLocationStrategyBadge(PhotoLocationStrategy strategy) {
+  return switch (strategy) {
+    PhotoLocationStrategy.askOnFirstCapture => '询问',
+    PhotoLocationStrategy.disabled => '关闭',
+    PhotoLocationStrategy.useRecentLocation => '最近',
+    PhotoLocationStrategy.waitOnConfirmation => '推荐',
+  };
+}
+
+String _photoLocationStrategyMenuLabel(PhotoLocationStrategy strategy) {
+  return switch (strategy) {
+    PhotoLocationStrategy.waitOnConfirmation => '确认记录时获取定位',
+    _ => strategy.label,
+  };
+}
+
+class _PhotoLocationStrategyDropdown extends StatelessWidget {
+  const _PhotoLocationStrategyDropdown({
+    required this.value,
+    required this.settings,
+    required this.onChanged,
+  });
+
+  final PhotoLocationStrategy value;
+  final AppSettings settings;
+  final ValueChanged<PhotoLocationStrategy?> onChanged;
+
+  static const _strategies = PhotoLocationStrategy.values;
+  static const _maxItemsWithoutScrollbar = 7;
+
+  @override
+  Widget build(BuildContext context) {
+    final omitScrollbarInset = _strategies.length <= _maxItemsWithoutScrollbar;
+
+    return Theme(
+      data: Theme.of(context).copyWith(
+        focusColor: Colors.transparent,
+        hoverColor: Colors.transparent,
+        highlightColor: AppColors.accent.withValues(alpha: 0.075),
+        splashColor: Colors.transparent,
+      ),
+      child: DropdownButtonFormField<PhotoLocationStrategy>(
+        key: ValueKey(value),
+        initialValue: value,
+        decoration: _decoration(),
+        isExpanded: true,
+        elevation: 2,
+        borderRadius: BorderRadius.circular(8),
+        dropdownColor: AppColors.surface,
+        itemHeight: null,
+        menuMaxHeight: appScaledOverlayExtent(settings, 360),
+        icon: const Padding(
+          padding: EdgeInsets.only(right: 8),
+          child: Icon(Icons.keyboard_arrow_down_rounded, size: 20),
+        ),
+        selectedItemBuilder: (context) => [
+          for (final strategy in _strategies)
+            _PhotoLocationStrategyDropdownItem(strategy: strategy),
+        ],
+        items: [
+          for (final strategy in _strategies)
+            DropdownMenuItem<PhotoLocationStrategy>(
+              value: strategy,
+              child: SizedBox(
+                height: appScaledOverlayExtent(settings, 48),
+                child: AppScaledOverlayContent(
+                  settings: settings,
+                  child: _PhotoLocationStrategyDropdownItem(
+                    strategy: strategy,
+                    selected: strategy == value,
+                    menuItem: true,
+                    omitScrollbarInset: omitScrollbarInset,
+                  ),
+                ),
+              ),
+            ),
+        ],
+        onChanged: onChanged,
+      ),
+    );
+  }
+
+  InputDecoration _decoration() {
+    return InputDecoration(
+      isDense: true,
+      filled: true,
+      fillColor: AppColors.surface,
+      hoverColor: AppColors.accent.withValues(alpha: 0.035),
+      contentPadding: const EdgeInsets.fromLTRB(14, 10, 4, 10),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: AppColors.border, width: 1.4),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: BorderSide(color: AppColors.accent, width: 1.4),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: Colors.redAccent, width: 1.4),
+      ),
+    );
+  }
+}
+
+class _PhotoLocationStrategyDropdownItem extends StatefulWidget {
+  const _PhotoLocationStrategyDropdownItem({
+    required this.strategy,
+    this.selected = false,
+    this.menuItem = false,
+    this.omitScrollbarInset = false,
+  });
+
+  final PhotoLocationStrategy strategy;
+  final bool selected;
+  final bool menuItem;
+  final bool omitScrollbarInset;
+
+  @override
+  State<_PhotoLocationStrategyDropdownItem> createState() =>
+      _PhotoLocationStrategyDropdownItemState();
+}
+
+class _PhotoLocationStrategyDropdownItemState
+    extends State<_PhotoLocationStrategyDropdownItem> {
+  static const _hoverOffset = 12.0;
+  static const _menuTrailingInset = 10.0;
+  static const _menuBackgroundTrailingInset = 6.0;
+
+  var _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final strategy = widget.strategy;
+    final selected = widget.selected;
+    final reserveScrollbarSpace = widget.menuItem && !widget.omitScrollbarInset;
+
+    final item = SizedBox(
+      width: double.infinity,
+      height: widget.menuItem ? double.infinity : null,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOutCubic,
+        alignment: Alignment.centerLeft,
+        transform: Matrix4.translationValues(
+          _hovered && !selected ? _hoverOffset : 0,
+          0,
+          0,
+        ),
+        transformAlignment: Alignment.centerLeft,
+        padding: EdgeInsets.only(
+          right: reserveScrollbarSpace ? _menuTrailingInset : 0,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: AppColors.accent.withValues(alpha: 0.08),
+                border: Border.all(
+                  color: AppColors.accent.withValues(alpha: 0.42),
+                ),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                _photoLocationStrategyBadge(strategy),
+                style: TextStyle(
+                  color: AppColors.accent,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  height: 1.15,
+                  letterSpacing: 0,
+                ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Transform.translate(
+                offset: Offset(0, widget.menuItem ? 0 : -1),
+                child: Text(
+                  _photoLocationStrategyMenuLabel(strategy),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 14,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ),
+            ),
+            if (selected) ...[
+              const SizedBox(width: 8),
+              Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+            ],
+          ],
+        ),
+      ),
+    );
+
+    final content = SizedBox(
+      width: double.infinity,
+      height: widget.menuItem ? double.infinity : null,
+      child: Stack(
+        clipBehavior: Clip.none,
+        fit: widget.menuItem ? StackFit.expand : StackFit.loose,
+        children: [
+          Positioned(
+            left: -8,
+            top: 6,
+            right: reserveScrollbarSpace ? _menuBackgroundTrailingInset : -8,
+            bottom: 6,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeOutCubic,
+              decoration: BoxDecoration(
+                color: AppColors.accent.withValues(
+                  alpha: selected ? 0.1 : (_hovered ? 0.05 : 0),
+                ),
+                borderRadius: BorderRadius.circular(6),
+              ),
+            ),
+          ),
+          item,
+        ],
+      ),
+    );
+
+    return MouseRegion(
+      onEnter: widget.menuItem && !selected
+          ? (_) => setState(() => _hovered = true)
+          : null,
+      onExit: widget.menuItem && !selected
+          ? (_) => setState(() => _hovered = false)
+          : null,
+      child: content,
+    );
+  }
 }
 
 class _AnitabiServiceSettingsPage extends StatefulWidget {
@@ -1135,17 +1392,17 @@ class _AnitabiServiceSettingsPageState
     });
     final config = _config;
     final probes = <String, Uri>{
-      '主站': config.siteUri('/'),
-      '静态数据': config.staticDataUri('g.json'),
+      '主站地址': config.siteUri('/'),
+      '静态地图数据': config.staticDataUri('g.json'),
       '数据 API': config.apiUri('bangumi/115908/lite'),
-      '官方图片': Uri.parse(
+      '官方图片服务': Uri.parse(
         config.officialImageUrl(
           Uri.parse(
             'https://image.anitabi.cn/points/115908/qys7fu.jpg?plan=h160',
           ),
         ),
       ),
-      '备用图片': Uri.parse(
+      '备用图片服务': Uri.parse(
         config.mirrorImageUrl(
           Uri.parse(
             'https://image.anitabi.cn/points/115908/qys7fu.jpg?plan=h160',
@@ -1189,7 +1446,18 @@ class _AnitabiServiceSettingsPageState
     }
   }
 
-  void _restoreDefaults() {
+  Future<void> _restoreDefaults() async {
+    final confirmed = await showConfirmActionDialog(
+      context,
+      title: '恢复默认地址',
+      message: '将把全部 Anitabi 服务地址恢复为官方默认值。',
+      confirmLabel: '恢复默认',
+      notice: '当前自定义地址不会被保留',
+      emphasizedValues: const ['全部 Anitabi 服务地址'],
+    );
+    if (!confirmed || !mounted) {
+      return;
+    }
     _update(
       _settings.copyWith(
         anitabiSiteBaseUrl: defaultAnitabiSiteBaseUrl,
@@ -1204,6 +1472,57 @@ class _AnitabiServiceSettingsPageState
   @override
   Widget build(BuildContext context) {
     final settings = _settings;
+    final services =
+        <
+          ({
+            Key key,
+            IconData icon,
+            String title,
+            String value,
+            ValueChanged<String> onSaved,
+          })
+        >[
+          (
+            key: const ValueKey('anitabi-site-base-url'),
+            icon: Icons.public_outlined,
+            title: '主站地址',
+            value: settings.anitabiSiteBaseUrl,
+            onSaved: (value) =>
+                _update(settings.copyWith(anitabiSiteBaseUrl: value)),
+          ),
+          (
+            key: const ValueKey('anitabi-static-data-base-url'),
+            icon: Icons.data_object_outlined,
+            title: '静态地图数据',
+            value: settings.anitabiStaticDataBaseUrl,
+            onSaved: (value) =>
+                _update(settings.copyWith(anitabiStaticDataBaseUrl: value)),
+          ),
+          (
+            key: const ValueKey('anitabi-api-base-url'),
+            icon: Icons.api_outlined,
+            title: '数据 API',
+            value: settings.anitabiApiBaseUrl,
+            onSaved: (value) =>
+                _update(settings.copyWith(anitabiApiBaseUrl: value)),
+          ),
+          (
+            key: const ValueKey('anitabi-official-image-base-url'),
+            icon: Icons.image_outlined,
+            title: '官方图片服务',
+            value: settings.anitabiOfficialImageBaseUrl,
+            onSaved: (value) =>
+                _update(settings.copyWith(anitabiOfficialImageBaseUrl: value)),
+          ),
+          (
+            key: const ValueKey('anitabi-mirror-image-base-url'),
+            icon: Icons.cloud_outlined,
+            title: '备用图片服务',
+            value: settings.anitabiMirrorImageBaseUrl,
+            onSaved: (value) =>
+                _update(settings.copyWith(anitabiMirrorImageBaseUrl: value)),
+          ),
+        ];
     return _ScaledDetailScaffold(
       title: 'Anitabi 服务地址',
       uiScale: settings.uiScale,
@@ -1211,62 +1530,28 @@ class _AnitabiServiceSettingsPageState
       children: [
         _SettingsSection(
           title: '服务地址',
+          titleSpacing: 4,
           children: [
-            _serviceRow(
-              key: const ValueKey('anitabi-site-base-url'),
-              icon: Icons.public_outlined,
-              title: '主站地址',
-              value: settings.anitabiSiteBaseUrl,
-              onSaved: (value) =>
-                  _update(settings.copyWith(anitabiSiteBaseUrl: value)),
-            ),
-            _serviceRow(
-              key: const ValueKey('anitabi-static-data-base-url'),
-              icon: Icons.data_object_outlined,
-              title: '静态地图数据',
-              value: settings.anitabiStaticDataBaseUrl,
-              onSaved: (value) =>
-                  _update(settings.copyWith(anitabiStaticDataBaseUrl: value)),
-            ),
-            _serviceRow(
-              key: const ValueKey('anitabi-api-base-url'),
-              icon: Icons.api_outlined,
-              title: '数据 API',
-              value: settings.anitabiApiBaseUrl,
-              onSaved: (value) =>
-                  _update(settings.copyWith(anitabiApiBaseUrl: value)),
-            ),
-            _serviceRow(
-              key: const ValueKey('anitabi-official-image-base-url'),
-              icon: Icons.image_outlined,
-              title: '官方图片服务',
-              value: settings.anitabiOfficialImageBaseUrl,
-              onSaved: (value) => _update(
-                settings.copyWith(anitabiOfficialImageBaseUrl: value),
+            for (var index = 0; index < services.length; index += 1) ...[
+              if (index > 0)
+                Divider(height: 1, thickness: 1, color: AppColors.border),
+              _AnitabiServiceRow(
+                key: services[index].key,
+                icon: services[index].icon,
+                title: services[index].title,
+                url: services[index].value,
+                status: _testResults[services[index].title],
+                testing:
+                    _testing &&
+                    !_testResults.containsKey(services[index].title),
+                onTap: () => _edit(
+                  title: services[index].title,
+                  value: services[index].value,
+                  onSaved: services[index].onSaved,
+                ),
               ),
-            ),
-            _serviceRow(
-              key: const ValueKey('anitabi-mirror-image-base-url'),
-              icon: Icons.cloud_outlined,
-              title: '备用图片服务',
-              value: settings.anitabiMirrorImageBaseUrl,
-              onSaved: (value) =>
-                  _update(settings.copyWith(anitabiMirrorImageBaseUrl: value)),
-            ),
-          ],
-        ),
-        const SizedBox(height: 12),
-        _SettingsSection(
-          title: '连接测试',
-          children: [
-            for (final entry in _testResults.entries)
-              _InfoRow(
-                icon: entry.value.startsWith('连接成功')
-                    ? Icons.check_circle_outline
-                    : Icons.error_outline,
-                text: '${entry.key}：${entry.value}',
-              ),
-            if (_testResults.isNotEmpty) const SizedBox(height: 8),
+            ],
+            const SizedBox(height: 12),
             SizedBox(
               width: double.infinity,
               child: FilledButton.icon(
@@ -1294,24 +1579,6 @@ class _AnitabiServiceSettingsPageState
           ],
         ),
       ],
-    );
-  }
-
-  Widget _serviceRow({
-    required Key key,
-    required IconData icon,
-    required String title,
-    required String value,
-    required ValueChanged<String> onSaved,
-  }) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: _MapUrlRow(
-        key: key,
-        icon: icon,
-        label: '$title\n$value',
-        onTap: () => _edit(title: title, value: value, onSaved: onSaved),
-      ),
     );
   }
 }
@@ -1564,10 +1831,7 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
               ),
             ),
             const SizedBox(height: 10),
-            const Text(
-              '服务域名变化时可单独调整，不会改写计划中的标准图片链接。',
-              style: _secondaryTextStyle,
-            ),
+            Text('服务域名变化时可单独调整，不会改写计划中的标准图片链接。', style: _secondaryTextStyle),
           ],
         ),
         const SizedBox(height: 12),
@@ -1674,7 +1938,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Icon(
+                Icon(
                   Icons.zoom_in_outlined,
                   color: AppColors.textSecondary,
                   size: 22,
@@ -1686,7 +1950,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
                     children: [
                       Row(
                         children: [
-                          const Expanded(
+                          Expanded(
                             child: Text('最大缩放倍率', style: _titleTextStyle),
                           ),
                           Text(
@@ -1701,10 +1965,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
                         ],
                       ),
                       const SizedBox(height: 3),
-                      const Text(
-                        '控制所有地图能够放大的最大级别。',
-                        style: _secondaryTextStyle,
-                      ),
+                      Text('控制所有地图能够放大的最大级别。', style: _secondaryTextStyle),
                       Slider(
                         key: const ValueKey('map-max-zoom-slider'),
                         min: 16,
@@ -1726,7 +1987,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
                           );
                         },
                       ),
-                      const Padding(
+                      Padding(
                         padding: EdgeInsets.symmetric(horizontal: 16),
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -1755,12 +2016,12 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
               child: SwitchListTile(
                 key: const ValueKey('hide-completed-points-on-map-toggle'),
                 contentPadding: EdgeInsets.zero,
-                secondary: const Icon(
+                secondary: Icon(
                   Icons.visibility_off_outlined,
                   color: AppColors.textSecondary,
                 ),
-                title: const Text('隐藏已完成点位', style: _titleTextStyle),
-                subtitle: const Text(
+                title: Text('隐藏已完成点位', style: _titleTextStyle),
+                subtitle: Text(
                   '在地图页不显示已标记完成的点位。关闭后仍可在地图上看到全部点位。',
                   style: _secondaryTextStyle,
                 ),
@@ -1774,7 +2035,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                const Icon(
+                Icon(
                   Icons.location_on_outlined,
                   color: AppColors.textSecondary,
                   size: 22,
@@ -1784,9 +2045,9 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      const Text('地图标记大小', style: _titleTextStyle),
+                      Text('地图标记大小', style: _titleTextStyle),
                       const SizedBox(height: 3),
-                      const Text(
+                      Text(
                         '统一调整点位、缩略图、聚合标记、当前位置和片区关键点的大小。',
                         style: _secondaryTextStyle,
                       ),
@@ -1835,12 +2096,12 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
               color: Colors.transparent,
               child: SwitchListTile(
                 contentPadding: EdgeInsets.zero,
-                secondary: const Icon(
+                secondary: Icon(
                   Icons.hub_outlined,
                   color: AppColors.textSecondary,
                 ),
-                title: const Text('自动聚合密集点位', style: _titleTextStyle),
-                subtitle: const Text(
+                title: Text('自动聚合密集点位', style: _titleTextStyle),
+                subtitle: Text(
                   '仅合并地图标记的显示；点位数据、选择和导入功能不受影响。',
                   style: _secondaryTextStyle,
                 ),
@@ -1901,7 +2162,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
               },
             ),
             const SizedBox(height: 8),
-            const Text('阈值为 0 时不会在地图上显示缩略图。', style: _secondaryTextStyle),
+            Text('阈值为 0 时不会在地图上显示缩略图。', style: _secondaryTextStyle),
           ],
         ),
       ],
@@ -2060,9 +2321,10 @@ class _CacheCleanupSettingsPageState extends State<_CacheCleanupSettingsPage> {
   }
 
   void _showCachePlaceholder() {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('清除缓存功能尚未接入，仅展示界面。')));
+    ScaffoldMessenger.of(context).showStatusSnack(
+      kind: AppStatusBannerKind.warning,
+      title: '清除缓存功能尚未接入，仅展示界面。',
+    );
   }
 }
 
@@ -2106,6 +2368,72 @@ class _DesktopSettingsPage extends StatelessWidget {
   }
 }
 
+class _SnackDebugSettingsPage extends StatelessWidget {
+  const _SnackDebugSettingsPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DetailScaffold(
+      title: 'Snack 调试',
+      children: [
+        Text(
+          '当前应用里会用到的提示条样式，按进行中 / 成功 / 警告 / 失败排列。',
+          style: TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 13,
+            height: 1.4,
+            letterSpacing: 0,
+          ),
+        ),
+        const SizedBox(height: 14),
+        for (final sample in statusSnackDebugSamples) ...[
+          AppStatusBanner(
+            kind: sample.kind,
+            title: sample.title,
+            subtitle: sample.subtitle,
+            actionLabel: sample.actionLabel,
+            icon: sample.icon,
+            subtitleWidget: sample.hasProgress
+                ? AppStatusBannerProgressLine(
+                    countLabel:
+                        '${sample.progressProcessed} / ${sample.progressTotal}',
+                    percentLabel:
+                        '${((sample.progressProcessed! / sample.progressTotal!) * 100).round()}%',
+                    value: sample.progressProcessed! / sample.progressTotal!,
+                  )
+                : null,
+            footer: sample.footer == null
+                ? null
+                : Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        Icons.info_outline,
+                        size: 15,
+                        color: AppColors.textSecondary,
+                      ),
+                      const SizedBox(width: 6),
+                      Expanded(
+                        child: Text(
+                          sample.footer!,
+                          style: TextStyle(
+                            color: AppColors.textSecondary,
+                            fontSize: 11,
+                            height: 1.3,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ],
+    );
+  }
+}
+
 class _AboutSettingsPage extends StatelessWidget {
   const _AboutSettingsPage({required this.appVersionLabel});
 
@@ -2123,7 +2451,7 @@ class _AboutSettingsPage extends StatelessWidget {
               children: [
                 const _AppIconMark(),
                 const SizedBox(width: 14),
-                const Expanded(
+                Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -2217,6 +2545,7 @@ class _DetailScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.background,
       appBar: AppBar(
         leading: appBackButtonIfCanPop(context),
         title: Text(title),
@@ -2296,6 +2625,30 @@ extension _ZoomStepSnap on double {
   double snapToZoomStep() => (this * 10).round() / 10;
 }
 
+class _SettingsChrome extends StatelessWidget {
+  const _SettingsChrome({required this.child, this.padding});
+
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.surface,
+      elevation: 0,
+      shadowColor: Colors.transparent,
+      surfaceTintColor: Colors.transparent,
+      clipBehavior: Clip.antiAlias,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(color: scheme.outline),
+      ),
+      child: padding == null ? child : Padding(padding: padding!, child: child),
+    );
+  }
+}
+
 class _SettingsCard extends StatelessWidget {
   const _SettingsCard({
     required this.header,
@@ -2308,17 +2661,18 @@ class _SettingsCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      clipBehavior: Clip.antiAlias,
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
+    final outline = Theme.of(context).colorScheme.outline;
+    return _SettingsChrome(
       child: Column(
         children: [
           header,
-          if (children.isNotEmpty) ...[const _SettingsDivider(), ...children],
+          for (final child in children) ...[
+            ColoredBox(
+              color: outline,
+              child: const SizedBox(height: 1, width: double.infinity),
+            ),
+            child,
+          ],
         ],
       ),
     );
@@ -2340,30 +2694,37 @@ class _SettingsCardHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return InkWell(
       onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.fromLTRB(18, 16, 16, 16),
         child: Row(
           children: [
-            Icon(icon, color: AppColors.textSecondary, size: 30),
+            Icon(icon, color: scheme.onSurfaceVariant, size: 30),
             const SizedBox(width: 16),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(title, style: _cardTitleTextStyle),
+                  Text(
+                    title,
+                    style: _cardTitleTextStyle.copyWith(
+                      color: scheme.onSurface,
+                    ),
+                  ),
                   const SizedBox(height: 3),
-                  Text(subtitle, style: _secondaryTextStyle),
+                  Text(
+                    subtitle,
+                    style: _secondaryTextStyle.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                  ),
                 ],
               ),
             ),
             const SizedBox(width: 12),
-            const Icon(
-              Icons.chevron_right,
-              color: AppColors.textSecondary,
-              size: 30,
-            ),
+            Icon(Icons.chevron_right, color: scheme.onSurfaceVariant, size: 30),
           ],
         ),
       ),
@@ -2378,25 +2739,21 @@ class _SummaryGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tiles = <Widget>[];
-    for (var index = 0; index < children.length; index += 1) {
-      tiles.add(
-        Expanded(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              border: index == children.length - 1
-                  ? null
-                  : const Border(right: BorderSide(color: Color(0xFFE8ECF1))),
-            ),
-            child: children[index],
-          ),
-        ),
-      );
-    }
-
+    final outline = Theme.of(context).colorScheme.outline;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 14),
-      child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: tiles),
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (var index = 0; index < children.length; index += 1) ...[
+              if (index > 0)
+                ColoredBox(color: outline, child: const SizedBox(width: 1)),
+              Expanded(child: children[index]),
+            ],
+          ],
+        ),
+      ),
     );
   }
 }
@@ -2425,7 +2782,12 @@ class _SummaryTile extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            swatch ?? Icon(icon, color: AppColors.textSecondary, size: 28),
+            swatch ??
+                Icon(
+                  icon,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  size: 28,
+                ),
             const SizedBox(width: 10),
             Flexible(
               child: Column(
@@ -2436,7 +2798,9 @@ class _SummaryTile extends StatelessWidget {
                     title,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: _titleTextStyle,
+                    style: _titleTextStyle.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
                   ),
                   const SizedBox(height: 2),
                   Text(
@@ -2514,21 +2878,16 @@ class _SettingsSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    return _SettingsChrome(
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           if (showTitle) ...[
             Text(
               title,
-              style: const TextStyle(
-                color: AppColors.textPrimary,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurface,
                 fontSize: 15,
                 fontWeight: FontWeight.w900,
                 letterSpacing: 0,
@@ -2558,7 +2917,7 @@ class _SettingsSubheading extends StatelessWidget {
         Expanded(
           child: Text(
             title,
-            style: const TextStyle(
+            style: TextStyle(
               color: AppColors.textPrimary,
               fontSize: 14,
               fontWeight: FontWeight.w900,
@@ -2638,7 +2997,7 @@ class _NumberStepperSetting extends StatelessWidget {
                 valueLabel,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
+                style: TextStyle(
                   color: AppColors.textPrimary,
                   fontSize: 13,
                   fontWeight: FontWeight.w900,
@@ -2685,7 +3044,7 @@ class _NumberStepperIconButton extends StatelessWidget {
           disabledForegroundColor: AppColors.textSecondary.withValues(
             alpha: 0.5,
           ),
-          side: const BorderSide(color: AppColors.border),
+          side: BorderSide(color: AppColors.border),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
         icon: Icon(icon, size: 18),
@@ -2875,6 +3234,7 @@ class _CustomAspectRatioDialog extends StatefulWidget {
 class _CustomAspectRatioDialogState extends State<_CustomAspectRatioDialog> {
   late final TextEditingController _widthController;
   late final TextEditingController _heightController;
+  String? _errorText;
 
   @override
   void initState() {
@@ -2898,11 +3258,7 @@ class _CustomAspectRatioDialogState extends State<_CustomAspectRatioDialog> {
     final width = double.tryParse(_widthController.text.trim());
     final height = double.tryParse(_heightController.text.trim());
     if (width == null || height == null || width <= 0 || height <= 0) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('\u8bf7\u8f93\u5165\u6709\u6548\u6bd4\u4f8b'),
-        ),
-      );
+      setState(() => _errorText = '请输入有效比例');
       return;
     }
     Navigator.of(context).pop((width: width, height: height));
@@ -2912,6 +3268,7 @@ class _CustomAspectRatioDialogState extends State<_CustomAspectRatioDialog> {
   Widget build(BuildContext context) {
     return AppInputDialog(
       title: '\u81ea\u5b9a\u4e49\u6bd4\u4f8b',
+      errorText: _errorText,
       content: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
@@ -2921,6 +3278,11 @@ class _CustomAspectRatioDialogState extends State<_CustomAspectRatioDialog> {
               child: TextField(
                 onTapOutside: dismissKeyboardOnTapOutside,
                 controller: _widthController,
+                onChanged: (_) {
+                  if (_errorText != null) {
+                    setState(() => _errorText = null);
+                  }
+                },
                 keyboardType: const TextInputType.numberWithOptions(
                   decimal: true,
                 ),
@@ -2941,6 +3303,11 @@ class _CustomAspectRatioDialogState extends State<_CustomAspectRatioDialog> {
               child: TextField(
                 onTapOutside: dismissKeyboardOnTapOutside,
                 controller: _heightController,
+                onChanged: (_) {
+                  if (_errorText != null) {
+                    setState(() => _errorText = null);
+                  }
+                },
                 keyboardType: const TextInputType.numberWithOptions(
                   decimal: true,
                 ),
@@ -3055,22 +3422,7 @@ class _AppearancePanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.04),
-            blurRadius: 12,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      child: child,
-    );
+    return _SettingsChrome(padding: const EdgeInsets.all(14), child: child);
   }
 }
 
@@ -3082,12 +3434,18 @@ class _InlineSectionTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(title, style: _titleTextStyle),
+        Text(title, style: _titleTextStyle.copyWith(color: scheme.onSurface)),
         const SizedBox(width: 10),
-        Flexible(child: Text(subtitle, style: _captionTextStyle)),
+        Flexible(
+          child: Text(
+            subtitle,
+            style: _captionTextStyle.copyWith(color: scheme.onSurfaceVariant),
+          ),
+        ),
       ],
     );
   }
@@ -3203,8 +3561,7 @@ class _ThemeColorButton extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          AnimatedContainer(
-            duration: const Duration(milliseconds: 160),
+          Container(
             width: selected ? 42 : 38,
             height: selected ? 42 : 38,
             padding: const EdgeInsets.all(4),
@@ -3258,6 +3615,7 @@ class _CustomThemeColorDialogState extends State<_CustomThemeColorDialog> {
   late final TextEditingController _nameController;
   late final TextEditingController _hexController;
   late Color _color;
+  String? _errorText;
 
   @override
   void initState() {
@@ -3296,11 +3654,7 @@ class _CustomThemeColorDialogState extends State<_CustomThemeColorDialog> {
     final name = _nameController.text.trim();
     final color = _colorFromHex(_hexController.text) ?? _color;
     if (name.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('\u8bf7\u8f93\u5165\u989c\u8272\u540d\u79f0'),
-        ),
-      );
+      setState(() => _errorText = '请输入颜色名称');
       return;
     }
     Navigator.of(
@@ -3312,6 +3666,7 @@ class _CustomThemeColorDialogState extends State<_CustomThemeColorDialog> {
   Widget build(BuildContext context) {
     return AppInputDialog(
       title: '\u81ea\u5b9a\u4e49\u4e3b\u9898\u8272',
+      errorText: _errorText,
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -3341,6 +3696,11 @@ class _CustomThemeColorDialogState extends State<_CustomThemeColorDialog> {
             child: TextField(
               onTapOutside: dismissKeyboardOnTapOutside,
               controller: _nameController,
+              onChanged: (_) {
+                if (_errorText != null) {
+                  setState(() => _errorText = null);
+                }
+              },
               decoration: appDialogInputDecoration(),
             ),
           ),
@@ -3614,6 +3974,7 @@ class _ModeButton extends StatelessWidget {
     required this.label,
     this.selected = false,
     this.onTap,
+    super.key,
   });
 
   final IconData icon;
@@ -3623,43 +3984,42 @@ class _ModeButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final border = selected ? AppColors.accent : scheme.outline;
+    final foreground = selected ? AppColors.accent : scheme.onSurfaceVariant;
     return InkWell(
       borderRadius: BorderRadius.circular(8),
       onTap: onTap,
-      child: Container(
-        height: 40,
+      child: DecoratedBox(
         decoration: BoxDecoration(
           color: selected
               ? AppColors.accent.withValues(alpha: 0.08)
-              : AppColors.surface,
+              : scheme.surface,
           borderRadius: BorderRadius.circular(8),
-          border: Border.all(
-            color: selected ? AppColors.accent : AppColors.border,
-          ),
+          border: Border.all(color: border),
         ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              icon,
-              color: selected ? AppColors.accent : AppColors.textSecondary,
-              size: 18,
-            ),
-            const SizedBox(width: 6),
-            Flexible(
-              child: Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  color: selected ? AppColors.accent : AppColors.textSecondary,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 0,
+        child: SizedBox(
+          height: 40,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(icon, color: foreground, size: 18),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: foreground,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -3692,7 +4052,7 @@ class _ScaleStepper extends StatelessWidget {
           Container(
             width: 72,
             alignment: Alignment.center,
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               border: Border.symmetric(
                 vertical: BorderSide(color: AppColors.border),
               ),
@@ -3848,13 +4208,107 @@ class _FontSizeButton extends StatelessWidget {
   }
 }
 
-class _SettingsDivider extends StatelessWidget {
-  const _SettingsDivider();
+class _AnitabiServiceRow extends StatelessWidget {
+  const _AnitabiServiceRow({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.url,
+    required this.onTap,
+    this.status,
+    this.testing = false,
+  });
+
+  final IconData icon;
+  final String title;
+  final String url;
+  final VoidCallback onTap;
+  final String? status;
+  final bool testing;
 
   @override
   Widget build(BuildContext context) {
-    return const Divider(height: 1, thickness: 1, color: Color(0xFFE8ECF1));
+    final compactStatus = status == null
+        ? null
+        : _compactAnitabiProbeStatus(status!);
+    final succeeded = status?.startsWith('连接成功') ?? false;
+    final statusColor = succeeded ? AppColors.accent : AppColors.error;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        child: Row(
+          children: [
+            Icon(icon, color: AppColors.accent, size: 22),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w800,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    url,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: _secondaryTextStyle,
+                  ),
+                ],
+              ),
+            ),
+            if (testing) ...[
+              const SizedBox(width: 8),
+              const SizedBox.square(
+                dimension: 14,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ] else if (compactStatus != null) ...[
+              const SizedBox(width: 8),
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 108),
+                child: Text(
+                  compactStatus,
+                  key: ValueKey('anitabi-service-status-$title'),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.right,
+                  style: TextStyle(
+                    color: statusColor,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ),
+            ],
+            const SizedBox(width: 2),
+            Icon(Icons.chevron_right, color: AppColors.textSecondary, size: 22),
+          ],
+        ),
+      ),
+    );
   }
+}
+
+String _compactAnitabiProbeStatus(String result) {
+  if (result.startsWith('连接成功')) {
+    final match = RegExp(r'(\d+)\s*ms').firstMatch(result);
+    if (match != null) {
+      return '成功 · ${match.group(1)}ms';
+    }
+    return '成功';
+  }
+  return '失败';
 }
 
 class _AnitabiServiceEntryRow extends StatelessWidget {
@@ -3878,7 +4332,7 @@ class _AnitabiServiceEntryRow extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 6),
         child: Row(
           children: [
-            const Icon(Icons.dns_outlined, color: AppColors.textSecondary),
+            Icon(Icons.dns_outlined, color: AppColors.textSecondary),
             const SizedBox(width: 10),
             Expanded(
               child: Column(
@@ -3888,7 +4342,7 @@ class _AnitabiServiceEntryRow extends StatelessWidget {
                     siteUrl,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: AppColors.textPrimary,
                       fontSize: 14,
                       fontWeight: FontWeight.w700,
@@ -3906,11 +4360,7 @@ class _AnitabiServiceEntryRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 10),
-            const Icon(
-              Icons.chevron_right,
-              color: AppColors.textSecondary,
-              size: 22,
-            ),
+            Icon(Icons.chevron_right, color: AppColors.textSecondary, size: 22),
           ],
         ),
       ),
@@ -3920,7 +4370,6 @@ class _AnitabiServiceEntryRow extends StatelessWidget {
 
 class _MapUrlRow extends StatelessWidget {
   const _MapUrlRow({
-    super.key,
     required this.icon,
     required this.label,
     required this.onTap,
@@ -3950,11 +4399,7 @@ class _MapUrlRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 10),
-            const Icon(
-              Icons.edit_outlined,
-              color: AppColors.textSecondary,
-              size: 20,
-            ),
+            Icon(Icons.edit_outlined, color: AppColors.textSecondary, size: 20),
           ],
         ),
       ),
@@ -4507,8 +4952,7 @@ class _ThemeSwatch extends StatelessWidget {
         customColorValue ?? AppColors.customAccentValue,
       ),
     };
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 160),
+    return Container(
       width: selected ? 42 : 38,
       height: selected ? 42 : 38,
       padding: const EdgeInsets.all(4),
@@ -4553,34 +4997,31 @@ class _InfoRow extends StatelessWidget {
   }
 }
 
-const _cardTitleTextStyle = TextStyle(
+TextStyle get _cardTitleTextStyle => TextStyle(
   color: AppColors.textPrimary,
   fontSize: 16,
   fontWeight: FontWeight.w900,
   letterSpacing: 0,
 );
 
-const _titleTextStyle = TextStyle(
+TextStyle get _titleTextStyle => TextStyle(
   color: AppColors.textPrimary,
   fontSize: 15,
   fontWeight: FontWeight.w800,
   letterSpacing: 0,
 );
 
-const _secondaryTextStyle = TextStyle(
-  color: AppColors.textSecondary,
-  fontSize: 13,
-  letterSpacing: 0,
-);
+TextStyle get _secondaryTextStyle =>
+    TextStyle(color: AppColors.textSecondary, fontSize: 13, letterSpacing: 0);
 
-const _captionTextStyle = TextStyle(
+TextStyle get _captionTextStyle => TextStyle(
   color: AppColors.textSecondary,
   fontSize: 12,
   fontWeight: FontWeight.w700,
   letterSpacing: 0,
 );
 
-const _secondaryParagraphTextStyle = TextStyle(
+TextStyle get _secondaryParagraphTextStyle => TextStyle(
   color: AppColors.textSecondary,
   fontSize: 13,
   height: 1.45,

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -105,7 +105,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return Scaffold(
       appBar: AppBar(
         key: const ValueKey('settings-app-bar'),
-        toolbarHeight: kToolbarHeight,
+        toolbarHeight: AppTheme.appBarHeight,
         title: const Text(
           '设置',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
@@ -1549,10 +1549,10 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
         _SettingsSection(
           title: 'Anitabi 服务地址',
           children: [
-            _MapUrlRow(
+            _AnitabiServiceEntryRow(
               key: const ValueKey('anitabi-service-settings-entry'),
-              icon: Icons.dns_outlined,
-              label: '主站、静态数据、API 与图片服务',
+              siteUrl: settings.anitabiSiteBaseUrl,
+              usingDefaults: _usesDefaultAnitabiService(settings),
               onTap: () => Navigator.of(context).push(
                 MaterialPageRoute<void>(
                   builder: (_) => _AnitabiServiceSettingsPage(
@@ -1750,6 +1750,27 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
         _SettingsSection(
           title: '地图标记',
           children: [
+            Material(
+              color: Colors.transparent,
+              child: SwitchListTile(
+                key: const ValueKey('hide-completed-points-on-map-toggle'),
+                contentPadding: EdgeInsets.zero,
+                secondary: const Icon(
+                  Icons.visibility_off_outlined,
+                  color: AppColors.textSecondary,
+                ),
+                title: const Text('隐藏已完成点位', style: _titleTextStyle),
+                subtitle: const Text(
+                  '在地图页不显示已标记完成的点位。关闭后仍可在地图上看到全部点位。',
+                  style: _secondaryTextStyle,
+                ),
+                value: settings.hideCompletedPointsOnMap,
+                onChanged: (value) {
+                  _update(settings.copyWith(hideCompletedPointsOnMap: value));
+                },
+              ),
+            ),
+            const SizedBox(height: 12),
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -3836,6 +3857,67 @@ class _SettingsDivider extends StatelessWidget {
   }
 }
 
+class _AnitabiServiceEntryRow extends StatelessWidget {
+  const _AnitabiServiceEntryRow({
+    super.key,
+    required this.siteUrl,
+    required this.usingDefaults,
+    required this.onTap,
+  });
+
+  final String siteUrl;
+  final bool usingDefaults;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Row(
+          children: [
+            const Icon(Icons.dns_outlined, color: AppColors.textSecondary),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    siteUrl,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: AppColors.textPrimary,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    usingDefaults ? '使用默认地址，点击管理全部服务' : '已自定义，点击管理全部服务',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: _secondaryTextStyle,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            const Icon(
+              Icons.chevron_right,
+              color: AppColors.textSecondary,
+              size: 22,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _MapUrlRow extends StatelessWidget {
   const _MapUrlRow({
     super.key,
@@ -4261,6 +4343,15 @@ String _mapProviderHint(MapTileProvider provider) {
     MapTileProvider.customXyz => '\u74e6\u7247\u6a21\u677f',
     MapTileProvider.customMapLibreStyle => '\u6837\u5f0f URL',
   };
+}
+
+bool _usesDefaultAnitabiService(AppSettings settings) {
+  return settings.anitabiSiteBaseUrl == defaultAnitabiSiteBaseUrl &&
+      settings.anitabiStaticDataBaseUrl == defaultAnitabiStaticDataBaseUrl &&
+      settings.anitabiApiBaseUrl == defaultAnitabiApiBaseUrl &&
+      settings.anitabiOfficialImageBaseUrl ==
+          defaultAnitabiOfficialImageBaseUrl &&
+      settings.anitabiMirrorImageBaseUrl == defaultAnitabiMirrorImageBaseUrl;
 }
 
 String _anitabiImageSourceLabel(AnitabiImageSource source) {

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -18,6 +18,7 @@ import '../records/comparison_export_config_storage_stub.dart'
     if (dart.library.io) '../records/comparison_export_config_storage_io.dart';
 import '../widgets/copyable_text.dart';
 import '../widgets/confirm_action_dialog.dart';
+import '../widgets/app_back_button.dart';
 import '../widgets/input_dialog.dart';
 import '../widgets/snackbar_helper.dart';
 
@@ -103,22 +104,27 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        key: const ValueKey('settings-app-bar'),
+        toolbarHeight: kToolbarHeight,
         title: const Text(
           '设置',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.w900),
         ),
         actions: [
           IconButton(
+            key: const ValueKey('settings-reset-button'),
             tooltip: '恢复初始设置',
             onPressed: _confirmResetSettings,
             icon: const Icon(Icons.restart_alt_outlined),
           ),
+          const SizedBox(width: 16),
         ],
       ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         children: [
           _SettingsCard(
+            key: const ValueKey('settings-appearance-card'),
             header: _SettingsCardHeader(
               icon: Icons.palette_outlined,
               title: '外观设置',
@@ -730,6 +736,33 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                 value: settings.showPlanGroupProgress,
                 onChanged: (value) {
                   _update(settings.copyWith(showPlanGroupProgress: value));
+                },
+              ),
+            ),
+          ),
+          const SizedBox(height: 14),
+          _AppearancePanel(
+            child: Material(
+              color: Colors.transparent,
+              child: SwitchListTile(
+                key: const ValueKey(
+                  'dismiss-plan-actions-on-outside-tap-toggle',
+                ),
+                contentPadding: EdgeInsets.zero,
+                secondary: const Icon(
+                  Icons.touch_app_outlined,
+                  color: AppColors.textSecondary,
+                ),
+                title: const Text('点击空白收回计划操作', style: _titleTextStyle),
+                subtitle: const Text(
+                  '展开计划操作后，点击面板外的空白区域自动收回',
+                  style: _secondaryTextStyle,
+                ),
+                value: settings.dismissPlanActionsOnOutsideTap,
+                onChanged: (value) {
+                  _update(
+                    settings.copyWith(dismissPlanActionsOnOutsideTap: value),
+                  );
                 },
               ),
             ),
@@ -2163,7 +2196,10 @@ class _DetailScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(title)),
+      appBar: AppBar(
+        leading: appBackButtonIfCanPop(context),
+        title: Text(title),
+      ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 24),
         children: children,
@@ -2240,7 +2276,11 @@ extension _ZoomStepSnap on double {
 }
 
 class _SettingsCard extends StatelessWidget {
-  const _SettingsCard({required this.header, this.children = const []});
+  const _SettingsCard({
+    required this.header,
+    this.children = const [],
+    super.key,
+  });
 
   final _SettingsCardHeader header;
   final List<Widget> children;

--- a/lib/widgets/app_back_button.dart
+++ b/lib/widgets/app_back_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class AppBackButton extends StatelessWidget {
+  const AppBackButton({this.onPressed, super.key});
+
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox.square(
+        dimension: 40,
+        child: IconButton(
+          onPressed: onPressed ?? () => Navigator.of(context).maybePop(),
+          padding: const EdgeInsets.all(8),
+          constraints: const BoxConstraints.tightFor(width: 40, height: 40),
+          style: IconButton.styleFrom(
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+          icon: const Icon(Icons.arrow_back, semanticLabel: '返回'),
+        ),
+      ),
+    );
+  }
+}
+
+Widget? appBackButtonIfCanPop(BuildContext context) {
+  return ModalRoute.of(context)?.canPop == true ? const AppBackButton() : null;
+}

--- a/lib/widgets/app_scaled_route.dart
+++ b/lib/widgets/app_scaled_route.dart
@@ -75,8 +75,10 @@ class _AppScaledRouteView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    AppColors.palette = settings.themePalette;
-    AppColors.customAccentValue = settings.customThemeColorValue;
+    applyAppColorsFromSettings(
+      settings,
+      platformBrightness: MediaQuery.platformBrightnessOf(context),
+    );
 
     return MediaQuery(
       data: MediaQuery.of(
@@ -87,9 +89,9 @@ class _AppScaledRouteView extends StatelessWidget {
         child: AppUiScaleView(
           scale: settings.uiScale,
           child: Theme(
-            data: AppTheme.light(
-              palette: settings.themePalette,
-              customAccentValue: settings.customThemeColorValue,
+            data: appThemeFor(
+              settings,
+              platformBrightness: MediaQuery.platformBrightnessOf(context),
             ),
             child: child,
           ),

--- a/lib/widgets/app_status_banner.dart
+++ b/lib/widgets/app_status_banner.dart
@@ -1,0 +1,485 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../app_theme.dart';
+
+enum AppStatusBannerKind { running, success, warning, error }
+
+const appStatusSnackDuration = Duration(seconds: 3);
+
+String statusBannerSentence(String text) {
+  if (text.endsWith('。') && !text.substring(0, text.length - 1).contains('。')) {
+    return text.substring(0, text.length - 1);
+  }
+  return text;
+}
+
+IconData statusBannerIcon({
+  required AppStatusBannerKind kind,
+  required String title,
+  IconData? icon,
+}) {
+  if (icon != null) {
+    return icon;
+  }
+  return switch (kind) {
+    AppStatusBannerKind.success => Icons.check_rounded,
+    AppStatusBannerKind.warning => Icons.warning_rounded,
+    AppStatusBannerKind.error => Icons.error_rounded,
+    AppStatusBannerKind.running => statusBannerRunningIcon(title),
+  };
+}
+
+IconData statusBannerRunningIcon(String title) {
+  if (title.contains('取消')) {
+    return Icons.cancel_outlined;
+  }
+  if (title.contains('导出')) {
+    return Icons.ios_share_outlined;
+  }
+  if (title.contains('导入')) {
+    return Icons.add_location_alt_outlined;
+  }
+  if (title.contains('替换')) {
+    return Icons.swap_horiz_outlined;
+  }
+  if (title.contains('比例') || title.contains('读取')) {
+    return Icons.aspect_ratio_outlined;
+  }
+  if (title.contains('清除') || title.contains('重新加载')) {
+    return Icons.cleaning_services_outlined;
+  }
+  if (title.contains('缩略图')) {
+    return Icons.photo_library_outlined;
+  }
+  if (title.contains('缓存')) {
+    return Icons.cached_outlined;
+  }
+  if (title.contains('保存')) {
+    return Icons.save_outlined;
+  }
+  return Icons.hourglass_top_outlined;
+}
+
+SnackBar appStatusSnackBar({
+  required AppStatusBannerKind kind,
+  required String title,
+  String? subtitle,
+  IconData? icon,
+  Duration duration = appStatusSnackDuration,
+}) {
+  return SnackBar(
+    backgroundColor: Colors.transparent,
+    elevation: 0,
+    padding: EdgeInsets.zero,
+    margin: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+    behavior: SnackBarBehavior.floating,
+    duration: duration,
+    content: AppStatusBanner(
+      kind: kind,
+      title: title,
+      subtitle: subtitle,
+      icon: icon,
+    ),
+  );
+}
+
+Future<void> showStatusBannerOverlay({
+  required BuildContext context,
+  required Widget Function(BuildContext dialogContext) builder,
+}) async {
+  final scaffold = context.findAncestorWidgetOfExactType<Scaffold>();
+  final navExtra = scaffold?.bottomNavigationBar == null
+      ? 0.0
+      : (NavigationBarTheme.of(context).height ?? 80);
+  Timer? autoClose;
+
+  await showGeneralDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    barrierColor: Colors.transparent,
+    transitionDuration: const Duration(milliseconds: 180),
+    pageBuilder: (dialogContext, animation, secondaryAnimation) {
+      autoClose ??= Timer(appStatusSnackDuration, () {
+        if (dialogContext.mounted) {
+          Navigator.of(dialogContext).pop();
+        }
+      });
+      return SafeArea(
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(12, 0, 12, 12 + navExtra),
+            child: SizedBox(
+              width: double.infinity,
+              child: builder(dialogContext),
+            ),
+          ),
+        ),
+      );
+    },
+    transitionBuilder: (context, animation, secondaryAnimation, child) {
+      final curved = CurvedAnimation(
+        parent: animation,
+        curve: Curves.easeOutCubic,
+        reverseCurve: Curves.easeInCubic,
+      );
+      return FadeTransition(
+        opacity: curved,
+        child: SlideTransition(
+          position: Tween<Offset>(
+            begin: const Offset(0, 0.1),
+            end: Offset.zero,
+          ).animate(curved),
+          child: child,
+        ),
+      );
+    },
+  );
+  autoClose?.cancel();
+}
+
+Future<void> showPlanExportBannerDebugPreview(BuildContext context) {
+  return showStatusBannerOverlay(
+    context: context,
+    builder: (_) {
+      return const SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AppStatusBanner(
+              key: ValueKey('plan-export-debug-running'),
+              kind: AppStatusBannerKind.running,
+              title: '正在导出...',
+              icon: Icons.ios_share_outlined,
+            ),
+            SizedBox(height: 8),
+            AppStatusBanner(
+              key: ValueKey('plan-export-debug-canceled'),
+              kind: AppStatusBannerKind.running,
+              title: '已取消导出',
+              icon: Icons.cancel_outlined,
+            ),
+            SizedBox(height: 8),
+            AppStatusBanner(
+              key: ValueKey('plan-export-debug-success'),
+              kind: AppStatusBannerKind.success,
+              title: '数据包已导出',
+              subtitle: '已保存到本地',
+            ),
+            SizedBox(height: 8),
+            AppStatusBanner(
+              key: ValueKey('plan-export-debug-warning'),
+              kind: AppStatusBannerKind.warning,
+              title: '数据包已导出',
+              subtitle: '3 张完整参考图下载失败，2 张巡礼照片缺失',
+            ),
+            SizedBox(height: 8),
+            AppStatusBanner(
+              key: ValueKey('plan-export-debug-failed'),
+              kind: AppStatusBannerKind.error,
+              title: '导出失败',
+              subtitle: '请稍后重试',
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+class AppStatusBanner extends StatelessWidget {
+  const AppStatusBanner({
+    super.key,
+    required this.kind,
+    required this.title,
+    this.subtitle,
+    this.subtitleWidget,
+    this.footer,
+    this.actionLabel,
+    this.onAction,
+    this.actionKey,
+    this.icon,
+  });
+
+  final AppStatusBannerKind kind;
+  final String title;
+  final String? subtitle;
+  final Widget? subtitleWidget;
+  final Widget? footer;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+  final Key? actionKey;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final palette = AppStatusBannerPalette.of(kind);
+    return Material(
+      color: palette.background,
+      elevation: kind == AppStatusBannerKind.running ? 8 : 2,
+      shadowColor: Colors.black.withValues(alpha: AppColors.isDark ? 0.45 : 0.18),
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: palette.border),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                _StatusIcon(
+                  kind: kind,
+                  palette: palette,
+                  title: title,
+                  icon: icon,
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        statusBannerSentence(title),
+                        style: TextStyle(
+                          color: AppColors.textPrimary,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w800,
+                          height: 1.2,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      if (subtitleWidget != null ||
+                          (subtitle != null && subtitle!.isNotEmpty)) ...[
+                        const SizedBox(height: 2),
+                        if (subtitleWidget != null)
+                          subtitleWidget!
+                        else
+                          Text(
+                            statusBannerSentence(subtitle!),
+                            style: TextStyle(
+                              color: AppColors.textSecondary,
+                              fontSize: 12,
+                              height: 1.2,
+                              letterSpacing: 0,
+                            ),
+                          ),
+                      ],
+                    ],
+                  ),
+                ),
+                if (actionLabel != null) ...[
+                  const SizedBox(width: 8),
+                  _ActionButton(
+                    buttonKey: actionKey,
+                    label: actionLabel!,
+                    color: palette.action,
+                    onPressed: onAction ?? () {},
+                  ),
+                ],
+              ],
+            ),
+            if (footer != null) ...[const SizedBox(height: 8), footer!],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class AppStatusBannerPalette {
+  const AppStatusBannerPalette({
+    required this.background,
+    required this.border,
+    required this.iconFill,
+    required this.iconColor,
+    required this.action,
+  });
+
+  final Color background;
+  final Color border;
+  final Color iconFill;
+  final Color iconColor;
+  final Color action;
+
+  factory AppStatusBannerPalette.of(AppStatusBannerKind kind) {
+    final isDark = AppColors.isDark;
+    final surface = AppColors.surface;
+    return switch (kind) {
+      AppStatusBannerKind.running => AppStatusBannerPalette(
+        background: surface,
+        border: AppColors.border,
+        iconFill: AppColors.accent.withValues(alpha: isDark ? 0.22 : 0.12),
+        iconColor: AppColors.accent,
+        action: AppColors.accent,
+      ),
+      AppStatusBannerKind.success => AppStatusBannerPalette(
+        background: isDark
+            ? Color.alphaBlend(
+                AppColors.accent.withValues(alpha: 0.28),
+                surface,
+              )
+            : const Color(0xFFE8F6F1),
+        border: AppColors.accent.withValues(alpha: isDark ? 0.55 : 0.38),
+        iconFill: AppColors.accent,
+        iconColor: Colors.white,
+        action: AppColors.accent,
+      ),
+      AppStatusBannerKind.warning => AppStatusBannerPalette(
+        background: isDark
+            ? Color.alphaBlend(
+                AppColors.warning.withValues(alpha: 0.28),
+                surface,
+              )
+            : const Color(0xFFFFF6E5),
+        border: AppColors.warning.withValues(alpha: isDark ? 0.58 : 0.42),
+        iconFill: isDark ? AppColors.warning : const Color(0xFFE2A336),
+        iconColor: Colors.white,
+        action: isDark ? AppColors.warning : const Color(0xFFD48806),
+      ),
+      AppStatusBannerKind.error => AppStatusBannerPalette(
+        background: isDark
+            ? Color.alphaBlend(AppColors.error.withValues(alpha: 0.28), surface)
+            : const Color(0xFFFDECEC),
+        border: AppColors.error.withValues(alpha: isDark ? 0.58 : 0.42),
+        iconFill: AppColors.error,
+        iconColor: Colors.white,
+        action: AppColors.error,
+      ),
+    };
+  }
+}
+
+class _StatusIcon extends StatelessWidget {
+  const _StatusIcon({
+    required this.kind,
+    required this.palette,
+    required this.title,
+    this.icon,
+  });
+
+  final AppStatusBannerKind kind;
+  final AppStatusBannerPalette palette;
+  final String title;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    if (kind == AppStatusBannerKind.warning) {
+      return Icon(Icons.warning_rounded, size: 32, color: palette.iconFill);
+    }
+    if (kind == AppStatusBannerKind.error) {
+      return Icon(Icons.error_rounded, size: 32, color: palette.iconFill);
+    }
+    final resolved = statusBannerIcon(kind: kind, title: title, icon: icon);
+    return Container(
+      width: 32,
+      height: 32,
+      alignment: Alignment.center,
+      decoration: ShapeDecoration(
+        color: palette.iconFill,
+        shape: const CircleBorder(),
+      ),
+      child: Icon(resolved, size: 18, color: palette.iconColor),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.label,
+    required this.color,
+    required this.onPressed,
+    this.buttonKey,
+  });
+
+  final Key? buttonKey;
+  final String label;
+  final Color color;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      key: buttonKey,
+      onPressed: onPressed,
+      style: OutlinedButton.styleFrom(
+        foregroundColor: color,
+        side: BorderSide(color: color),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        minimumSize: const Size(0, 30),
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        visualDensity: VisualDensity.compact,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        textStyle: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0,
+        ),
+      ),
+      child: Text(label),
+    );
+  }
+}
+
+class AppStatusBannerProgressLine extends StatelessWidget {
+  const AppStatusBannerProgressLine({
+    required this.countLabel,
+    required this.percentLabel,
+    required this.value,
+    this.barKey,
+    super.key,
+  });
+
+  final String countLabel;
+  final String percentLabel;
+  final double value;
+  final Key? barKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          countLabel,
+          style: TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(99),
+            child: LinearProgressIndicator(
+              key: barKey,
+              value: value,
+              minHeight: 4,
+              backgroundColor: AppColors.border.withValues(alpha: 0.7),
+              color: AppColors.accent,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          percentLabel,
+          style: TextStyle(
+            color: AppColors.accent,
+            fontSize: 13,
+            fontWeight: FontWeight.w800,
+            letterSpacing: 0,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/clear_anchor_selection_button.dart
+++ b/lib/widgets/clear_anchor_selection_button.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class ClearAnchorSelectionButton extends StatelessWidget {
+  const ClearAnchorSelectionButton({required this.onPressed, super.key});
+
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      tooltip: '清除选点',
+      onPressed: onPressed,
+      icon: const Icon(Icons.clear),
+    );
+  }
+}

--- a/lib/widgets/confirm_action_dialog.dart
+++ b/lib/widgets/confirm_action_dialog.dart
@@ -27,6 +27,22 @@ Future<bool> showConfirmActionDialog(
   return confirmed == true;
 }
 
+Future<void> showInfoActionDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  String confirmLabel = '知道了',
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (context) => InfoActionDialog(
+      title: title,
+      message: message,
+      confirmLabel: confirmLabel,
+    ),
+  );
+}
+
 class ConfirmActionDialog extends StatelessWidget {
   const ConfirmActionDialog({
     required this.title,
@@ -81,7 +97,7 @@ class ConfirmActionDialog extends StatelessWidget {
               children: [
                 Text(
                   title,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textPrimary,
                     fontSize: 18,
                     fontWeight: FontWeight.w800,
@@ -137,6 +153,66 @@ class ConfirmActionDialog extends StatelessWidget {
   }
 }
 
+class InfoActionDialog extends StatelessWidget {
+  const InfoActionDialog({
+    required this.title,
+    required this.message,
+    this.confirmLabel = '知道了',
+    super.key,
+  });
+
+  final String title;
+  final String message;
+  final String confirmLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final maxHeight = _availableDialogHeight(context);
+    return Dialog(
+      insetPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+      backgroundColor: AppColors.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: 420, maxHeight: maxHeight),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                _EmphasizedMessage(message, emphasizedValues: const []),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size.fromHeight(48),
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                  child: _DialogActionLabel(confirmLabel),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _StandardConfirmDialog extends StatelessWidget {
   const _StandardConfirmDialog({
     required this.title,
@@ -174,7 +250,7 @@ class _StandardConfirmDialog extends StatelessWidget {
               children: [
                 Text(
                   title,
-                  style: const TextStyle(
+                  style: TextStyle(
                     color: AppColors.textPrimary,
                     fontSize: 18,
                     fontWeight: FontWeight.w800,
@@ -329,7 +405,7 @@ class _EmphasizedMessage extends StatelessWidget {
             .toSet()
             .toList()
           ..sort((a, b) => b.length.compareTo(a.length));
-    final baseStyle = const TextStyle(
+    final baseStyle = TextStyle(
       color: AppColors.textSecondary,
       fontSize: 14,
       height: 1.55,
@@ -349,7 +425,7 @@ class _EmphasizedMessage extends StatelessWidget {
       spans.add(
         TextSpan(
           text: match.group(0),
-          style: const TextStyle(
+          style: TextStyle(
             color: AppColors.textPrimary,
             fontWeight: FontWeight.w800,
           ),

--- a/lib/widgets/confirm_action_dialog.dart
+++ b/lib/widgets/confirm_action_dialog.dart
@@ -121,37 +121,12 @@ class ConfirmActionDialog extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 16),
-                OverflowBar(
-                  spacing: 10,
-                  overflowSpacing: 8,
-                  alignment: MainAxisAlignment.end,
-                  overflowAlignment: OverflowBarAlignment.end,
-                  children: [
-                    FilledButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      style: FilledButton.styleFrom(
-                        foregroundColor: AppColors.textPrimary,
-                        backgroundColor: AppColors.surfaceMuted,
-                        minimumSize: const Size.fromHeight(48),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      child: Text(cancelLabel),
-                    ),
-                    FilledButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      style: FilledButton.styleFrom(
-                        foregroundColor: Colors.white,
-                        backgroundColor: dangerColor,
-                        minimumSize: const Size.fromHeight(48),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      child: Text(confirmLabel),
-                    ),
-                  ],
+                AppDialogActionRow(
+                  cancelLabel: cancelLabel,
+                  confirmLabel: confirmLabel,
+                  confirmColor: dangerColor,
+                  onCancel: () => Navigator.of(context).pop(false),
+                  onConfirm: () => Navigator.of(context).pop(true),
                 ),
               ],
             ),
@@ -247,32 +222,87 @@ class _StandardConfirmDialog extends StatelessWidget {
                   ),
                 ],
                 const SizedBox(height: 16),
-                OverflowBar(
-                  spacing: 6,
-                  overflowSpacing: 8,
-                  alignment: MainAxisAlignment.end,
-                  overflowAlignment: OverflowBarAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: Text(cancelLabel),
-                    ),
-                    FilledButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      style: FilledButton.styleFrom(
-                        minimumSize: const Size(0, 46),
-                        padding: const EdgeInsets.symmetric(horizontal: 20),
-                        shape: const StadiumBorder(),
-                      ),
-                      child: Text(confirmLabel),
-                    ),
-                  ],
+                AppDialogActionRow(
+                  cancelLabel: cancelLabel,
+                  confirmLabel: confirmLabel,
+                  onCancel: () => Navigator.of(context).pop(false),
+                  onConfirm: () => Navigator.of(context).pop(true),
                 ),
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class AppDialogActionRow extends StatelessWidget {
+  const AppDialogActionRow({
+    required this.cancelLabel,
+    required this.confirmLabel,
+    required this.onCancel,
+    required this.onConfirm,
+    this.confirmColor,
+    super.key,
+  });
+
+  final String cancelLabel;
+  final String confirmLabel;
+  final VoidCallback onCancel;
+  final VoidCallback onConfirm;
+  final Color? confirmColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: FilledButton(
+            onPressed: onCancel,
+            style: FilledButton.styleFrom(
+              foregroundColor: AppColors.textPrimary,
+              backgroundColor: AppColors.surfaceMuted,
+              minimumSize: const Size.fromHeight(48),
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            child: _DialogActionLabel(cancelLabel),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: FilledButton(
+            onPressed: onConfirm,
+            style: FilledButton.styleFrom(
+              foregroundColor: Colors.white,
+              backgroundColor: confirmColor ?? AppColors.accent,
+              minimumSize: const Size.fromHeight(48),
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+            child: _DialogActionLabel(confirmLabel),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DialogActionLabel extends StatelessWidget {
+  const _DialogActionLabel(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      child: Text(label, maxLines: 1, softWrap: false),
     );
   }
 }

--- a/lib/widgets/image_viewer_screen.dart
+++ b/lib/widgets/image_viewer_screen.dart
@@ -16,6 +16,7 @@ import '../plan_transfer/plan_export_delivery.dart';
 import '../plan_transfer/plan_export_delivery_result.dart';
 import '../records/gallery_saver_stub.dart'
     if (dart.library.io) '../records/gallery_saver_io.dart';
+import 'snackbar_helper.dart';
 
 typedef ImageViewerRemoteImageResolver =
     Future<Uint8List?> Function(String url, AnitabiImageSource imageSource);
@@ -105,7 +106,11 @@ class ImageViewerScreen extends StatelessWidget {
                 Navigator.of(ctx).pop();
                 final savePath = await _resolveLocalImagePath(context);
                 if (savePath == null) {
-                  _showSnackBar(messenger, '图片读取失败');
+                  _showSnackBar(
+                    messenger,
+                    '图片读取失败',
+                    kind: AppStatusBannerKind.error,
+                  );
                   return;
                 }
                 Share.shareXFiles([XFile(savePath)]);
@@ -114,11 +119,21 @@ class ImageViewerScreen extends StatelessWidget {
                 Navigator.of(ctx).pop();
                 final savePath = await _resolveLocalImagePath(context);
                 if (savePath == null) {
-                  _showSnackBar(messenger, '图片读取失败');
+                  _showSnackBar(
+                    messenger,
+                    '图片读取失败',
+                    kind: AppStatusBannerKind.error,
+                  );
                   return;
                 }
                 final success = await saveImageToGallery(savePath);
-                _showSnackBar(messenger, success ? '已保存到相册' : '保存失败');
+                _showSnackBar(
+                  messenger,
+                  success ? '已保存到相册' : '保存失败',
+                  kind: success
+                      ? AppStatusBannerKind.success
+                      : AppStatusBannerKind.error,
+                );
               },
             ),
       backgroundColor: const Color(0xFF2C2C2E),
@@ -133,7 +148,11 @@ class ImageViewerScreen extends StatelessWidget {
     try {
       final imageBytes = await _resolveImageBytes(sheetContext);
       if (imageBytes == null || imageBytes.isEmpty) {
-        _showSnackBar(messenger, '图片读取失败');
+        _showSnackBar(
+          messenger,
+          '图片读取失败',
+          kind: AppStatusBannerKind.error,
+        );
         return;
       }
       final extension = _preferredExtension();
@@ -147,12 +166,17 @@ class ImageViewerScreen extends StatelessWidget {
         extension: extension,
       );
       if (result.action == PlanExportDeliveryAction.canceled) {
-        _showSnackBar(messenger, '已取消保存');
+        _showSnackBar(
+          messenger,
+          '已取消保存',
+          kind: AppStatusBannerKind.running,
+          icon: Icons.cancel_outlined,
+        );
         return;
       }
-      _showSnackBar(messenger, '图片已保存');
+      _showSnackBar(messenger, '图片已保存', kind: AppStatusBannerKind.success);
     } catch (_) {
-      _showSnackBar(messenger, '保存失败');
+      _showSnackBar(messenger, '保存失败', kind: AppStatusBannerKind.error);
     }
   }
 
@@ -306,8 +330,13 @@ class ImageViewerScreen extends StatelessWidget {
     return base64Decode(payload);
   }
 
-  void _showSnackBar(ScaffoldMessengerState messenger, String message) {
-    messenger.showSnackBar(SnackBar(content: Text(message)));
+  void _showSnackBar(
+    ScaffoldMessengerState messenger,
+    String message, {
+    AppStatusBannerKind kind = AppStatusBannerKind.error,
+    IconData? icon,
+  }) {
+    messenger.showStatusSnack(kind: kind, title: message, icon: icon);
   }
 
   Widget _buildImage(BuildContext context) {

--- a/lib/widgets/input_dialog.dart
+++ b/lib/widgets/input_dialog.dart
@@ -10,6 +10,8 @@ class AppInputDialog extends StatelessWidget {
     required this.confirmLabel,
     required this.onConfirm,
     this.cancelLabel = '取消',
+    this.titleTrailing,
+    this.errorText,
     super.key,
   });
 
@@ -18,6 +20,8 @@ class AppInputDialog extends StatelessWidget {
   final String confirmLabel;
   final VoidCallback onConfirm;
   final String cancelLabel;
+  final Widget? titleTrailing;
+  final String? errorText;
 
   @override
   Widget build(BuildContext context) {
@@ -27,6 +31,12 @@ class AppInputDialog extends StatelessWidget {
           0.0,
           double.infinity,
         );
+    final titleStyle = TextStyle(
+      color: AppColors.textPrimary,
+      fontSize: 18,
+      fontWeight: FontWeight.w800,
+      letterSpacing: 0,
+    );
     return Dialog(
       insetPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
       backgroundColor: AppColors.surface,
@@ -39,17 +49,35 @@ class AppInputDialog extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              Text(
-                title,
-                style: const TextStyle(
-                  color: AppColors.textPrimary,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 0,
+              if (titleTrailing == null)
+                Text(title, style: titleStyle)
+              else
+                SizedBox(
+                  height: 32,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Expanded(child: Text(title, style: titleStyle)),
+                      const SizedBox(width: 8),
+                      titleTrailing!,
+                    ],
+                  ),
                 ),
-              ),
               const SizedBox(height: 18),
               Flexible(child: SingleChildScrollView(child: content)),
+              if (errorText != null && errorText!.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                Text(
+                  errorText!,
+                  style: TextStyle(
+                    color: AppColors.error,
+                    fontSize: 13,
+                    height: 1.3,
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ],
               const SizedBox(height: 16),
               AppDialogActionRow(
                 cancelLabel: cancelLabel,
@@ -59,6 +87,36 @@ class AppInputDialog extends StatelessWidget {
               ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class AppDialogPasteButton extends StatelessWidget {
+  const AppDialogPasteButton({required this.onPressed, super.key});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      key: const ValueKey('dialog-paste-button'),
+      onPressed: onPressed,
+      icon: const Icon(Icons.content_paste_outlined, size: 16),
+      label: const Text('粘贴'),
+      style: OutlinedButton.styleFrom(
+        visualDensity: VisualDensity.compact,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        minimumSize: const Size(0, 32),
+        padding: const EdgeInsets.symmetric(horizontal: 10),
+        foregroundColor: AppColors.textPrimary,
+        side: BorderSide(color: AppColors.border),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        textStyle: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0,
         ),
       ),
     );
@@ -115,7 +173,7 @@ InputDecoration appDialogInputDecoration({
 }) {
   final border = OutlineInputBorder(
     borderRadius: BorderRadius.circular(10),
-    borderSide: const BorderSide(color: AppColors.border),
+    borderSide: BorderSide(color: AppColors.border),
   );
   return InputDecoration(
     hintText: hintText,
@@ -133,11 +191,11 @@ InputDecoration appDialogInputDecoration({
     ),
     errorBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(10),
-      borderSide: const BorderSide(color: AppColors.error),
+      borderSide: BorderSide(color: AppColors.error),
     ),
     focusedErrorBorder: OutlineInputBorder(
       borderRadius: BorderRadius.circular(10),
-      borderSide: const BorderSide(color: AppColors.error, width: 1.25),
+      borderSide: BorderSide(color: AppColors.error, width: 1.25),
     ),
   );
 }

--- a/lib/widgets/input_dialog.dart
+++ b/lib/widgets/input_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../app_theme.dart';
+import 'confirm_action_dialog.dart';
 
 class AppInputDialog extends StatelessWidget {
   const AppInputDialog({
@@ -50,29 +51,11 @@ class AppInputDialog extends StatelessWidget {
               const SizedBox(height: 18),
               Flexible(child: SingleChildScrollView(child: content)),
               const SizedBox(height: 16),
-              OverflowBar(
-                spacing: 6,
-                overflowSpacing: 8,
-                alignment: MainAxisAlignment.end,
-                overflowAlignment: OverflowBarAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    style: TextButton.styleFrom(
-                      foregroundColor: AppColors.textSecondary,
-                    ),
-                    child: Text(cancelLabel),
-                  ),
-                  FilledButton(
-                    onPressed: onConfirm,
-                    style: FilledButton.styleFrom(
-                      minimumSize: const Size(0, 46),
-                      padding: const EdgeInsets.symmetric(horizontal: 20),
-                      shape: const StadiumBorder(),
-                    ),
-                    child: Text(confirmLabel),
-                  ),
-                ],
+              AppDialogActionRow(
+                cancelLabel: cancelLabel,
+                confirmLabel: confirmLabel,
+                onCancel: () => Navigator.of(context).pop(),
+                onConfirm: onConfirm,
               ),
             ],
           ),

--- a/lib/widgets/reference_image_placeholder.dart
+++ b/lib/widgets/reference_image_placeholder.dart
@@ -54,7 +54,7 @@ class ReferenceImagePlaceholder extends StatelessWidget {
                     Text(
                       label,
                       textAlign: TextAlign.center,
-                      style: const TextStyle(
+                      style: TextStyle(
                         color: AppColors.textSecondary,
                         fontSize: 13,
                         fontWeight: FontWeight.w700,

--- a/lib/widgets/snackbar_helper.dart
+++ b/lib/widgets/snackbar_helper.dart
@@ -1,9 +1,35 @@
 import 'package:flutter/material.dart';
 
+import 'app_status_banner.dart';
+
+export 'app_status_banner.dart'
+    show
+        AppStatusBannerKind,
+        appStatusSnackBar,
+        appStatusSnackDuration;
+
 extension ShowReplacingSnackBar on ScaffoldMessengerState {
   ScaffoldFeatureController<SnackBar, SnackBarClosedReason>
   showReplacingSnackBar(SnackBar snackBar) {
     removeCurrentSnackBar();
     return showSnackBar(snackBar);
+  }
+
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showStatusSnack({
+    required AppStatusBannerKind kind,
+    required String title,
+    String? subtitle,
+    IconData? icon,
+    Duration duration = appStatusSnackDuration,
+  }) {
+    return showReplacingSnackBar(
+      appStatusSnackBar(
+        kind: kind,
+        title: title,
+        subtitle: subtitle,
+        icon: icon,
+        duration: duration,
+      ),
+    );
   }
 }

--- a/lib/widgets/status_snack_samples.dart
+++ b/lib/widgets/status_snack_samples.dart
@@ -213,6 +213,10 @@ const statusSnackDebugSamples = <StatusSnackSample>[
   ),
   StatusSnackSample(
     kind: AppStatusBannerKind.warning,
+    title: '无法读取剪贴板。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
     title: '剪贴板中没有有效坐标。',
   ),
   StatusSnackSample(

--- a/lib/widgets/status_snack_samples.dart
+++ b/lib/widgets/status_snack_samples.dart
@@ -1,0 +1,373 @@
+import 'package:flutter/material.dart';
+
+import 'app_status_banner.dart';
+
+class StatusSnackSample {
+  const StatusSnackSample({
+    required this.kind,
+    required this.title,
+    this.subtitle,
+    this.actionLabel,
+    this.progressProcessed,
+    this.progressTotal,
+    this.footer,
+    this.icon,
+  });
+
+  final AppStatusBannerKind kind;
+  final String title;
+  final String? subtitle;
+  final String? actionLabel;
+  final int? progressProcessed;
+  final int? progressTotal;
+  final String? footer;
+  final IconData? icon;
+
+  bool get hasProgress =>
+      progressProcessed != null && progressTotal != null && progressTotal! > 0;
+}
+
+const statusSnackDebugSamples = <StatusSnackSample>[
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '正在导出...',
+    icon: Icons.ios_share_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '已取消导出',
+    icon: Icons.cancel_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '正在缓存参考图...',
+    progressProcessed: 8,
+    progressTotal: 18,
+    footer: '提示：缓存过程中请保持网络连接，避免切换页面或锁屏。',
+    icon: Icons.cached_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '正在保存记录，请稍候。',
+    icon: Icons.save_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '正在替换参考图...',
+    icon: Icons.swap_horiz_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '正在读取参考图比例，请稍后拍摄。',
+    icon: Icons.aspect_ratio_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '正在清除缓存并重新加载 Anitabi 点位...',
+    icon: Icons.cleaning_services_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '正在导入 12 个点位...',
+    icon: Icons.add_location_alt_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '正在缓存缩略图 8/12，成功 7',
+    icon: Icons.photo_library_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.running,
+    title: '已取消保存',
+    icon: Icons.cancel_outlined,
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '参考图缓存完成',
+    subtitle: '18 / 18 张成功，已保存到本地',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '数据包已导出',
+    subtitle: '已保存到本地',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: 'My Maps CSV 已导出',
+    subtitle: '已通过系统分享送出',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已恢复初始设置',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '计划备忘录已保存',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已复制「宇治一日」',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已添加「声之形」。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已填入坐标。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已分配 6 个点位',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已将 3 个点位分配到「宇治站附近」',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已替换参考图',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已保存到相册',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '图片已保存',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已还原为原图',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已生成自动调色参数',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已保存调色结果',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已导入计划「宇治一日」',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '记录已保存，并备份到相册',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.success,
+    title: '已保存并标记完成，下一个：平等院',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '参考图缓存完成',
+    subtitle: '14 / 18 张成功 · 4 张失败',
+    actionLabel: '重试失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '数据包已导出',
+    subtitle: '3 张完整参考图下载失败，2 张巡礼照片缺失',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '已导入计划「宇治一日」，部分资源未恢复',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '当前计划没有需要缓存的参考图',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '当前计划还没有点位。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '当前环境无法编辑点位。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '至少需要保留一个计划',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '当前距离内没有可分配点位',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '请先完成片区分配',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '请先创建片区',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '框选范围内没有未分组点位',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '框选范围内没有可添加点位',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '剪贴板中没有有效坐标。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '无法读取剪贴板，请手动粘贴 Anitabi 链接。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '剪贴板中没有可用的 Anitabi 链接。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '清除缓存功能尚未接入，仅展示界面。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '巡礼图不可用，无法导出对比图片。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '当前平台暂不支持保存导出偏好。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '没有可用于自动调色的参考图',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '请先自动匹配色调',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '链接格式不正确',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '手动添加的作品没有 Bangumi ID，无法从 Anitabi 地图导入点位。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '点位已导入，但整理流程打开失败，可以稍后在计划中调整片区。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '定位获取失败，本次照片不记录定位。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.warning,
+    title: '已导入 12 个点位，缩略图缓存 8/12，其余稍后会自动补齐。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '参考图缓存失败',
+    subtitle: '0 / 18 张成功 · 18 张失败',
+    actionLabel: '重试全部',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '导出失败',
+    subtitle: '请稍后重试',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '导入文件读取失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '计划文件导入失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '导入失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '定位失败，请检查权限和定位服务。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '片区创建失败，请稍后重试。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '点位保存失败，请稍后重试。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '作品添加失败，请稍后重试。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '参考图读取失败，请重新选择。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '参考图替换失败，请稍后重试。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '计划备忘录保存失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '切换计划失败，请稍后重试。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '复制计划失败，请稍后重试。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '保存计划顺序失败，已恢复原来的顺序。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '作品删除失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '照片导入失败，请重新选择。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '图片读取失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '保存失败，请稍后重试。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '巡礼图读取失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '自动调色失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '无法打开链接',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '无法打开 Google 地图。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '点位分配失败，请稍后重试。',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '最近分配失败',
+  ),
+  StatusSnackSample(
+    kind: AppStatusBannerKind.error,
+    title: '框选分配失败',
+  ),
+];

--- a/test/app_status_banner_test.dart
+++ b/test/app_status_banner_test.dart
@@ -1,0 +1,273 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:miriago/app_theme.dart';
+import 'package:miriago/widgets/app_status_banner.dart';
+import 'package:miriago/widgets/status_snack_samples.dart';
+
+void main() {
+  tearDown(() {
+    AppTheme.light();
+  });
+
+  test('status snack catalog covers every banner kind', () {
+    expect(statusSnackDebugSamples, isNotEmpty);
+    expect(
+      statusSnackDebugSamples.map((sample) => sample.kind).toSet(),
+      AppStatusBannerKind.values.toSet(),
+    );
+    expect(
+      statusSnackDebugSamples.any(
+        (sample) => sample.title == '正在缓存参考图...' && sample.hasProgress,
+      ),
+      isTrue,
+    );
+  });
+
+  test('running catalog samples use distinct fitting icons', () {
+    final running = statusSnackDebugSamples
+        .where((sample) => sample.kind == AppStatusBannerKind.running)
+        .toList();
+    expect(running, isNotEmpty);
+    expect(running.every((sample) => sample.icon != null), isTrue);
+    expect(
+      running.map((sample) => sample.icon).toSet().length,
+      9,
+    );
+    expect(
+      running.any((sample) => sample.icon == Icons.download_rounded),
+      isFalse,
+    );
+
+    IconData? iconFor(String title) => running
+        .firstWhere((sample) => sample.title == title)
+        .icon;
+    expect(iconFor('正在导出...'), Icons.ios_share_outlined);
+    expect(iconFor('已取消导出'), Icons.cancel_outlined);
+    expect(iconFor('正在缓存参考图...'), Icons.cached_outlined);
+    expect(iconFor('正在保存记录，请稍候。'), Icons.save_outlined);
+    expect(iconFor('正在替换参考图...'), Icons.swap_horiz_outlined);
+    expect(iconFor('正在读取参考图比例，请稍后拍摄。'), Icons.aspect_ratio_outlined);
+    expect(
+      iconFor('正在清除缓存并重新加载 Anitabi 点位...'),
+      Icons.cleaning_services_outlined,
+    );
+    expect(iconFor('正在导入 12 个点位...'), Icons.add_location_alt_outlined);
+    expect(iconFor('正在缓存缩略图 8/12，成功 7'), Icons.photo_library_outlined);
+    expect(iconFor('已取消保存'), Icons.cancel_outlined);
+  });
+
+  test('dark mode status banners use opaque fills', () {
+    AppTheme.dark();
+    for (final kind in AppStatusBannerKind.values) {
+      final palette = AppStatusBannerPalette.of(kind);
+      expect(
+        palette.background.a,
+        1.0,
+        reason: '$kind background should be opaque',
+      );
+    }
+  });
+
+  testWidgets('export snack uses the status banner layout', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return TextButton(
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    appStatusSnackBar(
+                      kind: AppStatusBannerKind.success,
+                      title: '数据包已导出',
+                      subtitle: '已保存到本地',
+                    ),
+                  );
+                },
+                child: const Text('export'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('export'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.text('数据包已导出'), findsOneWidget);
+    expect(find.text('已保存到本地'), findsOneWidget);
+    expect(find.byType(AppStatusBanner), findsOneWidget);
+    expect(find.byIcon(Icons.check_rounded), findsOneWidget);
+  });
+
+  test('single-sentence status titles drop the trailing period', () {
+    expect(statusBannerSentence('已添加「声之形」。'), '已添加「声之形」');
+    expect(statusBannerSentence('已填入坐标。'), '已填入坐标');
+    expect(
+      statusBannerSentence('保存计划顺序失败，已恢复原来的顺序。'),
+      '保存计划顺序失败，已恢复原来的顺序',
+    );
+    expect(statusBannerSentence('数据包已导出'), '数据包已导出');
+    expect(statusBannerSentence('失败。请稍后重试。'), '失败。请稍后重试。');
+  });
+
+  testWidgets('single-sentence snack hides the trailing period', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: const Scaffold(
+          body: AppStatusBanner(
+            kind: AppStatusBannerKind.success,
+            title: '已添加「声之形」。',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('已添加「声之形」'), findsOneWidget);
+    expect(find.text('已添加「声之形」。'), findsNothing);
+  });
+
+  test('running titles infer distinct action icons', () {
+    expect(statusBannerRunningIcon('正在导出...'), Icons.ios_share_outlined);
+    expect(statusBannerRunningIcon('已取消导出'), Icons.cancel_outlined);
+    expect(statusBannerRunningIcon('正在缓存参考图...'), Icons.cached_outlined);
+    expect(statusBannerRunningIcon('正在保存记录，请稍候。'), Icons.save_outlined);
+    expect(statusBannerRunningIcon('正在替换参考图...'), Icons.swap_horiz_outlined);
+    expect(
+      statusBannerRunningIcon('正在读取参考图比例，请稍后拍摄。'),
+      Icons.aspect_ratio_outlined,
+    );
+    expect(
+      statusBannerRunningIcon('正在清除缓存并重新加载 Anitabi 点位...'),
+      Icons.cleaning_services_outlined,
+    );
+    expect(
+      statusBannerRunningIcon('正在导入 12 个点位...'),
+      Icons.add_location_alt_outlined,
+    );
+    expect(
+      statusBannerRunningIcon('正在缓存缩略图 8/12，成功 7'),
+      Icons.photo_library_outlined,
+    );
+    expect(statusBannerRunningIcon('已取消保存'), Icons.cancel_outlined);
+    expect(statusBannerRunningIcon('正在处理...'), Icons.hourglass_top_outlined);
+  });
+
+  testWidgets('unknown running banner uses an hourglass instead of download', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: const Scaffold(
+          body: AppStatusBanner(
+            kind: AppStatusBannerKind.running,
+            title: '正在处理...',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.hourglass_top_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.download_rounded), findsNothing);
+  });
+
+  testWidgets('running banner renders a custom icon when provided', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: const Scaffold(
+          body: AppStatusBanner(
+            kind: AppStatusBannerKind.running,
+            title: '正在导出...',
+            icon: Icons.ios_share_outlined,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.ios_share_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.download_rounded), findsNothing);
+  });
+
+  testWidgets('export debug preview shows all package export states', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return Center(
+                child: FilledButton(
+                  onPressed: () => showPlanExportBannerDebugPreview(context),
+                  child: const Text('export-package'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('export-package'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(
+      find.byKey(const ValueKey('plan-export-debug-running')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-export-debug-canceled')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-export-debug-success')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-export-debug-warning')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-export-debug-failed')),
+      findsOneWidget,
+    );
+    expect(find.text('正在导出...'), findsOneWidget);
+    expect(find.text('已取消导出'), findsOneWidget);
+    expect(find.text('数据包已导出'), findsNWidgets(2));
+    expect(find.text('导出失败'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-export-debug-running')),
+        matching: find.byIcon(Icons.ios_share_outlined),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-export-debug-canceled')),
+        matching: find.byIcon(Icons.cancel_outlined),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.download_rounded), findsNothing);
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(
+      find.byKey(const ValueKey('plan-export-debug-running')),
+      findsNothing,
+    );
+  });
+}

--- a/test/desktop_repository_state_test.dart
+++ b/test/desktop_repository_state_test.dart
@@ -50,6 +50,7 @@ void main() {
         mapThumbnailConcurrentLoads: 12,
         showPlanGroupProgress: false,
         dismissPlanActionsOnOutsideTap: false,
+        hideCompletedPointsOnMap: false,
         mapMarkerClusteringEnabled: false,
         mapMarkerClusterRadius: 88,
         mapMarkerClusterMaxZoom: 20,
@@ -144,6 +145,7 @@ void main() {
     expect(decoded.settings.mapThumbnailVisibleThreshold, 55);
     expect(decoded.settings.mapThumbnailConcurrentLoads, 12);
     expect(decoded.settings.showPlanGroupProgress, isFalse);
+    expect(decoded.settings.hideCompletedPointsOnMap, isFalse);
     expect(decoded.settings.mapMarkerClusteringEnabled, isFalse);
     expect(decoded.settings.mapMarkerClusterRadius, 88);
     expect(decoded.settings.mapMarkerClusterMaxZoom, 20);

--- a/test/desktop_repository_state_test.dart
+++ b/test/desktop_repository_state_test.dart
@@ -16,6 +16,35 @@ void main() {
     expect(decoded!.settings.dismissPlanActionsOnOutsideTap, isFalse);
   });
 
+  test('desktop persists appearance theme mode', () {
+    final repository = SamplePilgrimageRepository(
+      settings: const AppSettings(themeMode: AppThemeMode.dark),
+    );
+    final encoded = encodeDesktopRepositoryState(repository.snapshot());
+
+    final decoded = decodeDesktopRepositoryState(encoded);
+
+    expect(decoded, isNotNull);
+    expect(decoded!.settings.themeMode, AppThemeMode.dark);
+  });
+
+  test('desktop persists sample uji-station zone chain', () {
+    final encoded = encodeDesktopRepositoryState(
+      SamplePilgrimageRepository().snapshot(),
+    );
+
+    final decoded = decodeDesktopRepositoryState(encoded);
+    final chain = _ujiStationChain(decoded!.plans.single);
+
+    expect(decoded.plans.single.currentGroupId, 'sample-group-uji-station');
+    expect(chain.map((point) => point.name), _ujiStationChainNames);
+    expect(chain.map((point) => point.groupOrderIndex), [0, 1, 2, 4, 5, 6]);
+    expect(
+      chain.map((point) => point.groupId),
+      everyElement('sample-group-uji-station'),
+    );
+  });
+
   test('desktop repository state round-trips sample data', () async {
     final repository = SamplePilgrimageRepository();
     await repository.saveAppSettings(
@@ -23,6 +52,7 @@ void main() {
         uiScale: 1.25,
         cameraCaptureAspectRatio: CameraPhotoAspectRatio.landscape16x9,
         photoLocationStrategy: PhotoLocationStrategy.waitOnConfirmation,
+        themeMode: AppThemeMode.dark,
         themePalette: AppThemePalette.miriaYellow,
         mapTileProvider: MapTileProvider.customMapLibreStyle,
         openFreeMapStyle: OpenFreeMapStyle.fiord,
@@ -89,6 +119,7 @@ void main() {
     expect(decoded!.activePlanId, source.activePlanId);
     expect(decoded.settings.uiScale, 1.0);
     expect(decoded.settings.dismissPlanActionsOnOutsideTap, isFalse);
+    expect(decoded.settings.themeMode, AppThemeMode.dark);
     expect(
       decoded.settings.cameraCaptureAspectRatio,
       CameraPhotoAspectRatio.landscape16x9,
@@ -252,4 +283,23 @@ void main() {
     expect(point.work.title, '未知作品');
     expect(point.work.title, isNot('不应该被绑定的作品'));
   });
+}
+
+const _ujiStationChainNames = [
+  '井用机前步行道',
+  '宇治桥',
+  'JR 宇治站',
+  '宇治文化中心 停车场',
+  '宇治川河畔',
+  '京阪宇治站前',
+];
+
+List<PilgrimagePoint> _ujiStationChain(PilgrimagePlan plan) {
+  return [
+    for (final point in plan.points)
+      if (point.groupId == 'sample-group-uji-station') point,
+  ]..sort(
+    (left, right) =>
+        (left.groupOrderIndex ?? 0).compareTo(right.groupOrderIndex ?? 0),
+  );
 }

--- a/test/desktop_repository_state_test.dart
+++ b/test/desktop_repository_state_test.dart
@@ -4,6 +4,18 @@ import 'package:miriago/desktop/desktop_repository_state.dart';
 import 'package:miriago/plan/pilgrimage_models.dart';
 
 void main() {
+  test('desktop persists plan action outside-tap preference', () {
+    final repository = SamplePilgrimageRepository(
+      settings: const AppSettings(dismissPlanActionsOnOutsideTap: false),
+    );
+    final encoded = encodeDesktopRepositoryState(repository.snapshot());
+
+    final decoded = decodeDesktopRepositoryState(encoded);
+
+    expect(decoded, isNotNull);
+    expect(decoded!.settings.dismissPlanActionsOnOutsideTap, isFalse);
+  });
+
   test('desktop repository state round-trips sample data', () async {
     final repository = SamplePilgrimageRepository();
     await repository.saveAppSettings(
@@ -37,6 +49,7 @@ void main() {
         mapThumbnailVisibleThreshold: 55,
         mapThumbnailConcurrentLoads: 12,
         showPlanGroupProgress: false,
+        dismissPlanActionsOnOutsideTap: false,
         mapMarkerClusteringEnabled: false,
         mapMarkerClusterRadius: 88,
         mapMarkerClusterMaxZoom: 20,
@@ -74,6 +87,7 @@ void main() {
     expect(decoded, isNotNull);
     expect(decoded!.activePlanId, source.activePlanId);
     expect(decoded.settings.uiScale, 1.0);
+    expect(decoded.settings.dismissPlanActionsOnOutsideTap, isFalse);
     expect(
       decoded.settings.cameraCaptureAspectRatio,
       CameraPhotoAspectRatio.landscape16x9,
@@ -231,6 +245,7 @@ void main() {
     final decoded = decodeDesktopRepositoryState(source);
     final point = decoded!.plans.single.points.single;
 
+    expect(decoded.settings.dismissPlanActionsOnOutsideTap, isTrue);
     expect(point.work.id, 'missing-work');
     expect(point.work.title, '未知作品');
     expect(point.work.title, isNot('不应该被绑定的作品'));

--- a/test/dialog_layout_test.dart
+++ b/test/dialog_layout_test.dart
@@ -34,6 +34,15 @@ void main() {
 
     expect(find.text('暂不删除'), findsOneWidget);
     expect(find.byType(SingleChildScrollView), findsOneWidget);
+    final actionButtons = find.descendant(
+      of: find.byType(AppDialogActionRow),
+      matching: find.byType(FilledButton),
+    );
+    expect(actionButtons, findsNWidgets(2));
+    expect(
+      tester.getTopLeft(actionButtons.first).dy,
+      closeTo(tester.getTopLeft(actionButtons.last).dy, 0.1),
+    );
     expect(tester.takeException(), isNull);
   });
 
@@ -74,6 +83,15 @@ void main() {
         )
         .singleWhere((box) => box.constraints.maxWidth == 420);
     expect(frame.constraints.maxHeight, 292);
+    final actionButtons = find.descendant(
+      of: find.byType(AppDialogActionRow),
+      matching: find.byType(FilledButton),
+    );
+    expect(actionButtons, findsNWidgets(2));
+    expect(
+      tester.getTopLeft(actionButtons.first).dy,
+      closeTo(tester.getTopLeft(actionButtons.last).dy, 0.1),
+    );
     expect(tester.takeException(), isNull);
   });
 }

--- a/test/dialog_layout_test.dart
+++ b/test/dialog_layout_test.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:miriago/plan/coordinate_input_dialog.dart';
 import 'package:miriago/widgets/confirm_action_dialog.dart';
 import 'package:miriago/widgets/input_dialog.dart';
 
@@ -42,6 +45,41 @@ void main() {
     expect(
       tester.getTopLeft(actionButtons.first).dy,
       closeTo(tester.getTopLeft(actionButtons.last).dy, 0.1),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('info dialog uses a single confirm action', (tester) async {
+    tester.view.physicalSize = const Size(320, 480);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            size: Size(320, 480),
+            textScaler: TextScaler.linear(1.4),
+          ),
+          child: const InfoActionDialog(
+            title: '从其他 App 打开 .sjhplan',
+            message: '请在文件、聊天、浏览器下载页找到 .sjhplan 文件，然后用 MiriaGo 打开。',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('知道了'), findsOneWidget);
+    expect(find.byType(AppDialogActionRow), findsNothing);
+    expect(find.byType(TextButton), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byType(InfoActionDialog),
+        matching: find.byType(FilledButton),
+      ),
+      findsOneWidget,
     );
     expect(tester.takeException(), isNull);
   });
@@ -94,4 +132,69 @@ void main() {
     );
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'coordinate dialog paste sits on the title row and fills fields',
+    (tester) async {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.getData') {
+            return <String, dynamic>{'text': '35.712576, 139.722166'};
+          }
+          return null;
+        },
+      );
+      addTearDown(() {
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        );
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) {
+                return TextButton(
+                  onPressed: () {
+                    showCoordinateInputDialog(
+                      context: context,
+                      current: const LatLng(34, 135),
+                    );
+                  },
+                  child: const Text('open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      final paste = find.byKey(const ValueKey('dialog-paste-button'));
+      final title = find.text('输入经纬度');
+      final firstField = find.byType(TextField).first;
+      expect(paste, findsOneWidget);
+      expect(
+        tester.getCenter(paste).dy,
+        closeTo(tester.getCenter(title).dy, 1.0),
+      );
+      expect(
+        tester.getRect(paste).right,
+        closeTo(tester.getRect(firstField).right, 0.5),
+      );
+
+      await tester.tap(paste);
+      await tester.pumpAndSettle();
+
+      final fields = tester
+          .widgetList<TextField>(find.byType(TextField))
+          .toList();
+      expect(fields[0].controller?.text, '35.712576');
+      expect(fields[1].controller?.text, '139.722166');
+    },
+  );
 }

--- a/test/in_app_navigation_screen_test.dart
+++ b/test/in_app_navigation_screen_test.dart
@@ -1,0 +1,392 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:miriago/app_theme.dart';
+import 'package:miriago/map/in_app_navigation_screen.dart';
+import 'package:miriago/plan/pilgrimage_models.dart';
+
+void main() {
+  const work = PilgrimageWork(
+    id: 'work-1',
+    title: '测试作品',
+    subtitle: '',
+    city: '京都',
+    source: WorkSource.manual,
+  );
+  const point = PilgrimagePoint(
+    id: 'point-1',
+    work: work,
+    name: '宇治桥',
+    subtitle: '表参道',
+    position: LatLng(34.8894, 135.8074),
+    episodeLabel: 'EP 1',
+    referenceLabel: '手动',
+  );
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    AppSettings settings = const AppSettings(),
+    String? groupName,
+    List<PilgrimagePoint> stops = const [],
+    PilgrimagePoint? startPoint,
+  }) async {
+    final selected = startPoint ?? point;
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: FilledButton(
+                  onPressed: () => InAppNavigationScreen.open(
+                    context,
+                    point: selected,
+                    settings: settings,
+                    groupName: groupName,
+                    stops: stops,
+                  ),
+                  child: const Text('打开导航'),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.text('打开导航'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders light-mode apple-style navigation chrome', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsOneWidget,
+    );
+    expect(find.text('475米'), findsOneWidget);
+    expect(find.text('右转进入表参道'), findsOneWidget);
+    expect(find.textContaining('终点: 宇治桥'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-trip-summary')),
+      findsOneWidget,
+    );
+    expect(find.text('到达'), findsOneWidget);
+    expect(find.text('小时'), findsOneWidget);
+    expect(find.text('公里'), findsOneWidget);
+    expect(find.text('17 分钟'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-expand')),
+      findsOneWidget,
+    );
+    expect(find.text('结束路线'), findsNothing);
+  });
+
+  testWidgets('navigation chrome uses theme accent instead of map blue', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    final icon = tester.widget<Icon>(
+      find.descendant(
+        of: find.byKey(const ValueKey('in-app-navigation-recenter')),
+        matching: find.byType(Icon),
+      ),
+    );
+    expect(icon.color, AppColors.accent);
+    expect(icon.color, isNot(const Color(0xFF007AFF)));
+  });
+
+  testWidgets(
+    'collapsing the bottom panel keeps the sheet flush with the screen',
+    (tester) async {
+      await pumpScreen(tester);
+
+      await tester.tap(find.byKey(const ValueKey('in-app-navigation-expand')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey('in-app-navigation-collapse')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 140));
+
+      final panel = tester.getRect(
+        find.byKey(const ValueKey('in-app-navigation-bottom-panel')),
+      );
+      expect(panel.bottom, 844);
+      expect(panel.height, greaterThan(80));
+    },
+  );
+
+  testWidgets('expanded sheet shows destination details and can end route', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-expand')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('结束路线'), findsOneWidget);
+    expect(find.text('已到达'), findsOneWidget);
+    expect(find.text('全部点位'), findsOneWidget);
+    expect(find.text('到达'), findsOneWidget);
+    expect(find.text('小时'), findsOneWidget);
+    expect(find.text('公里'), findsOneWidget);
+    expect(find.text('详细信息'), findsNothing);
+    expect(find.text('宇治桥'), findsWidgets);
+    expect(find.textContaining('测试作品'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-collapse')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-arrive-debug')));
+    await tester.pumpAndSettle();
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-arrive-debug-sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('到达点位'), findsOneWidget);
+    expect(find.textContaining('第 1 / 1 个剩余点位'), findsOneWidget);
+    expect(find.text('打开相机'), findsOneWidget);
+    expect(find.text('前往下一点'), findsNothing);
+    expect(find.text('片区'), findsNothing);
+    Navigator.of(
+      tester.element(
+        find.byKey(const ValueKey('in-app-navigation-arrive-debug-sheet')),
+      ),
+    ).pop();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-all-stops')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-all-stops-sheet')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('终点: 宇治桥'), findsWidgets);
+
+    Navigator.of(
+      tester.element(
+        find.byKey(const ValueKey('in-app-navigation-all-stops-sheet')),
+      ),
+    ).pop();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-end-route')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('trip summary stays visible after collapsing the panel', (
+    tester,
+  ) async {
+    await pumpScreen(tester, groupName: '宇治站附近');
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-trip-summary')),
+      findsOneWidget,
+    );
+    expect(find.text('到达'), findsOneWidget);
+    expect(find.textContaining('终点: 宇治桥'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-expand')));
+    await tester.pumpAndSettle();
+    expect(find.text('结束路线'), findsOneWidget);
+    expect(find.text('到达'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-collapse')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('结束路线'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-trip-summary')),
+      findsOneWidget,
+    );
+    expect(find.text('到达'), findsOneWidget);
+    expect(find.text('小时'), findsOneWidget);
+    expect(find.text('公里'), findsOneWidget);
+    expect(find.text('片区'), findsOneWidget);
+    expect(find.text('宇治站附近'), findsOneWidget);
+    expect(find.textContaining('终点: 宇治桥'), findsOneWidget);
+    final zoneStrip = tester.getRect(
+      find.byKey(const ValueKey('in-app-navigation-top-zone')),
+    );
+    expect(zoneStrip.center.dx, closeTo(195, 24));
+    expect(zoneStrip.top, lessThan(80));
+    expect(zoneStrip.width, greaterThan(300));
+  });
+
+  testWidgets('instruction pager can swipe to the next preview step', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    await tester.drag(
+      find.byKey(const ValueKey('in-app-navigation-steps')),
+      const Offset(-280, 0),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('210米'), findsOneWidget);
+    expect(find.text('沿表参道直行'), findsOneWidget);
+  });
+
+  testWidgets('dark theme mode uses dark navigation chrome', (tester) async {
+    await pumpScreen(
+      tester,
+      settings: const AppSettings(themeMode: AppThemeMode.dark),
+    );
+
+    final scaffold = tester.widget<Scaffold>(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+    );
+    expect(scaffold.backgroundColor, const Color(0xFF1C1C1E));
+    expect(find.text('475米'), findsOneWidget);
+    expect(find.textContaining('终点: 宇治桥'), findsOneWidget);
+  });
+
+  test('resolvedAppBrightness follows light, dark, and system', () {
+    expect(
+      resolvedAppBrightness(
+        const AppSettings(),
+        platformBrightness: Brightness.dark,
+      ),
+      Brightness.light,
+    );
+    expect(
+      resolvedAppBrightness(
+        const AppSettings(themeMode: AppThemeMode.dark),
+        platformBrightness: Brightness.light,
+      ),
+      Brightness.dark,
+    );
+    expect(
+      resolvedAppBrightness(
+        const AppSettings(themeMode: AppThemeMode.system),
+        platformBrightness: Brightness.dark,
+      ),
+      Brightness.dark,
+    );
+  });
+
+  testWidgets('zone tour shows next stop, group badge, and all points', (
+    tester,
+  ) async {
+    const lastPoint = PilgrimagePoint(
+      id: 'point-2',
+      work: work,
+      name: '京阪宇治站前',
+      subtitle: '京阪宇治駅前',
+      position: LatLng(34.8942, 135.8069),
+      episodeLabel: 'EP 5',
+      referenceLabel: '手动',
+    );
+
+    await pumpScreen(
+      tester,
+      groupName: '宇治站附近',
+      stops: const [point, lastPoint],
+    );
+
+    expect(find.text('片区'), findsOneWidget);
+    expect(find.text('宇治站附近'), findsOneWidget);
+    expect(find.text('宇治桥'), findsOneWidget);
+    expect(find.textContaining('下一个:'), findsNothing);
+    expect(find.textContaining('终点: 宇治桥'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-expand')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-arrive-debug')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-arrive-debug-sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('到达点位'), findsOneWidget);
+    expect(find.textContaining('第 1 / 2 个剩余点位'), findsOneWidget);
+    expect(find.text('打开相机'), findsOneWidget);
+    expect(find.text('片区'), findsOneWidget);
+    expect(find.text('京阪宇治站前'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('in-app-navigation-arrive-debug-next')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('终点: 京阪宇治站前'), findsOneWidget);
+    expect(find.text('结束路线'), findsNothing);
+    expect(find.text('已到达'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-expand')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-expand')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-all-stops')));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('下一个:'), findsNothing);
+    expect(find.textContaining('终点: 京阪宇治站前'), findsWidgets);
+  });
+
+  testWidgets('zone tour from a later point skips earlier stops', (
+    tester,
+  ) async {
+    const firstPoint = PilgrimagePoint(
+      id: 'point-0',
+      work: work,
+      name: '井用机前步行道',
+      subtitle: 'あじろぎの道',
+      position: LatLng(34.8899, 135.8081),
+      episodeLabel: 'EP 1',
+      referenceLabel: '手动',
+    );
+    const lastPoint = PilgrimagePoint(
+      id: 'point-2',
+      work: work,
+      name: '京阪宇治站前',
+      subtitle: '京阪宇治駅前',
+      position: LatLng(34.8942, 135.8069),
+      episodeLabel: 'EP 5',
+      referenceLabel: '手动',
+    );
+
+    await pumpScreen(
+      tester,
+      groupName: '宇治站附近',
+      stops: const [firstPoint, point, lastPoint],
+    );
+
+    expect(find.textContaining('宇治桥'), findsOneWidget);
+    expect(find.textContaining('下一个:'), findsNothing);
+    expect(find.textContaining('下一个: 井用机前步行道'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-expand')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-all-stops')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-stop-skipped-point-0')),
+      findsOneWidget,
+    );
+    expect(find.text('井用机前步行道'), findsOneWidget);
+    expect(find.textContaining('宇治桥'), findsWidgets);
+    expect(find.textContaining('下一个:'), findsNothing);
+    expect(find.textContaining('终点: 京阪宇治站前'), findsOneWidget);
+  });
+}

--- a/test/map_marker_clustering_test.dart
+++ b/test/map_marker_clustering_test.dart
@@ -372,4 +372,90 @@ void main() {
       );
     },
   );
+
+  testWidgets('hides completed point markers on the map by default', (
+    tester,
+  ) async {
+    const work = PilgrimageWork(
+      id: 'work',
+      title: '测试作品',
+      subtitle: '',
+      city: '',
+      source: WorkSource.manual,
+    );
+    const pending = PilgrimagePoint(
+      id: 'point-pending',
+      work: work,
+      name: '未完成点位',
+      subtitle: '',
+      position: LatLng(35, 139),
+      episodeLabel: '',
+      referenceLabel: '',
+    );
+    const completed = PilgrimagePoint(
+      id: 'point-completed',
+      work: work,
+      name: '已完成点位',
+      subtitle: '',
+      position: LatLng(35.001, 139.001),
+      episodeLabel: '',
+      referenceLabel: '',
+    );
+    final now = DateTime(2026);
+    final controller = PilgrimagePlanController(
+      plan: PilgrimagePlan(
+        id: 'plan',
+        name: '测试计划',
+        area: '',
+        works: const [work],
+        points: const [pending, completed],
+        createdAt: now,
+        updatedAt: now,
+        currentPointId: pending.id,
+        completedPointIds: {completed.id},
+      ),
+    );
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PilgrimageMapScreen(
+          controller: controller,
+          settings: const AppSettings(mapMarkerClusteringEnabled: false),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('plan-map-marker-point-pending')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-map-marker-point-completed')),
+      findsNothing,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PilgrimageMapScreen(
+          controller: controller,
+          settings: const AppSettings(
+            mapMarkerClusteringEnabled: false,
+            hideCompletedPointsOnMap: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('plan-map-marker-point-pending')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('plan-map-marker-point-completed')),
+      findsOneWidget,
+    );
+  });
 }

--- a/test/navigation_route_confirm_screen_test.dart
+++ b/test/navigation_route_confirm_screen_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:miriago/app_theme.dart';
+import 'package:miriago/map/navigation_route_confirm_screen.dart';
+import 'package:miriago/plan/pilgrimage_models.dart';
+
+void main() {
+  const work = PilgrimageWork(
+    id: 'work-1',
+    title: '测试作品',
+    subtitle: '',
+    city: '京都',
+    source: WorkSource.manual,
+  );
+  const point = PilgrimagePoint(
+    id: 'point-1',
+    work: work,
+    name: '井用机前步行道',
+    subtitle: 'あじろぎの道',
+    position: LatLng(34.8899, 135.8081),
+    episodeLabel: 'EP 1',
+    referenceLabel: '手动',
+  );
+  const lastPoint = PilgrimagePoint(
+    id: 'point-2',
+    work: work,
+    name: '京阪宇治站前',
+    subtitle: '京阪宇治駅前',
+    position: LatLng(34.8942, 135.8069),
+    episodeLabel: 'EP 5',
+    referenceLabel: '手动',
+  );
+
+  Future<void> pumpConfirm(
+    WidgetTester tester, {
+    String? groupName,
+    List<PilgrimagePoint> stops = const [],
+    PilgrimagePoint? startPoint,
+  }) async {
+    final selected = startPoint ?? point;
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: FilledButton(
+                  onPressed: () => NavigationRouteConfirmScreen.open(
+                    context,
+                    point: selected,
+                    settings: const AppSettings(),
+                    groupName: groupName,
+                    stops: stops,
+                  ),
+                  child: const Text('打开确认'),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.text('打开确认'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('zone confirm highlights chaining the whole group', (
+    tester,
+  ) async {
+    await pumpConfirm(
+      tester,
+      groupName: '宇治站附近',
+      stops: const [point, lastPoint],
+    );
+
+    expect(
+      find.byKey(const ValueKey('navigation-route-confirm-screen')),
+      findsOneWidget,
+    );
+    expect(find.text('确认路线'), findsOneWidget);
+    expect(find.text('片区'), findsOneWidget);
+    expect(find.text('宇治站附近'), findsOneWidget);
+    expect(find.text('串联整个片区导航'), findsOneWidget);
+    expect(find.textContaining('点击即按顺序连接'), findsNothing);
+    expect(find.text('仅导航到选中点'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('confirming the zone starts chained in-app navigation', (
+    tester,
+  ) async {
+    await pumpConfirm(
+      tester,
+      groupName: '宇治站附近',
+      stops: const [point, lastPoint],
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('navigation-route-confirm-zone')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('navigation-route-confirm-screen')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('井用机前步行道'), findsOneWidget);
+    expect(find.text('片区'), findsOneWidget);
+  });
+
+  testWidgets('confirming a single selected point skips the zone chain', (
+    tester,
+  ) async {
+    await pumpConfirm(
+      tester,
+      groupName: '宇治站附近',
+      stops: const [point, lastPoint],
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('navigation-route-confirm-point')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('终点: 井用机前步行道'), findsOneWidget);
+    expect(find.textContaining('下一个:'), findsNothing);
+    expect(find.text('片区'), findsNothing);
+  });
+
+  testWidgets('single-stop confirm only offers starting navigation', (
+    tester,
+  ) async {
+    await pumpConfirm(tester, stops: const [point]);
+
+    expect(find.text('串联整个片区导航'), findsNothing);
+    expect(find.text('仅导航到选中点'), findsNothing);
+    expect(find.text('开始导航'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('navigation-route-confirm-point')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('终点: 井用机前步行道'), findsOneWidget);
+  });
+
+  testWidgets('zone confirm starts the chain from the selected point', (
+    tester,
+  ) async {
+    await pumpConfirm(
+      tester,
+      groupName: '宇治站附近',
+      startPoint: lastPoint,
+      stops: const [point, lastPoint],
+    );
+
+    expect(find.text('串联整个片区导航'), findsNothing);
+    expect(find.textContaining('按顺序连接 2 个点位'), findsNothing);
+    expect(find.text('开始导航'), findsOneWidget);
+    expect(find.textContaining('终点：京阪宇治站前'), findsOneWidget);
+  });
+
+  testWidgets('zone confirm remaining chain starts at the selected point', (
+    tester,
+  ) async {
+    const middle = PilgrimagePoint(
+      id: 'point-mid',
+      work: work,
+      name: '宇治桥',
+      subtitle: '宇治橋',
+      position: LatLng(34.8929, 135.8065),
+      episodeLabel: 'EP 2',
+      referenceLabel: '手动',
+    );
+
+    await pumpConfirm(
+      tester,
+      groupName: '宇治站附近',
+      startPoint: middle,
+      stops: const [point, middle, lastPoint],
+    );
+
+    expect(find.textContaining('按顺序连接 2 个点位：宇治桥 → 京阪宇治站前'), findsOneWidget);
+    expect(find.textContaining('井用机前步行道'), findsNothing);
+    expect(find.text('串联整个片区导航'), findsOneWidget);
+  });
+}

--- a/test/photo_location_choice_sheet_test.dart
+++ b/test/photo_location_choice_sheet_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:miriago/app_theme.dart';
+import 'package:miriago/camera_reference/photo_location_choice_sheet.dart';
+import 'package:miriago/plan/pilgrimage_models.dart';
+
+void main() {
+  testWidgets('photo location sheet strengthens copy and highlights recommend', (
+    tester,
+  ) async {
+    PhotoLocationStrategy? selected;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: Builder(
+          builder: (context) {
+            return Scaffold(
+              body: Center(
+                child: FilledButton(
+                  onPressed: () async {
+                    selected = await showModalBottomSheet<PhotoLocationStrategy>(
+                      context: context,
+                      builder: (_) => const PhotoLocationChoiceSheet(),
+                    );
+                  },
+                  child: const Text('询问定位'),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('询问定位'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('是否在巡礼照片中记录定位？'), findsOneWidget);
+    expect(find.text('以后可以在“拍摄设置”中修改。'), findsOneWidget);
+    expect(find.text('不会使用点位坐标代替实际定位。'), findsOneWidget);
+    expect(find.text('确认记录时获取定位'), findsOneWidget);
+    expect(find.text('推荐'), findsOneWidget);
+    expect(find.textContaining('（推荐）'), findsNothing);
+
+    final confirmTile = tester.widget<Material>(
+      find
+          .descendant(
+            of: find.byKey(const ValueKey('photo-location-choice-confirm')),
+            matching: find.byType(Material),
+          )
+          .first,
+    );
+    expect(confirmTile.color, AppColors.accent.withValues(alpha: 0.08));
+
+    await tester.tap(
+      find.byKey(const ValueKey('photo-location-choice-recent')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(selected, PhotoLocationStrategy.useRecentLocation);
+  });
+}

--- a/test/photo_location_settings_test.dart
+++ b/test/photo_location_settings_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:miriago/data/sample_pilgrimage_repository.dart';
+import 'package:miriago/main.dart';
+
+Future<void> _openCameraSettings(WidgetTester tester) async {
+  await tester.pumpWidget(MiriaGoApp(repository: SamplePilgrimageRepository()));
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.text('设置').last);
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('拍摄设置'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('debug camera settings show photo location strategy dropdown', (
+    tester,
+  ) async {
+    await _openCameraSettings(tester);
+
+    await tester.scrollUntilVisible(
+      find.text('照片定位信息'),
+      280,
+      scrollable: find.byType(Scrollable).last,
+    );
+
+    expect(find.text('照片定位信息'), findsOneWidget);
+    expect(find.text('首次拍摄时询问'), findsOneWidget);
+    expect(find.text('询问'), findsOneWidget);
+
+    await tester.tap(find.text('首次拍摄时询问'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('不记录定位'), findsOneWidget);
+    expect(find.text('使用最近一次定位'), findsOneWidget);
+    expect(find.text('确认记录时获取定位'), findsOneWidget);
+    expect(find.text('推荐'), findsOneWidget);
+  });
+}

--- a/test/plan_group_utils_test.dart
+++ b/test/plan_group_utils_test.dart
@@ -212,6 +212,51 @@ void main() {
     expect(largeAverage, closeTo(240, 3));
     expect(largeAverage, greaterThan(smallAverage * 2.9));
   });
+
+  test('in-app navigation tour chains all coordinate points in a zone', () {
+    final fixture = _buildGroupedPlanFixture();
+    final tour = inAppNavigationTourFor(
+      point: fixture.groupAFirst,
+      buckets: planGroupBuckets(fixture.plan, const {}),
+    );
+
+    expect(tour.groupName, '片区 A');
+    expect(tour.stops.map((point) => point.id), ['a-1', 'a-2']);
+    expect(tour.startIndex, 0);
+    expect(tour.remainingStops.map((point) => point.id), ['a-1', 'a-2']);
+  });
+
+  test('in-app navigation tour starts from the selected point in a zone', () {
+    final fixture = _buildGroupedPlanFixture();
+    final tour = inAppNavigationTourFor(
+      point: fixture.groupASecond,
+      buckets: planGroupBuckets(fixture.plan, const {}),
+    );
+
+    expect(tour.groupName, '片区 A');
+    expect(tour.startIndex, 1);
+    expect(tour.stops.map((point) => point.id), ['a-1', 'a-2']);
+    expect(tour.remainingStops.map((point) => point.id), ['a-2']);
+  });
+
+  test('in-app navigation tour stays on a single ungrouped point', () {
+    final fixture = _buildGroupedPlanFixture();
+    final ungrouped = fixture.groupAFirst.copyWith(
+      id: 'ungrouped-1',
+      groupId: null,
+      groupOrderIndex: null,
+    );
+    final plan = fixture.plan.copyWith(
+      points: [...fixture.plan.points, ungrouped],
+    );
+    final tour = inAppNavigationTourFor(
+      point: ungrouped,
+      buckets: planGroupBuckets(plan, const {}),
+    );
+
+    expect(tour.groupName, isNull);
+    expect(tour.stops.map((point) => point.id), ['ungrouped-1']);
+  });
 }
 
 _GroupedPlanFixture _buildGroupedPlanFixture() {

--- a/test/reference_cache_progress_dialog_test.dart
+++ b/test/reference_cache_progress_dialog_test.dart
@@ -1,0 +1,417 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:miriago/plan/reference_cache_progress_dialog.dart';
+import 'package:miriago/plan/reference_full_cache_runner.dart';
+
+void main() {
+  testWidgets('shows in-progress cache state with percent', (tester) async {
+    final started = Completer<void>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReferenceCacheProgressDialog(
+            run: (onProgress) async {
+              onProgress(
+                const ReferenceFullCacheProgress(
+                  total: 18,
+                  processed: 8,
+                  succeeded: 8,
+                ),
+              );
+              started.complete();
+              await Completer<void>().future;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await started.future;
+    await tester.pump();
+
+    expect(find.text('正在缓存参考图...'), findsOneWidget);
+    expect(find.text('8 / 18'), findsOneWidget);
+    expect(find.text('44%'), findsOneWidget);
+    expect(find.byKey(const ValueKey('reference-cache-progress-bar')), findsOneWidget);
+    expect(
+      find.text('提示：缓存过程中请保持网络连接，避免切换页面或锁屏。'),
+      findsOneWidget,
+    );
+    expect(find.text('重试失败'), findsNothing);
+    expect(find.byIcon(Icons.close), findsNothing);
+  });
+
+  testWidgets('shows all-success cache state', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReferenceCacheProgressDialog(
+            run: (onProgress) async {
+              onProgress(
+                const ReferenceFullCacheProgress(
+                  total: 18,
+                  processed: 18,
+                  succeeded: 18,
+                  done: true,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('参考图缓存完成'), findsOneWidget);
+    expect(find.text('18 / 18 张成功，已保存到本地'), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsNothing);
+    expect(find.text('重试失败'), findsNothing);
+    expect(find.text('重试全部'), findsNothing);
+  });
+
+  testWidgets('shows partial-success cache state with retry', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReferenceCacheProgressDialog(
+            run: (onProgress) async {
+              onProgress(
+                const ReferenceFullCacheProgress(
+                  total: 18,
+                  processed: 18,
+                  succeeded: 14,
+                  failed: 4,
+                  done: true,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('参考图缓存完成'), findsOneWidget);
+    expect(find.text('14 / 18 张成功 · 4 张失败'), findsOneWidget);
+    expect(find.text('重试失败'), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsNothing);
+  });
+
+  testWidgets('shows all-failed cache state with retry all', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReferenceCacheProgressDialog(
+            run: (onProgress) async {
+              onProgress(
+                const ReferenceFullCacheProgress(
+                  total: 18,
+                  processed: 18,
+                  failed: 18,
+                  done: true,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('参考图缓存失败'), findsOneWidget);
+    expect(find.text('0 / 18 张成功 · 18 张失败'), findsOneWidget);
+    expect(find.text('重试全部'), findsOneWidget);
+  });
+
+  testWidgets('pins the cache banner to the bottom like a snack bar', (
+    tester,
+  ) async {
+    final started = Completer<void>();
+    final hold = Completer<void>();
+    addTearDown(() {
+      if (!hold.isCompleted) {
+        hold.complete();
+      }
+    });
+
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return Center(
+                child: FilledButton(
+                  onPressed: () {
+                    showReferenceCacheProgressDialog(
+                      context: context,
+                      run: (onProgress) async {
+                        onProgress(
+                          const ReferenceFullCacheProgress(
+                            total: 18,
+                            processed: 8,
+                            succeeded: 8,
+                          ),
+                        );
+                        started.complete();
+                        await hold.future;
+                      },
+                    );
+                  },
+                  child: const Text('start-cache'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('start-cache'));
+    await tester.pump();
+    await started.future;
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    final banner = tester.getRect(
+      find.byKey(const ValueKey('reference-cache-progress-dialog')),
+    );
+    expect(banner.top, greaterThan(844 * 0.5));
+    expect(banner.bottom, closeTo(844 - 12, 8));
+    expect(find.text('正在缓存参考图...'), findsOneWidget);
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 400));
+  });
+
+  testWidgets('tapping outside closes the cache banner', (tester) async {
+    final started = Completer<void>();
+    final hold = Completer<void>();
+    addTearDown(() {
+      if (!hold.isCompleted) {
+        hold.complete();
+      }
+    });
+
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return Center(
+                child: FilledButton(
+                  onPressed: () {
+                    showReferenceCacheProgressDialog(
+                      context: context,
+                      run: (onProgress) async {
+                        onProgress(
+                          const ReferenceFullCacheProgress(
+                            total: 18,
+                            processed: 8,
+                            succeeded: 8,
+                          ),
+                        );
+                        started.complete();
+                        await hold.future;
+                      },
+                    );
+                  },
+                  child: const Text('start-cache'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('start-cache'));
+    await tester.pump();
+    await started.future;
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(
+      find.byKey(const ValueKey('reference-cache-progress-dialog')),
+      findsOneWidget,
+    );
+
+    await tester.tapAt(const Offset(24, 24));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(
+      find.byKey(const ValueKey('reference-cache-progress-dialog')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('cache banner auto-closes after 3 seconds', (tester) async {
+    final started = Completer<void>();
+    final hold = Completer<void>();
+    addTearDown(() {
+      if (!hold.isCompleted) {
+        hold.complete();
+      }
+    });
+
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return Center(
+                child: FilledButton(
+                  onPressed: () {
+                    showReferenceCacheProgressDialog(
+                      context: context,
+                      run: (onProgress) async {
+                        onProgress(
+                          const ReferenceFullCacheProgress(
+                            total: 18,
+                            processed: 8,
+                            succeeded: 8,
+                          ),
+                        );
+                        started.complete();
+                        await hold.future;
+                      },
+                    );
+                  },
+                  child: const Text('start-cache'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('start-cache'));
+    await tester.pump();
+    await started.future;
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(
+      find.byKey(const ValueKey('reference-cache-progress-dialog')),
+      findsOneWidget,
+    );
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(
+      find.byKey(const ValueKey('reference-cache-progress-dialog')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('debug preview shows all cache banner states', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              return Center(
+                child: FilledButton(
+                  onPressed: () =>
+                      showReferenceCacheBannerDebugPreview(context),
+                  child: const Text('start-cache'),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('start-cache'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(
+      find.byKey(const ValueKey('reference-cache-debug-running')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('reference-cache-debug-success')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('reference-cache-debug-partial')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('reference-cache-debug-failed')),
+      findsOneWidget,
+    );
+    expect(find.text('正在缓存参考图...'), findsOneWidget);
+    expect(find.text('重试失败'), findsOneWidget);
+    expect(find.text('重试全部'), findsOneWidget);
+    expect(find.text('参考图缓存完成'), findsNWidgets(2));
+
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(
+      find.byKey(const ValueKey('reference-cache-debug-running')),
+      findsNothing,
+    );
+  });
+
+  testWidgets('retry returns to the in-progress state', (tester) async {
+    var runs = 0;
+    final secondRun = Completer<void>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReferenceCacheProgressDialog(
+            run: (onProgress) async {
+              runs += 1;
+              if (runs == 1) {
+                onProgress(
+                  const ReferenceFullCacheProgress(
+                    total: 18,
+                    processed: 18,
+                    succeeded: 14,
+                    failed: 4,
+                    done: true,
+                  ),
+                );
+                return;
+              }
+              onProgress(
+                const ReferenceFullCacheProgress(
+                  total: 4,
+                  processed: 1,
+                  succeeded: 1,
+                ),
+              );
+              await secondRun.future;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('重试失败'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('reference-cache-retry')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('正在缓存参考图...'), findsOneWidget);
+    expect(find.text('1 / 4'), findsOneWidget);
+    expect(find.text('25%'), findsOneWidget);
+    secondRun.complete();
+    await tester.pump();
+  });
+}

--- a/test/sqlite_pilgrimage_repository_test.dart
+++ b/test/sqlite_pilgrimage_repository_test.dart
@@ -66,6 +66,19 @@ void main() {
     expect(ungrouped.currentGroupId, 'ungrouped');
   });
 
+  test('persists plan action outside-tap preference', () async {
+    final database = AppDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+    final repository = SqlitePilgrimageRepository(database: database);
+
+    await repository.saveAppSettings(
+      const AppSettings(dismissPlanActionsOnOutsideTap: false),
+    );
+
+    final settings = await repository.loadAppSettings();
+    expect(settings.dismissPlanActionsOnOutsideTap, isFalse);
+  });
+
   test('persists work type and cover metadata', () async {
     final database = AppDatabase(NativeDatabase.memory());
     addTearDown(database.close);
@@ -503,6 +516,49 @@ void main() {
       expect(
         (await repository.loadAppSettings()).photoLocationStrategy,
         PhotoLocationStrategy.waitOnConfirmation,
+      );
+    },
+  );
+
+  test(
+    'schema 38 to 39 adds plan action dismissal preference without data loss',
+    () async {
+      final database = AppDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+      final repository = SqlitePilgrimageRepository(database: database);
+      final plan = await repository.createPlan(name: '计划操作设置迁移', area: '东京');
+      await repository.saveAppSettings(
+        const AppSettings(customXyzTileUrl: 'https://example.com/tiles'),
+      );
+      await database.customStatement(
+        'ALTER TABLE app_settings_entries '
+        'DROP COLUMN dismiss_plan_actions_on_outside_tap',
+      );
+
+      await database.migration.onUpgrade(
+        database.createMigrator(),
+        38,
+        database.schemaVersion,
+      );
+
+      expect(
+        await _tableColumnNames(database, 'app_settings_entries'),
+        contains('dismiss_plan_actions_on_outside_tap'),
+      );
+      final migratedPlan = (await repository.loadPlans()).singleWhere(
+        (candidate) => candidate.id == plan.id,
+      );
+      final settings = await repository.loadAppSettings();
+      expect(migratedPlan.name, plan.name);
+      expect(settings.customXyzTileUrl, 'https://example.com/tiles');
+      expect(settings.dismissPlanActionsOnOutsideTap, isTrue);
+
+      await repository.saveAppSettings(
+        settings.copyWith(dismissPlanActionsOnOutsideTap: false),
+      );
+      expect(
+        (await repository.loadAppSettings()).dismissPlanActionsOnOutsideTap,
+        isFalse,
       );
     },
   );

--- a/test/sqlite_pilgrimage_repository_test.dart
+++ b/test/sqlite_pilgrimage_repository_test.dart
@@ -233,6 +233,7 @@ void main() {
     expect(migratedPlan.name, plan.name);
     expect(settings.customXyzTileUrl, 'https://example.com/{z}/{x}/{y}.png');
     expect(settings.mapMarkerClusteringEnabled, isTrue);
+    expect(settings.hideCompletedPointsOnMap, isTrue);
     expect(settings.mapMarkerClusterRadius, 40);
     expect(settings.mapMarkerClusterMaxZoom, 21);
   });
@@ -558,6 +559,49 @@ void main() {
       );
       expect(
         (await repository.loadAppSettings()).dismissPlanActionsOnOutsideTap,
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    'schema 39 to 40 adds hide completed map points preference without data loss',
+    () async {
+      final database = AppDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+      final repository = SqlitePilgrimageRepository(database: database);
+      final plan = await repository.createPlan(name: '隐藏完成点位迁移', area: '东京');
+      await repository.saveAppSettings(
+        const AppSettings(customXyzTileUrl: 'https://example.com/tiles'),
+      );
+      await database.customStatement(
+        'ALTER TABLE app_settings_entries '
+        'DROP COLUMN hide_completed_points_on_map',
+      );
+
+      await database.migration.onUpgrade(
+        database.createMigrator(),
+        39,
+        database.schemaVersion,
+      );
+
+      expect(
+        await _tableColumnNames(database, 'app_settings_entries'),
+        contains('hide_completed_points_on_map'),
+      );
+      final migratedPlan = (await repository.loadPlans()).singleWhere(
+        (candidate) => candidate.id == plan.id,
+      );
+      final settings = await repository.loadAppSettings();
+      expect(migratedPlan.name, plan.name);
+      expect(settings.customXyzTileUrl, 'https://example.com/tiles');
+      expect(settings.hideCompletedPointsOnMap, isTrue);
+
+      await repository.saveAppSettings(
+        settings.copyWith(hideCompletedPointsOnMap: false),
+      );
+      expect(
+        (await repository.loadAppSettings()).hideCompletedPointsOnMap,
         isFalse,
       );
     },
@@ -1696,6 +1740,7 @@ void main() {
         mapThumbnailVisibleThreshold: 55,
         mapThumbnailConcurrentLoads: 12,
         showPlanGroupProgress: false,
+        hideCompletedPointsOnMap: false,
         mapMarkerClusteringEnabled: false,
         mapMarkerClusterRadius: 88,
         mapMarkerClusterMaxZoom: 20,
@@ -1749,6 +1794,7 @@ void main() {
     expect(settings.mapThumbnailVisibleThreshold, 55);
     expect(settings.mapThumbnailConcurrentLoads, 12);
     expect(settings.showPlanGroupProgress, isFalse);
+    expect(settings.hideCompletedPointsOnMap, isFalse);
     expect(settings.mapMarkerClusteringEnabled, isFalse);
     expect(settings.mapMarkerClusterRadius, 88);
     expect(settings.mapMarkerClusterMaxZoom, 20);

--- a/test/sqlite_pilgrimage_repository_test.dart
+++ b/test/sqlite_pilgrimage_repository_test.dart
@@ -79,6 +79,97 @@ void main() {
     expect(settings.dismissPlanActionsOnOutsideTap, isFalse);
   });
 
+  test('persists appearance theme mode', () async {
+    final database = AppDatabase(NativeDatabase.memory());
+    addTearDown(database.close);
+    final repository = SqlitePilgrimageRepository(database: database);
+
+    await repository.saveAppSettings(
+      const AppSettings(themeMode: AppThemeMode.dark),
+    );
+
+    final settings = await repository.loadAppSettings();
+    expect(settings.themeMode, AppThemeMode.dark);
+  });
+
+  test(
+    'seeds and persists uji-station zone chain across repository instances',
+    () async {
+      final database = AppDatabase(NativeDatabase.memory());
+      addTearDown(database.close);
+      final repository = SqlitePilgrimageRepository(database: database);
+      final plan = await repository.loadActivePlan();
+
+      expect(plan.currentGroupId, 'sample-group-uji-station');
+      expect(
+        _ujiStationChain(plan).map((point) => point.name),
+        _ujiStationChainNames,
+      );
+      expect(_ujiStationChain(plan).map((point) => point.groupOrderIndex), [
+        0,
+        1,
+        2,
+        4,
+        5,
+        6,
+      ]);
+
+      final reloaded = SqlitePilgrimageRepository(database: database);
+      final reloadedPlan = await reloaded.loadActivePlan();
+      expect(
+        _ujiStationChain(reloadedPlan).map((point) => point.name),
+        _ujiStationChainNames,
+      );
+    },
+  );
+
+  test(
+    'sqlite file persists theme mode and uji-station chain after reopen',
+    () async {
+      final tempDirectory = await Directory.systemTemp.createTemp(
+        'miriago_sqlite_persist_',
+      );
+      addTearDown(() async {
+        if (tempDirectory.existsSync()) {
+          await tempDirectory.delete(recursive: true);
+        }
+      });
+      final file = File(p.join(tempDirectory.path, 'seichi_junrei.sqlite'));
+
+      final database = AppDatabase(NativeDatabase(file));
+      final repository = SqlitePilgrimageRepository(database: database);
+      await repository.saveAppSettings(
+        const AppSettings(themeMode: AppThemeMode.system),
+      );
+      final seeded = await repository.loadActivePlan();
+      expect(
+        _ujiStationChain(seeded).map((point) => point.name),
+        _ujiStationChainNames,
+      );
+      await database.close();
+
+      final reopened = AppDatabase(NativeDatabase(file));
+      addTearDown(reopened.close);
+      final reloaded = SqlitePilgrimageRepository(database: reopened);
+      final settings = await reloaded.loadAppSettings();
+      final plan = await reloaded.loadActivePlan();
+
+      expect(settings.themeMode, AppThemeMode.system);
+      expect(
+        _ujiStationChain(plan).map((point) => point.name),
+        _ujiStationChainNames,
+      );
+      expect(_ujiStationChain(plan).map((point) => point.groupOrderIndex), [
+        0,
+        1,
+        2,
+        4,
+        5,
+        6,
+      ]);
+    },
+  );
+
   test('persists work type and cover metadata', () async {
     final database = AppDatabase(NativeDatabase.memory());
     addTearDown(database.close);
@@ -2444,4 +2535,23 @@ Future<void> _insertLegacyPoint(
           sortOrder: Value(sortOrder),
         ),
       );
+}
+
+const _ujiStationChainNames = [
+  '井用机前步行道',
+  '宇治桥',
+  'JR 宇治站',
+  '宇治文化中心 停车场',
+  '宇治川河畔',
+  '京阪宇治站前',
+];
+
+List<PilgrimagePoint> _ujiStationChain(PilgrimagePlan plan) {
+  return [
+    for (final point in plan.points)
+      if (point.groupId == 'sample-group-uji-station') point,
+  ]..sort(
+    (left, right) =>
+        (left.groupOrderIndex ?? 0).compareTo(right.groupOrderIndex ?? 0),
+  );
 }

--- a/test/visit_record_confirmation_screen_test.dart
+++ b/test/visit_record_confirmation_screen_test.dart
@@ -97,6 +97,42 @@ void main() {
       isNotNull,
     );
   });
+
+  testWidgets('skip location waits no longer and keeps save enabled', (
+    tester,
+  ) async {
+    final fixture = await _fixture();
+    addTearDown(fixture.controller.dispose);
+    await _pumpConfirmation(
+      tester,
+      fixture,
+      photoLocationStrategy: PhotoLocationStrategy.waitOnConfirmation,
+      resolvePhotoLocation: () => Completer<PhotoLocationData>().future,
+      writePhotoLocation: (_, _) async => true,
+      settle: false,
+    );
+
+    expect(find.text('正在获取拍摄位置...'), findsOneWidget);
+    expect(find.text('跳过'), findsOneWidget);
+    expect(
+      find.ancestor(of: find.text('跳过'), matching: find.byType(OutlinedButton)),
+      findsOneWidget,
+    );
+    expect(
+      tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+      isNull,
+    );
+
+    await tester.tap(find.text('跳过'));
+    await tester.pump();
+
+    expect(find.text('已跳过定位，本次照片不会写入位置。'), findsOneWidget);
+    expect(find.text('跳过'), findsNothing);
+    expect(
+      tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+      isNotNull,
+    );
+  });
 }
 
 class _Fixture {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -58,6 +58,10 @@ void _invokeKeyedAction(WidgetTester tester, String key) {
     widget.onPressed!();
     return;
   }
+  if (widget is IconButton) {
+    widget.onPressed!();
+    return;
+  }
   if (widget is InkWell) {
     widget.onTap!();
     return;
@@ -2519,6 +2523,64 @@ void main() {
     expect(updatedPlan.currentPointId, initialPlan.currentPointId);
   });
 
+  testWidgets('quick manual point paste fills coordinates without a dialog', (
+    tester,
+  ) async {
+    await tester.pumpWidget(MiriaGoApp(repository: SamplePilgrimageRepository()));
+    await tester.pumpAndSettle();
+
+    await _openPlanMenu(tester);
+    await tester.tap(find.text('添加点位').last);
+    await tester.pumpAndSettle();
+    _invokeKeyedAction(tester, 'add-points-quick-manual-point');
+    await tester.pumpAndSettle();
+    _mockClipboardRead(tester, '35.712576, 139.722166');
+
+    _invokeKeyedAction(tester, 'quick-point-paste-coordinate');
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<TextFormField>(
+            find.byKey(const ValueKey('quick-point-latitude')),
+          )
+          .controller
+          ?.text,
+      '35.712576',
+    );
+    expect(
+      tester
+          .widget<TextFormField>(
+            find.byKey(const ValueKey('quick-point-longitude')),
+          )
+          .controller
+          ?.text,
+      '139.722166',
+    );
+    expect(find.text('粘贴坐标'), findsNothing);
+    expect(find.textContaining('已填入坐标'), findsOneWidget);
+  });
+
+  testWidgets('quick manual point paste explains empty clipboard', (
+    tester,
+  ) async {
+    await tester.pumpWidget(MiriaGoApp(repository: SamplePilgrimageRepository()));
+    await tester.pumpAndSettle();
+
+    await _openPlanMenu(tester);
+    await tester.tap(find.text('添加点位').last);
+    await tester.pumpAndSettle();
+    _invokeKeyedAction(tester, 'add-points-quick-manual-point');
+    await tester.pumpAndSettle();
+    _mockClipboardRead(tester, '');
+
+    _invokeKeyedAction(tester, 'quick-point-paste-coordinate');
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('剪贴板中没有有效坐标'), findsOneWidget);
+    expect(find.text('粘贴坐标'), findsNothing);
+  });
+
   testWidgets('creates a new plan from the plan manager', (tester) async {
     final repository = SamplePilgrimageRepository();
     await tester.pumpWidget(MiriaGoApp(repository: repository));
@@ -3172,6 +3234,43 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('点击地图任意位置设置点位坐标'), findsOneWidget);
     expect(find.textContaining('点击地图可继续调整位置'), findsNothing);
+  });
+
+  testWidgets('manual point paste fills coordinates without a dialog', (
+    tester,
+  ) async {
+    await _pumpAppWithEmptyPlan(tester);
+
+    await _openAddPointsFromEmptyPlan(tester);
+    _invokeKeyedAction(tester, 'add-points-manual-point');
+    await tester.pumpAndSettle();
+    await tester.drag(find.byType(ListView), const Offset(0, -700));
+    await tester.pumpAndSettle();
+    _mockClipboardRead(tester, '35.008900, 135.771100');
+
+    _invokeKeyedAction(tester, 'point-form-paste-coordinate');
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<TextFormField>(
+            find.byKey(const ValueKey('point-form-latitude')),
+          )
+          .controller
+          ?.text,
+      '35.008900',
+    );
+    expect(
+      tester
+          .widget<TextFormField>(
+            find.byKey(const ValueKey('point-form-longitude')),
+          )
+          .controller
+          ?.text,
+      '135.771100',
+    );
+    expect(find.text('粘贴坐标'), findsNothing);
+    expect(find.textContaining('已填入坐标'), findsOneWidget);
   });
 
   testWidgets('Anitabi link import adds missing work on import', (

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -19,11 +19,13 @@ import 'package:miriago/plan/nearest_group_assign_screen.dart';
 import 'package:miriago/plan/plan_group_manager_screen.dart';
 import 'package:miriago/plan/plan_manager_screen.dart';
 import 'package:miriago/plan/point_manager_screen.dart';
+import 'package:miriago/plan/work_manager_screen.dart';
 import 'package:miriago/plan/pilgrimage_models.dart';
 import 'package:miriago/plan/pilgrimage_plan_controller.dart';
 import 'package:miriago/records/records_screen.dart';
 import 'package:miriago/records/comparison_export_config.dart';
 import 'package:miriago/widgets/constrained_menu_anchor.dart';
+import 'package:miriago/widgets/confirm_action_dialog.dart';
 import 'package:miriago/widgets/input_dialog.dart';
 import 'package:miriago/widgets/reference_image_placeholder.dart';
 
@@ -40,7 +42,7 @@ Future<void> _pumpAppWithEmptyPlan(WidgetTester tester) async {
 }
 
 Future<void> _openPlanMenu(WidgetTester tester) async {
-  await tester.tap(find.byTooltip('计划操作').first);
+  await tester.tap(find.byKey(const ValueKey('plan-actions-toggle')));
   await tester.pumpAndSettle();
 }
 
@@ -166,6 +168,214 @@ void main() {
     expect(find.text('默认计划'), findsOneWidget);
     expect(find.text('井用机前步行道'), findsWidgets);
     expect(find.textContaining('1 部作品'), findsOneWidget);
+    final planTitle = tester.widget<Text>(
+      find.descendant(of: find.byType(AppBar), matching: find.text('示例计划')),
+    );
+    expect(planTitle.style?.fontSize, 20);
+    expect(planTitle.style?.fontWeight, FontWeight.w900);
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
+    final metaStrip = tester.widget<Padding>(
+      find.byKey(const ValueKey('plan-meta-strip')),
+    );
+    expect(metaStrip.padding, const EdgeInsets.fromLTRB(16, 0, 16, 8));
+    final metaText = tester.widget<Text>(
+      find.byKey(const ValueKey('plan-meta-text')),
+    );
+    expect(metaText.textAlign, TextAlign.left);
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('plan-meta-text'))).dx,
+      closeTo(16, 0.1),
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-meta-strip')),
+        matching: find.byIcon(Icons.movie_filter_outlined),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('plan actions expand inline and keep five actions', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpApp(tester);
+
+    final switchButton = find.byKey(const ValueKey('plan-switch-button'));
+    final toggleButton = find.byKey(const ValueKey('plan-actions-toggle'));
+    final collapsedAppBarRect = tester.getRect(find.byType(AppBar));
+    final collapsedToggleRect = tester.getRect(toggleButton);
+    expect(switchButton, findsOneWidget);
+    expect(toggleButton, findsOneWidget);
+    expect(tester.getSize(switchButton), tester.getSize(toggleButton));
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: switchButton,
+        matching: find.byIcon(Icons.swap_horiz),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: toggleButton,
+        matching: find.byIcon(Icons.expand_more),
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(toggleButton);
+    await tester.pumpAndSettle();
+
+    final panel = find.byKey(const ValueKey('plan-actions-panel'));
+    expect(panel, findsOneWidget);
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
+    expect(tester.getRect(find.byType(AppBar)), collapsedAppBarRect);
+    expect(tester.getRect(toggleButton), collapsedToggleRect);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
+    expect(
+      find.descendant(
+        of: toggleButton,
+        matching: find.byIcon(Icons.expand_less),
+      ),
+      findsOneWidget,
+    );
+    for (final key in const [
+      'plan-action-cache-references',
+      'plan-action-add-points',
+      'plan-action-manage-points',
+      'plan-action-memo',
+      'plan-action-import-export',
+    ]) {
+      expect(find.byKey(ValueKey(key)), findsOneWidget);
+    }
+    expect(
+      tester.getBottomLeft(panel).dy,
+      lessThanOrEqualTo(
+        tester.getTopLeft(find.byKey(const ValueKey('plan-group-switcher'))).dy,
+      ),
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-action-cache-references')),
+        matching: find.byIcon(Icons.download_for_offline_outlined),
+      ),
+      findsOneWidget,
+    );
+
+    final addPointsRect = tester.getRect(
+      find.byKey(const ValueKey('plan-action-add-points')),
+    );
+    final managePointsRect = tester.getRect(
+      find.byKey(const ValueKey('plan-action-manage-points')),
+    );
+    final cacheReferencesRect = tester.getRect(
+      find.byKey(const ValueKey('plan-action-cache-references')),
+    );
+    expect(addPointsRect.top, closeTo(managePointsRect.top, 0.1));
+    expect(addPointsRect.bottom, closeTo(managePointsRect.bottom, 0.1));
+    expect(cacheReferencesRect.top, greaterThan(addPointsRect.bottom));
+    expect(cacheReferencesRect.left, closeTo(addPointsRect.left, 0.1));
+
+    await tester.tap(find.byKey(const ValueKey('plan-action-add-points')));
+    await tester.pumpAndSettle();
+    expect(find.byType(AddPointsScreen), findsOneWidget);
+    expect(find.byTooltip('Back'), findsNothing);
+    final addPointsBackButton = tester.widget<IconButton>(
+      find
+          .descendant(
+            of: find.byType(AppBar),
+            matching: find.byType(IconButton),
+          )
+          .first,
+    );
+    expect(addPointsBackButton.tooltip, isNull);
+    Navigator.of(tester.element(find.byType(AddPointsScreen))).pop();
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+
+    await tester.tap(toggleButton);
+    await tester.pumpAndSettle();
+
+    final reopenedPanel = find.byKey(const ValueKey('plan-actions-panel'));
+    expect(reopenedPanel, findsOneWidget);
+    await tester.tapAt(Offset(5, tester.getCenter(reopenedPanel).dy));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
+    expect(
+      find.descendant(
+        of: toggleButton,
+        matching: find.byIcon(Icons.expand_more),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: toggleButton,
+        matching: find.byIcon(Icons.expand_more),
+      ),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('plan actions can ignore taps outside the panel', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(360, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final repository = SamplePilgrimageRepository();
+    await repository.saveAppSettings(
+      const AppSettings(dismissPlanActionsOnOutsideTap: false),
+    );
+    await tester.pumpWidget(MiriaGoApp(repository: repository));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('plan-actions-toggle')));
+    await tester.pumpAndSettle();
+    final panel = find.byKey(const ValueKey('plan-actions-panel'));
+    expect(panel, findsOneWidget);
+
+    await tester.tapAt(Offset(5, tester.getCenter(panel).dy));
+    await tester.pumpAndSettle();
+
+    expect(panel, findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey('plan-action-cache-references')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byType(ConfirmActionDialog), findsOneWidget);
+
+    final confirmButton = find
+        .descendant(
+          of: find.byType(AppDialogActionRow),
+          matching: find.byType(FilledButton),
+        )
+        .last;
+    await tester.tap(confirmButton);
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
   });
 
   testWidgets('restores the last selected plan group', (tester) async {
@@ -425,6 +635,13 @@ void main() {
 
     await tester.tap(find.text('记录').last);
     await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<AppBar>(find.byKey(const ValueKey('records-app-bar')))
+          .toolbarHeight,
+      kToolbarHeight,
+    );
 
     final title = tester.widget<Text>(
       find.descendant(of: find.byType(AppBar), matching: find.text('记录')),
@@ -727,6 +944,50 @@ void main() {
     expect(tester.testTextInput.isVisible, isFalse);
   });
 
+  testWidgets(
+    'records search empty state explains no matches and clears search',
+    (tester) async {
+      await _pumpApp(tester);
+
+      await tester.tap(find.text('记录').last);
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('records-search-field')),
+        '不存在的巡礼记录',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('records-empty-state')), findsOneWidget);
+      expect(find.text('没有找到相关记录'), findsOneWidget);
+      expect(find.byIcon(Icons.search_off_rounded), findsOneWidget);
+      expect(find.textContaining('点位、作品或场景'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('records-empty-clear-search')),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('records-empty-clear-search')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('records-empty-state')), findsNothing);
+      expect(
+        find.byKey(const ValueKey('record-card-sample-record-jr-uji-01')),
+        findsOneWidget,
+      );
+      expect(
+        tester
+            .widget<TextField>(
+              find.byKey(const ValueKey('records-search-field')),
+            )
+            .controller
+            ?.text,
+        isEmpty,
+      );
+    },
+  );
+
   testWidgets('records can filter by work and plan group', (tester) async {
     await _pumpApp(tester);
 
@@ -941,6 +1202,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('记录详情'), findsOneWidget);
+    expect(tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight, 44);
+    final backButton = tester.widget<IconButton>(
+      find.descendant(
+        of: find.byKey(const ValueKey('record-detail-back-button')),
+        matching: find.byType(IconButton),
+      ),
+    );
+    expect(backButton.tooltip, isNull);
+    expect(
+      tester.getSize(
+        find.descendant(
+          of: find.byKey(const ValueKey('record-detail-back-button')),
+          matching: find.byType(IconButton),
+        ),
+      ),
+      const Size.square(40),
+    );
+    expect(
+      tester
+          .widget<Icon>(
+            find.descendant(
+              of: find.byKey(const ValueKey('record-detail-back-button')),
+              matching: find.byType(Icon),
+            ),
+          )
+          .semanticLabel,
+      '返回',
+    );
 
     await tester.tap(find.byTooltip('删除记录'));
     await tester.pumpAndSettle();
@@ -1285,6 +1574,28 @@ void main() {
     );
   });
 
+  testWidgets(
+    'map point card content opens detail and keeps navigation actions',
+    (tester) async {
+      await _pumpApp(tester);
+
+      await tester.tap(find.byIcon(Icons.map_outlined).last);
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.info_outline), findsNothing);
+      expect(find.byIcon(Icons.near_me_outlined), findsNWidgets(2));
+
+      await tester.tap(
+        find.byKey(
+          const ValueKey('map-point-card-content-anitabi-115908-7evkbmy2'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PointDetailSheet), findsOneWidget);
+    },
+  );
+
   testWidgets('plan map marker opens detail after selecting the point', (
     tester,
   ) async {
@@ -1495,6 +1806,76 @@ void main() {
     expect(find.textContaining('桌面启动器'), findsNothing);
   });
 
+  testWidgets('aligns plan, records, and settings root app bars', (
+    tester,
+  ) async {
+    await _pumpApp(tester);
+
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
+    final planAppBarTop = tester.getTopLeft(find.byType(AppBar)).dy;
+    final planActionTop = tester
+        .getTopLeft(find.byKey(const ValueKey('plan-actions-toggle')))
+        .dy;
+
+    await tester.tap(find.text('记录').last);
+    await tester.pumpAndSettle();
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('records-app-bar'))).dy,
+      closeTo(planAppBarTop, 0.1),
+    );
+    final recordsTitleTop = tester
+        .getTopLeft(
+          find.descendant(
+            of: find.byKey(const ValueKey('records-app-bar')),
+            matching: find.text('记录'),
+          ),
+        )
+        .dy;
+    final recordsActionTop = tester
+        .getTopLeft(find.byKey(const ValueKey('records-toggle-all-sections')))
+        .dy;
+    expect(recordsActionTop, closeTo(planActionTop, 0.1));
+
+    await tester.tap(find.text('设置').last);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .widget<AppBar>(find.byKey(const ValueKey('settings-app-bar')))
+          .toolbarHeight,
+      kToolbarHeight,
+    );
+    expect(
+      tester
+          .getTopLeft(
+            find.descendant(
+              of: find.byKey(const ValueKey('settings-app-bar')),
+              matching: find.text('设置'),
+            ),
+          )
+          .dy,
+      closeTo(recordsTitleTop, 0.1),
+    );
+    expect(
+      tester.getTopLeft(find.byKey(const ValueKey('settings-reset-button'))).dy,
+      closeTo(recordsActionTop, 0.1),
+    );
+    expect(
+      tester
+          .getTopRight(find.byKey(const ValueKey('settings-reset-button')))
+          .dx,
+      closeTo(
+        tester
+            .getTopRight(find.byKey(const ValueKey('settings-appearance-card')))
+            .dx,
+        0.1,
+      ),
+    );
+  });
+
   testWidgets('restores app and comparison settings together', (tester) async {
     final configured = const ComparisonExportConfig(
       borderWidthPercent: 2,
@@ -1547,6 +1928,15 @@ void main() {
       find.byKey(const ValueKey('plan-group-progress-toggle')),
     );
     expect(progressToggle.value, isTrue);
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('dismiss-plan-actions-on-outside-tap-toggle')),
+      180,
+      scrollable: find.byType(Scrollable).last,
+    );
+    final dismissToggle = tester.widget<SwitchListTile>(
+      find.byKey(const ValueKey('dismiss-plan-actions-on-outside-tap-toggle')),
+    );
+    expect(dismissToggle.value, isTrue);
 
     Navigator.of(tester.element(find.text('外观设置').first)).pop();
     await tester.pumpAndSettle();
@@ -1782,8 +2172,7 @@ void main() {
     await tester.pumpWidget(MiriaGoApp(repository: repository));
     await tester.pumpAndSettle();
 
-    await _openPlanMenu(tester);
-    await tester.tap(find.text('切换计划'));
+    await tester.tap(find.byKey(const ValueKey('plan-switch-button')));
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey('current-plan-section')), findsNothing);
     expect(find.byKey(const ValueKey('all-plans-section')), findsOneWidget);
@@ -2027,14 +2416,72 @@ void main() {
     expect(find.text('切换计划'), findsNothing);
   });
 
+  testWidgets('work manager opens a compact delete menu', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(360, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final repository = SamplePilgrimageRepository();
+    final plan = await repository.loadActivePlan();
+    final work = plan.works.first;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: WorkManagerScreen(
+          plan: plan,
+          repository: repository,
+          settings: const AppSettings(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final moreButton = find.byKey(ValueKey('work-manage-more-${work.id}'));
+    expect(moreButton, findsOneWidget);
+    expect(
+      find.descendant(of: moreButton, matching: find.byIcon(Icons.more_horiz)),
+      findsOneWidget,
+    );
+    expect(tester.getSize(moreButton), const Size.square(34));
+    final moreMenu = tester.widget<PopupMenuButton<String>>(moreButton);
+    expect(moreMenu.style?.side?.resolve({}), isNull);
+    expect(find.byKey(const ValueKey('work-action-delete')), findsNothing);
+    final cardBadgeTexts = tester.widgetList<Text>(
+      find.descendant(
+        of: find.byKey(ValueKey('work-manage-badges-${work.id}')),
+        matching: find.byType(Text),
+      ),
+    );
+    expect(cardBadgeTexts, isNotEmpty);
+    for (final badgeText in cardBadgeTexts) {
+      expect(badgeText.maxLines, 1);
+      expect(badgeText.softWrap, isFalse);
+    }
+
+    await tester.tap(moreButton);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('work-action-delete')), findsOneWidget);
+    expect(find.text('删除作品'), findsOneWidget);
+    expect(find.text('作品操作'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('work-action-delete')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('删除作品'), findsOneWidget);
+    expect(find.widgetWithText(FilledButton, '删除'), findsOneWidget);
+    await tester.tap(find.text('取消'));
+    await tester.pumpAndSettle();
+    expect(find.text('作品管理'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('switches plan when tapping copyable card title', (tester) async {
     final repository = SamplePilgrimageRepository();
     await repository.createPlan(name: '第二计划', area: '京都');
     await tester.pumpWidget(MiriaGoApp(repository: repository));
     await tester.pumpAndSettle();
 
-    await _openPlanMenu(tester);
-    await tester.tap(find.text('切换计划'));
+    await tester.tap(find.byKey(const ValueKey('plan-switch-button')));
     await tester.pumpAndSettle();
     await tester.tap(
       find.byKey(const ValueKey('plan-card-title-sample-uji-hibike')),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -167,7 +167,6 @@ void main() {
     expect(find.text('宇治站附近'), findsWidgets);
     expect(find.text('默认计划'), findsOneWidget);
     expect(find.text('井用机前步行道'), findsWidgets);
-    expect(find.textContaining('1 部作品'), findsOneWidget);
     final planTitle = tester.widget<Text>(
       find.descendant(of: find.byType(AppBar), matching: find.text('示例计划')),
     );
@@ -177,25 +176,8 @@ void main() {
       tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
       kToolbarHeight,
     );
-    final metaStrip = tester.widget<Padding>(
-      find.byKey(const ValueKey('plan-meta-strip')),
-    );
-    expect(metaStrip.padding, const EdgeInsets.fromLTRB(16, 0, 16, 8));
-    final metaText = tester.widget<Text>(
-      find.byKey(const ValueKey('plan-meta-text')),
-    );
-    expect(metaText.textAlign, TextAlign.left);
-    expect(
-      tester.getTopLeft(find.byKey(const ValueKey('plan-meta-text'))).dx,
-      closeTo(16, 0.1),
-    );
-    expect(
-      find.descendant(
-        of: find.byKey(const ValueKey('plan-meta-strip')),
-        matching: find.byIcon(Icons.movie_filter_outlined),
-      ),
-      findsNothing,
-    );
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-text')), findsNothing);
   });
 
   testWidgets('plan actions expand inline and keep five actions', (
@@ -213,8 +195,8 @@ void main() {
     expect(toggleButton, findsOneWidget);
     expect(tester.getSize(switchButton), tester.getSize(toggleButton));
     expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
-    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
-    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
     expect(
       find.descendant(
         of: switchButton,
@@ -304,8 +286,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('plan-actions-panel')), findsNothing);
-    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
-    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
 
     await tester.tap(toggleButton);
     await tester.pumpAndSettle();
@@ -327,8 +309,8 @@ void main() {
       tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
       kToolbarHeight,
     );
-    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
-    expect(find.byKey(const ValueKey('plan-meta-strip')), findsOneWidget);
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsNothing);
+    expect(find.byKey(const ValueKey('plan-meta-strip')), findsNothing);
     expect(
       find.descendant(
         of: toggleButton,
@@ -1202,7 +1184,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('记录详情'), findsOneWidget);
-    expect(tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight, 44);
+    expect(
+      tester.widget<AppBar>(find.byType(AppBar)).toolbarHeight,
+      kToolbarHeight,
+    );
     final backButton = tester.widget<IconButton>(
       find.descendant(
         of: find.byKey(const ValueKey('record-detail-back-button')),
@@ -1953,6 +1938,7 @@ void main() {
 
     expect(find.text('最大缩放倍率'), findsOneWidget);
     expect(find.text('地图标记大小'), findsOneWidget);
+    expect(find.text('隐藏已完成点位'), findsOneWidget);
     expect(find.text('片区范围半径'), findsOneWidget);
     expect(find.text('显示片区进度条'), findsNothing);
     expect(find.text('90%'), findsOneWidget);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -167,6 +167,17 @@ void main() {
     expect(find.text('宇治站附近'), findsWidgets);
     expect(find.text('默认计划'), findsOneWidget);
     expect(find.text('井用机前步行道'), findsWidgets);
+    expect(find.text('吹响吧！上低音号'), findsWidgets);
+    expect(find.textContaining('あじろぎの道'), findsNothing);
+    expect(find.text('已拍 2'), findsNothing);
+    expect(find.byKey(const ValueKey('plan-point-shot-badge')), findsWidgets);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-point-shot-badge')),
+        matching: find.text('2'),
+      ),
+      findsNothing,
+    );
     final planTitle = tester.widget<Text>(
       find.descendant(of: find.byType(AppBar), matching: find.text('示例计划')),
     );
@@ -319,6 +330,43 @@ void main() {
       findsOneWidget,
     );
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('plan action subtitles hide on a narrow screen', (tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await _pumpApp(tester);
+
+    await tester.tap(find.byKey(const ValueKey('plan-actions-toggle')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsOneWidget);
+    expect(find.text('添加点位'), findsOneWidget);
+    expect(find.text('计划备忘录'), findsOneWidget);
+    expect(find.text('加入巡礼场景'), findsNothing);
+    expect(find.text('整理片区点位'), findsNothing);
+    expect(find.text('保存完整图片'), findsNothing);
+    expect(find.text('记录行程要点'), findsNothing);
+    expect(find.text('备份迁移计划'), findsNothing);
+  });
+
+  testWidgets('plan action subtitles stay visible on a wider screen', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(430, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpApp(tester);
+
+    await tester.tap(find.byKey(const ValueKey('plan-actions-toggle')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('plan-actions-panel')), findsOneWidget);
+    expect(find.text('添加点位'), findsOneWidget);
+    expect(find.text('加入巡礼场景'), findsOneWidget);
+    expect(find.text('计划备忘录'), findsOneWidget);
+    expect(find.text('记录行程要点'), findsOneWidget);
   });
 
   testWidgets('plan actions can ignore taps outside the panel', (tester) async {
@@ -748,15 +796,11 @@ void main() {
         const ValueKey('records-group-surface-sample-group-uji-station'),
       ),
     );
-    final groupDividerRect = tester.getRect(
-      find.byKey(const ValueKey('records-group-divider')).first,
-    );
     final firstRecordRect = tester.getRect(
       find.byKey(const ValueKey('record-card-sample-record-jr-uji-01')),
     );
-    expect(groupDividerRect.width, closeTo(groupSurfaceRect.width - 20, 0.1));
-    expect(groupDividerRect.left, greaterThan(groupSurfaceRect.left));
-    expect(firstRecordRect.top - groupDividerRect.bottom, closeTo(4, 0.1));
+    expect(find.byKey(const ValueKey('records-group-divider')), findsNothing);
+    expect(firstRecordRect.top - groupSurfaceRect.bottom, closeTo(4, 0.1));
     expect(
       find.ancestor(
         of: find.byKey(
@@ -1250,6 +1294,9 @@ void main() {
 
     await tester.tap(find.byTooltip('编辑'));
     await tester.pumpAndSettle();
+    expect(find.text('备忘录内容'), findsOneWidget);
+    expect(find.text('取消'), findsNothing);
+    expect(find.text('可以记录交通、预约、补拍事项、同行安排等。'), findsOneWidget);
     await tester.enterText(find.byType(TextField), '第一天先去宇治站，下午整理补拍点。');
     await tester.tap(find.widgetWithText(FilledButton, '保存'));
     await tester.pumpAndSettle();
@@ -1537,6 +1584,15 @@ void main() {
     expect(find.text('井用机前步行道'), findsWidgets);
     expect(find.text('吹响吧！上低音号 / EP 1 / 2:08'), findsOneWidget);
     expect(find.textContaining('あじろぎの道 / 34.'), findsNothing);
+    expect(find.text('已拍 2'), findsNothing);
+    expect(find.byKey(const ValueKey('map-point-shot-badge')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byTooltip('拍摄参考'),
+        matching: find.byKey(const ValueKey('map-point-shot-badge')),
+      ),
+      findsOneWidget,
+    );
     expect(
       tester
           .widgetList<PolygonLayer>(find.byType(PolygonLayer))
@@ -1581,6 +1637,146 @@ void main() {
     },
   );
 
+  testWidgets('map large navigation button opens in-app navigation ui', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpApp(tester);
+
+    await tester.tap(find.byIcon(Icons.map_outlined).last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('map-in-app-navigation-button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('navigation-route-confirm-screen')),
+      findsOneWidget,
+    );
+    expect(find.text('确认路线'), findsOneWidget);
+    expect(find.text('串联整个片区导航'), findsOneWidget);
+    expect(find.text('仅导航到选中点'), findsOneWidget);
+    expect(find.textContaining('点击即按顺序连接'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsNothing,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('navigation-route-confirm-zone')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsOneWidget,
+    );
+    expect(find.text('片区'), findsOneWidget);
+    expect(find.text('宇治站附近'), findsOneWidget);
+    expect(find.textContaining('井用机前步行道'), findsOneWidget);
+    expect(find.text('到达'), findsOneWidget);
+    expect(find.text('小时'), findsOneWidget);
+    expect(find.text('公里'), findsOneWidget);
+    expect(find.text('17 分钟'), findsNothing);
+    expect(find.text('结束路线'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-expand')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('结束路线'), findsOneWidget);
+    expect(find.text('全部点位'), findsOneWidget);
+    expect(find.text('详细信息'), findsNothing);
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-all-stops')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-all-stops-sheet')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('宇治桥'), findsOneWidget);
+    expect(find.textContaining('下一个:'), findsNothing);
+    expect(find.textContaining('终点: 京阪宇治站前'), findsOneWidget);
+
+    Navigator.of(
+      tester.element(
+        find.byKey(const ValueKey('in-app-navigation-all-stops-sheet')),
+      ),
+    ).pop();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-end-route')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('map-in-app-navigation-button')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('map navigation can start only the selected point', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpApp(tester);
+
+    await tester.tap(find.byIcon(Icons.map_outlined).last);
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('map-in-app-navigation-button')),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('navigation-route-confirm-point')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('终点: 井用机前步行道'), findsOneWidget);
+    expect(find.textContaining('下一个:'), findsNothing);
+  });
+
+  testWidgets('plan point detail navigation opens in-app navigation ui', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpApp(tester);
+
+    await tester.tap(find.text('井用机前步行道').first);
+    await tester.pumpAndSettle();
+    _invokeKeyedAction(tester, 'point-detail-in-app-navigation-button');
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('navigation-route-confirm-screen')),
+      findsOneWidget,
+    );
+    expect(find.text('串联整个片区导航'), findsOneWidget);
+    await tester.tap(
+      find.byKey(const ValueKey('navigation-route-confirm-zone')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-screen')),
+      findsOneWidget,
+    );
+    expect(find.textContaining('井用机前步行道'), findsOneWidget);
+    expect(find.byType(PointDetailSheet), findsNothing);
+  });
+
   testWidgets('plan map marker opens detail after selecting the point', (
     tester,
   ) async {
@@ -1611,9 +1807,100 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('管理计划'), findsOneWidget);
-    expect(find.textContaining('关键点'), findsWidgets);
+    expect(find.byKey(const ValueKey('point-manager-group-switcher')), findsOneWidget);
+    expect(
+      tester.widget(find.byKey(const ValueKey('point-manager-group-switcher'))),
+      isA<FilledButton>(),
+    );
+    expect(find.text('宇治站附近'), findsOneWidget);
+    expect(find.byKey(const ValueKey('point-manager-anchor-row')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('point-manager-anchor-row')),
+        matching: find.text('关键点：JR 宇治站'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('point-manager-anchor-row')))
+          .height,
+      40,
+    );
+    expect(find.text('更改'), findsOneWidget);
     expect(find.text('无序'), findsWidgets);
     expect(find.text('井用机前步行道'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('point-manager-count-chip-points')),
+        matching: find.text('6'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('point-manager-count-chip-points')),
+        matching: find.text('点位'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<Text>(
+            find.descendant(
+              of: find.byKey(const ValueKey('point-manager-count-chip-points')),
+              matching: find.text('6'),
+            ),
+          )
+          .style
+          ?.fontSize,
+      14,
+    );
+    expect(
+      tester
+          .widget<Text>(
+            find.descendant(
+              of: find.byKey(const ValueKey('point-manager-count-chip-points')),
+              matching: find.text('点位'),
+            ),
+          )
+          .style
+          ?.fontSize,
+      10,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('point-manager-count-chip-completed')),
+        matching: find.text('0'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('point-manager-count-chip-completed')),
+        matching: find.text('完成'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('关键点 · JR 宇治站'), findsNothing);
+    expect(find.text('1 / 7'), findsNothing);
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('point-manager-count-chip-points')))
+          .height,
+      tester
+          .getSize(find.byKey(const ValueKey('point-manager-order-button')))
+          .height,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('point-manager-order-button')));
+    await tester.pumpAndSettle();
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('point-manager-order-menu')))
+          .width,
+      124,
+    );
   });
 
   testWidgets('plan manager reuses plan region drawers', (tester) async {
@@ -1631,7 +1918,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithText(FilledButton, '宇治站附近'));
+    await tester.tap(find.byKey(const ValueKey('point-manager-group-switcher')));
     await tester.pumpAndSettle();
     expect(find.text('选择区域'), findsOneWidget);
     expect(
@@ -1753,7 +2040,12 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('新建片区'));
+    expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
+    expect(find.byIcon(Icons.account_tree_outlined), findsNothing);
+    expect(find.text('未分配点位'), findsOneWidget);
+    expect(find.textContaining('个点位等待整理'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('plan-group-create-fab')));
     await tester.pumpAndSettle();
     await tester.tap(find.text('创建'));
     await tester.pumpAndSettle();
@@ -1776,6 +2068,16 @@ void main() {
 
     expect(find.text('片区名不能为空'), findsNothing);
     expect(find.text('新片区'), findsOneWidget);
+    expect(find.text('未设置关键点'), findsOneWidget);
+    expect(find.text('空'), findsOneWidget);
+    expect(find.text('无序'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('片区操作'));
+    await tester.pumpAndSettle();
+    expect(find.text('重命名'), findsOneWidget);
+    expect(find.text('设置关键点'), findsOneWidget);
+    expect(find.text('切换为手动排序'), findsOneWidget);
+    expect(find.text('删除片区'), findsOneWidget);
   });
 
   testWidgets('hides desktop launcher status outside web builds', (
@@ -2003,6 +2305,16 @@ void main() {
       find.byKey(const ValueKey('anitabi-service-restore-defaults')),
       findsOneWidget,
     );
+    expect(find.text('连接测试'), findsNothing);
+    expect(find.text('主站地址'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('anitabi-service-restore-defaults')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('将把全部 Anitabi 服务地址恢复为官方默认值。'), findsOneWidget);
+    await tester.tap(find.text('取消'));
+    await tester.pumpAndSettle();
 
     Navigator.of(tester.element(find.text('Anitabi 服务地址').first)).pop();
     await tester.pumpAndSettle();
@@ -2016,6 +2328,45 @@ void main() {
     expect(find.text('地图标记大小'), findsNothing);
     expect(find.text('片区范围半径'), findsNothing);
     expect(find.text('自动聚合密集点位'), findsNothing);
+  });
+
+  testWidgets('appearance settings can switch app theme mode', (tester) async {
+    final repository = SamplePilgrimageRepository();
+    await tester.pumpWidget(MiriaGoApp(repository: repository));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('设置').last);
+    await tester.pumpAndSettle();
+    expect(find.text('主题模式'), findsOneWidget);
+    expect(find.text('主题色'), findsOneWidget);
+    expect(find.text('浅色'), findsWidgets);
+
+    await tester.tap(find.text('外观设置'));
+    await tester.pumpAndSettle();
+    expect(find.text('影响应用整体浅色或深色显示'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('appearance-theme-mode-dark')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('appearance-theme-mode-dark')));
+    await tester.pumpAndSettle();
+
+    expect((await repository.loadAppSettings()).themeMode, AppThemeMode.dark);
+    expect(AppColors.isDark, isTrue);
+    expect(
+      Theme.of(tester.element(find.text('外观设置').first)).brightness,
+      Brightness.dark,
+    );
+    Navigator.of(tester.element(find.text('外观设置').first)).pop();
+    await tester.pumpAndSettle();
+    expect(find.text('深色'), findsWidgets);
+    expect(
+      Theme.of(
+        tester.element(find.byKey(const ValueKey('settings-app-bar'))),
+      ).scaffoldBackgroundColor,
+      AppColors.background,
+    );
   });
 
   testWidgets('custom theme palette updates the hex color', (tester) async {
@@ -2086,6 +2437,21 @@ void main() {
     expect(find.text('请先通过 Bangumi 搜索添加作品'), findsOneWidget);
     expect(quickManualPointInkWell.onTap, isNull);
     expect(manualPointInkWell.onTap, isNotNull);
+  });
+
+  testWidgets('empty map guide splits title and supporting copy', (tester) async {
+    await _pumpAppWithEmptyPlan(tester);
+
+    await tester.tap(find.text('地图').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('当前计划还没有点位'), findsOneWidget);
+    expect(find.text('添加点位后会在地图上显示标记。'), findsOneWidget);
+    expect(find.text('当前计划还没有点位。添加点位后会在地图上显示标记。'), findsNothing);
+    expect(
+      tester.getSize(find.byKey(const ValueKey('map-empty-card'))).height,
+      lessThan(120),
+    );
   });
 
   testWidgets('quick manual point page keeps only the lightweight fields', (
@@ -2529,7 +2895,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect((await repository.loadPlans()).map((plan) => plan.id), originalIds);
-    expect(find.text('保存计划顺序失败，已恢复原来的顺序。'), findsOneWidget);
+    expect(find.text('保存计划顺序失败，已恢复原来的顺序'), findsOneWidget);
     final cardKeys = tester
         .widgetList<Padding>(
           find.byWidgetPredicate(
@@ -2661,7 +3027,7 @@ void main() {
       tester.widget<TextFormField>(fields.at(2)).controller!.text,
       isEmpty,
     );
-    await tester.pageBack();
+    await tester.tap(find.byIcon(Icons.arrow_back));
     await tester.pumpAndSettle();
 
     expect(find.text('原创短片'), findsOneWidget);


### PR DESCRIPTION
Depends on #11. Once that PR merges, the unique change here is `feat: polish plan/map chrome, in-app nav, and status feedback`.

## 简介

把计划、地图、记录、设置的视觉和反馈收成一套：描边卡片、主题随明暗变化、统一状态条；并补上应用内导航、片区/关键点管理改版，以及拍摄定位与调色确认。

## 主要修改

- `AppColors` / `AppTheme` 随明暗模式切换；新增 `AppStatusBanner`，Snack 用同一套卡片
- 地图「导航」先进入路线确认页，再进应用内导航；到达后可开相机、去下一点
- 优化首次拍照询问是否在巡礼照片里写入定位弹窗的样式
- 参考图全量缓存用独立进度对话框；自动调色重置改为图标并二次确认
- 计划页点位行左侧改为缩略图（无图时仍显示状态图标）；已拍标贴在相机图标上
- 管理计划：片区切换与计划页同款；关键点行 + badge + 排序；未分组「等待整理」+ 最近/框选分配
- 选关键点「清除选点」确认后仍留在地图页
- 片区管理可拖拽排序，点卡片跳回对应片区；没有关键点不再用警示色
- 记录卡片去阴影、改描边；设置页与对话框跟着主题对齐
- 坐标输入对话框，可解析剪贴板

## 验证

- [ ] 明/暗主题：计划、地图、设置、对话框颜色一致
- [ ] 缓存/保存/失败：状态条与 Snack
- [ ] 计划列表：缩略图 / 无图状态图标；相机上已拍小标
- [ ] 管理计划：片区切换、关键点行、badge、未分组两按钮、批量条
- [ ] 选关键点：清除选点确认后仍留在地图页
- [ ] 片区管理：拖拽、点选回跳、未分配箭头
- [ ] 地图：已拍标；应用内导航确认 → 到达 → 开相机
- [ ] 首次拍照定位询问；设置可改
- [ ] 自动调色：重置图标 + 确认框
- [ ] 记录页卡片为描边、无阴影

## 说明

- 计划页缩略图是试验改动，不合适时只回退 `lib/plan/plan_screen.dart` 点位行左侧即可
- 不含 `output/`、`build/`