### PR TITLE
feat: improve responsive actions and icon consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,7 @@ iOS 本地归档和 TestFlight 上传需要在 Xcode 中选择自己的 Apple De
 ## 开源协议
 
 本项目代码基于 [MIT License](LICENSE) 开源。
+
+## 第三方许可证
+
+本项目使用 [`lucide_icons_flutter`](https://pub.dev/packages/lucide_icons_flutter) 提供 Lucide 图标。该软件包以 MIT License 发布，Copyright (c) 2024 vqhapp；许可证全文见软件包发行内容中的 `LICENSE` 文件。

--- a/lib/app_shell.dart
+++ b/lib/app_shell.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import 'app_theme.dart';
 import 'data/anitabi_image_source_scope.dart';
@@ -357,26 +358,26 @@ class _AppShellState extends State<AppShell> {
                       },
                       destinations: const [
                         NavigationDestination(
-                          icon: Icon(Icons.checklist_outlined),
-                          selectedIcon: Icon(Icons.checklist),
+                          icon: Icon(LucideIcons.listTodo),
+                          selectedIcon: Icon(LucideIcons.listTodo),
                           label: '计划',
                           tooltip: '',
                         ),
                         NavigationDestination(
-                          icon: Icon(Icons.map_outlined),
-                          selectedIcon: Icon(Icons.map),
+                          icon: Icon(LucideIcons.map),
+                          selectedIcon: Icon(LucideIcons.map),
                           label: '地图',
                           tooltip: '',
                         ),
                         NavigationDestination(
-                          icon: Icon(Icons.collections_bookmark_outlined),
-                          selectedIcon: Icon(Icons.collections_bookmark),
+                          icon: Icon(LucideIcons.images),
+                          selectedIcon: Icon(LucideIcons.images),
                           label: '记录',
                           tooltip: '',
                         ),
                         NavigationDestination(
-                          icon: Icon(Icons.settings_outlined),
-                          selectedIcon: Icon(Icons.settings),
+                          icon: Icon(LucideIcons.settings),
+                          selectedIcon: Icon(LucideIcons.settings),
                           label: '设置',
                           tooltip: '',
                         ),
@@ -411,7 +412,7 @@ class _PlanLoadState extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Icon(
-                hasError ? Icons.error_outline : Icons.route_outlined,
+                hasError ? LucideIcons.circleAlert : LucideIcons.route,
                 color: hasError ? AppColors.error : AppColors.accent,
                 size: 40,
               ),
@@ -450,7 +451,7 @@ class _PlanLoadState extends StatelessWidget {
               if (hasError)
                 OutlinedButton.icon(
                   onPressed: onRetry,
-                  icon: const Icon(Icons.refresh, size: 18),
+                  icon: const Icon(LucideIcons.refreshCw, size: 18),
                   label: const Text('重试'),
                 )
               else

--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -254,6 +254,17 @@ class AppTheme {
           ),
         ),
       ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: AppColors.accentDark,
+          minimumSize: const Size(44, 44),
+          textStyle: const TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0,
+          ),
+        ),
+      ),
       iconButtonTheme: IconButtonThemeData(
         style: IconButton.styleFrom(
           foregroundColor: AppColors.textPrimary,

--- a/lib/camera_reference/camerawesome_reference_screen.dart
+++ b/lib/camera_reference/camerawesome_reference_screen.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 import 'package:camerawesome/camerawesome_plugin.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -478,7 +479,7 @@ class _CamerawesomeReferenceScreenState
                   ScaffoldMessenger.of(context).showStatusSnack(
                     kind: AppStatusBannerKind.running,
                     title: '正在读取参考图比例，请稍后拍摄。',
-                    icon: Icons.aspect_ratio_outlined,
+                    icon: LucideIcons.ratio,
                   );
                   return;
                 }
@@ -1419,13 +1420,13 @@ class _NativeCameraTopBar extends StatelessWidget {
           _CameraCircleButton(
             tooltip: null,
             semanticLabel: '返回',
-            icon: Icons.arrow_back,
+            icon: LucideIcons.arrowLeft,
             onPressed: () => Navigator.of(context).maybePop(),
           ),
           const Spacer(),
           _CameraCircleButton(
             tooltip: '参考图',
-            icon: Icons.image_outlined,
+            icon: LucideIcons.image,
             onPressed: onPickReference,
           ),
           const SizedBox(width: 8),
@@ -1433,7 +1434,7 @@ class _NativeCameraTopBar extends StatelessWidget {
           const SizedBox(width: 8),
           _CameraCircleButton(
             tooltip: '切换横屏 UI',
-            icon: Icons.screen_rotation_alt_outlined,
+            icon: LucideIcons.rotate3d,
             onPressed: onPreferLandscapeUi,
           ),
         ],
@@ -1492,8 +1493,8 @@ class _NativeCameraBottomPanel extends StatelessWidget {
               _CameraActionButton(
                 tooltip: '相册导入',
                 icon: galleryImage == null
-                    ? Icons.photo_library_outlined
-                    : Icons.photo_library,
+                    ? LucideIcons.images
+                    : LucideIcons.images,
                 onPressed: onPickGallery,
               ),
               const Spacer(),
@@ -1651,7 +1652,7 @@ class _NativeLandscapeLeftRail extends StatelessWidget {
                 iconSize: metrics.controlIconSize,
                 tooltip: null,
                 semanticLabel: '返回',
-                icon: Icons.arrow_back,
+                icon: LucideIcons.arrowLeft,
                 onPressed: onBack,
               ),
               SizedBox(height: metrics.leftGap),
@@ -1659,7 +1660,7 @@ class _NativeLandscapeLeftRail extends StatelessWidget {
                 size: metrics.controlButtonSize,
                 iconSize: metrics.controlIconSize,
                 tooltip: '参考图',
-                icon: Icons.image_outlined,
+                icon: LucideIcons.image,
                 onPressed: onPickReference,
               ),
               SizedBox(height: metrics.leftGap + 2),
@@ -1708,7 +1709,7 @@ class _NativeLandscapeZoomRail extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 3, vertical: 6),
           child: _VerticalCameraSlider(
             compact: true,
-            icon: Icons.zoom_in_outlined,
+            icon: LucideIcons.zoomIn,
             value: sliderValue,
             label: _formatRealZoom(controller.zoomRatio),
             onChanged: (value) {
@@ -1782,7 +1783,7 @@ class _NativeLandscapeRightRail extends StatelessWidget {
                   size: layout.controlButtonSize,
                   iconSize: layout.controlIconSize,
                   tooltip: '切换竖屏 UI',
-                  icon: Icons.screen_rotation_alt_outlined,
+                  icon: LucideIcons.rotate3d,
                   onPressed: onPreferPortraitUi,
                 ),
               ];
@@ -1800,7 +1801,7 @@ class _NativeLandscapeRightRail extends StatelessWidget {
                       builder: (context, opacity, child) {
                         return _VerticalCameraSlider(
                           compact: true,
-                          icon: Icons.opacity,
+                          icon: LucideIcons.droplets,
                           value: opacity,
                           label: '${(opacity * 100).round()}%',
                           onChanged: onOpacityChanged,
@@ -1838,7 +1839,7 @@ class _NativeLandscapeRightRail extends StatelessWidget {
                             size: layout.actionButtonSize,
                             iconSize: layout.actionIconSize,
                             tooltip: '检查照片',
-                            icon: Icons.fact_check_outlined,
+                            icon: LucideIcons.listChecks,
                             onPressed: () {},
                           )
                         : _GalleryImportButton(
@@ -1960,10 +1961,10 @@ class _NativeFlashButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final icon = switch (controller.flashMode) {
-      'off' => Icons.flash_off,
-      'on' => Icons.flash_on,
-      'torch' => Icons.flashlight_on,
-      _ => Icons.flash_auto,
+      'off' => LucideIcons.zapOff,
+      'on' => LucideIcons.zap,
+      'torch' => LucideIcons.flashlight,
+      _ => LucideIcons.zap,
     };
 
     return _CameraCircleButton(
@@ -1978,9 +1979,9 @@ class _NativeFlashButton extends StatelessWidget {
 
 IconData _nativeLensIcon(_NativeCameraController controller) {
   return switch (controller.lensMode) {
-    'backTelephoto' => Icons.center_focus_strong_outlined,
-    'front' => Icons.flip_camera_android_outlined,
-    _ => Icons.cameraswitch_outlined,
+    'backTelephoto' => LucideIcons.focus,
+    'front' => LucideIcons.switchCamera,
+    _ => LucideIcons.switchCamera,
   };
 }
 
@@ -2016,7 +2017,7 @@ class _NativeZoomAndOpacityControls extends StatelessWidget {
     return Column(
       children: [
         _SliderRow(
-          icon: Icons.zoom_in_outlined,
+          icon: LucideIcons.zoomIn,
           value: sliderValue,
           label: _formatRealZoom(controller.zoomRatio),
           onChanged: (value) {
@@ -2033,7 +2034,7 @@ class _NativeZoomAndOpacityControls extends StatelessWidget {
           valueListenable: overlayOpacity,
           builder: (context, opacity, child) {
             return _SliderRow(
-              icon: Icons.opacity,
+              icon: LucideIcons.droplets,
               value: opacity,
               label: '${(opacity * 100).round()}%',
               onChanged: onOpacityChanged,
@@ -2431,13 +2432,13 @@ class _CameraTopBar extends StatelessWidget {
           _CameraCircleButton(
             tooltip: null,
             semanticLabel: '返回',
-            icon: Icons.arrow_back,
+            icon: LucideIcons.arrowLeft,
             onPressed: () => Navigator.of(context).maybePop(),
           ),
           const Spacer(),
           _CameraCircleButton(
             tooltip: '参考图',
-            icon: Icons.image_outlined,
+            icon: LucideIcons.image,
             onPressed: onPickReference,
           ),
           const SizedBox(width: 8),
@@ -2601,9 +2602,7 @@ class _LandscapeCaptureRail extends StatelessWidget {
           children: [
             _CameraActionButton(
               tooltip: '相册导入',
-              icon: hasGalleryImage
-                  ? Icons.photo_library
-                  : Icons.photo_library_outlined,
+              icon: hasGalleryImage ? LucideIcons.images : LucideIcons.images,
               onPressed: onPickGallery,
             ),
             const SizedBox(width: 12),
@@ -2614,7 +2613,7 @@ class _LandscapeCaptureRail extends StatelessWidget {
               const SizedBox(width: 18),
               _CameraActionButton(
                 tooltip: '检查照片',
-                icon: Icons.fact_check_outlined,
+                icon: LucideIcons.listChecks,
                 onPressed: () {},
               ),
             ],
@@ -2695,10 +2694,10 @@ class _CompactFlashButton extends StatelessWidget {
           builder: (context, flashSnapshot) {
             final flashMode = flashSnapshot.data ?? sensorConfig.flashMode;
             final icon = switch (flashMode) {
-              FlashMode.none => Icons.flash_off,
-              FlashMode.on => Icons.flash_on,
-              FlashMode.auto => Icons.flash_auto,
-              FlashMode.always => Icons.flashlight_on,
+              FlashMode.none => LucideIcons.zapOff,
+              FlashMode.on => LucideIcons.zap,
+              FlashMode.auto => LucideIcons.zap,
+              FlashMode.always => LucideIcons.flashlight,
             };
 
             return _CameraCircleButton(
@@ -2726,7 +2725,7 @@ class _CompactCameraSwitchButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return _CameraCircleButton(
       tooltip: showTooltip ? '切换摄像头' : null,
-      icon: Icons.cameraswitch_outlined,
+      icon: LucideIcons.switchCamera,
       onPressed: () => state.switchCameraSensor(
         zoom: state.sensorConfig.zoom,
         flash: state.sensorConfig.flashMode,
@@ -2792,8 +2791,8 @@ class _CameraBottomPanel extends StatelessWidget {
               _CameraActionButton(
                 tooltip: '相册导入',
                 icon: galleryImage == null
-                    ? Icons.photo_library_outlined
-                    : Icons.photo_library,
+                    ? LucideIcons.images
+                    : LucideIcons.images,
                 onPressed: onPickGallery,
               ),
               const Spacer(),
@@ -2801,7 +2800,7 @@ class _CameraBottomPanel extends StatelessWidget {
               const Spacer(),
               _CameraActionButton(
                 tooltip: '检查照片',
-                icon: Icons.fact_check_outlined,
+                icon: LucideIcons.listChecks,
                 onPressed: galleryImage == null ? null : () {},
               ),
             ],
@@ -2821,8 +2820,8 @@ class _ModeSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const modes = [
-      (AwesomeReferenceMode.overlay, Icons.layers_outlined, '叠影'),
-      (AwesomeReferenceMode.split, Icons.splitscreen_outlined, '上下'),
+      (AwesomeReferenceMode.overlay, LucideIcons.layers, '叠影'),
+      (AwesomeReferenceMode.split, LucideIcons.panelsTopLeft, '上下'),
     ];
 
     return LayoutBuilder(
@@ -2871,8 +2870,8 @@ class _ModeColumnSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const modes = [
-      (AwesomeReferenceMode.overlay, Icons.layers_outlined, '叠影'),
-      (AwesomeReferenceMode.split, Icons.splitscreen_outlined, '上下'),
+      (AwesomeReferenceMode.overlay, LucideIcons.layers, '叠影'),
+      (AwesomeReferenceMode.split, LucideIcons.panelsTopLeft, '上下'),
     ];
 
     return Column(
@@ -3040,7 +3039,7 @@ class _ZoomAndOpacityControls extends StatelessWidget {
           valueListenable: overlayOpacity,
           builder: (context, opacity, child) {
             return _SliderRow(
-              icon: Icons.opacity,
+              icon: LucideIcons.droplets,
               value: opacity,
               label: '${(opacity * 100).round()}%',
               onChanged: onOpacityChanged,
@@ -3168,7 +3167,7 @@ class _CameraZoomSliderState extends State<_CameraZoomSlider> {
                 _realZoomFromSliderValue(minZoom, maxZoom, sliderValue),
               );
         return _SliderRow(
-          icon: Icons.zoom_in_outlined,
+          icon: LucideIcons.zoomIn,
           value: sliderValue,
           label: label,
           onChanged: minZoom == null || maxZoom == null
@@ -3520,7 +3519,7 @@ class _GalleryImportButton extends StatelessWidget {
     if (!showLabel) {
       return _CameraActionButton(
         tooltip: '从相册导入',
-        icon: Icons.add_photo_alternate_outlined,
+        icon: LucideIcons.imagePlus,
         size: size,
         iconSize: iconSize,
         onPressed: onPressed,
@@ -3538,7 +3537,7 @@ class _GalleryImportButton extends StatelessWidget {
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
         onPressed: onPressed,
-        icon: Icon(Icons.add_photo_alternate_outlined, size: iconSize),
+        icon: Icon(LucideIcons.imagePlus, size: iconSize),
         label: const Text(
           '导入',
           style: TextStyle(fontSize: 11, fontWeight: FontWeight.w800),
@@ -3664,7 +3663,7 @@ class _WebCameraFallback extends StatelessWidget {
                 _ModeSelector(mode: mode, onChanged: onModeChanged),
                 const SizedBox(height: 6),
                 _SliderRow(
-                  icon: Icons.opacity,
+                  icon: LucideIcons.droplets,
                   value: overlayOpacity,
                   label: '${(overlayOpacity * 100).round()}%',
                   onChanged: onOpacityChanged,
@@ -3674,13 +3673,13 @@ class _WebCameraFallback extends StatelessWidget {
                     _CameraActionButton(
                       tooltip: '相册导入',
                       icon: galleryImage == null
-                          ? Icons.photo_library_outlined
-                          : Icons.photo_library,
+                          ? LucideIcons.images
+                          : LucideIcons.images,
                       onPressed: onPickGallery,
                     ),
                     const Spacer(),
                     const Icon(
-                      Icons.photo_camera_outlined,
+                      LucideIcons.camera,
                       color: Colors.white,
                       size: 36,
                     ),
@@ -3717,7 +3716,7 @@ class _FallbackTopBar extends StatelessWidget {
         children: [
           IconButton(
             onPressed: () => Navigator.of(context).maybePop(),
-            icon: const Icon(Icons.arrow_back, semanticLabel: '返回'),
+            icon: const Icon(LucideIcons.arrowLeft, semanticLabel: '返回'),
           ),
           Expanded(
             child: Text(
@@ -3734,7 +3733,7 @@ class _FallbackTopBar extends StatelessWidget {
           IconButton(
             tooltip: '参考图',
             onPressed: onPickReference,
-            icon: const Icon(Icons.image_outlined),
+            icon: const Icon(LucideIcons.image),
           ),
         ],
       ),
@@ -3753,7 +3752,7 @@ class _FallbackPreview extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.photo_camera_outlined, color: AppColors.accentDark),
+            Icon(LucideIcons.camera, color: AppColors.accentDark),
             SizedBox(height: 8),
             Text(
               'Web 预览不启动实时相机',
@@ -3787,7 +3786,7 @@ class _NativeCameraUnavailableMessage extends StatelessWidget {
               mainAxisSize: MainAxisSize.min,
               children: [
                 const Icon(
-                  Icons.error_outline,
+                  LucideIcons.circleAlert,
                   color: Colors.white70,
                   size: 36,
                 ),
@@ -3814,7 +3813,7 @@ class _NativeCameraUnavailableMessage extends StatelessWidget {
                 const SizedBox(height: 18),
                 FilledButton.icon(
                   onPressed: () => Navigator.of(context).maybePop(),
-                  icon: const Icon(Icons.arrow_back),
+                  icon: const Icon(LucideIcons.arrowLeft),
                   label: const Text('返回'),
                 ),
               ],
@@ -3926,7 +3925,7 @@ class _ReferenceError extends StatelessWidget {
     return ColoredBox(
       color: AppColors.surfaceMuted,
       child: Center(
-        child: Icon(Icons.broken_image_outlined, color: AppColors.accentDark),
+        child: Icon(LucideIcons.imageOff, color: AppColors.accentDark),
       ),
     );
   }

--- a/lib/camera_reference/photo_location_choice_sheet.dart
+++ b/lib/camera_reference/photo_location_choice_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../plan/pilgrimage_models.dart';
@@ -48,7 +49,7 @@ class PhotoLocationChoiceSheet extends StatelessWidget {
             const SizedBox(height: 16),
             _PhotoLocationChoiceTile(
               key: const ValueKey('photo-location-choice-recent'),
-              icon: Icons.history_toggle_off_outlined,
+              icon: LucideIcons.history,
               title: '使用最近一次定位',
               subtitle: '优先快速写入近期有效定位，没有时获取一次。',
               onTap: () => Navigator.of(
@@ -58,7 +59,7 @@ class PhotoLocationChoiceSheet extends StatelessWidget {
             const SizedBox(height: 10),
             _PhotoLocationChoiceTile(
               key: const ValueKey('photo-location-choice-confirm'),
-              icon: Icons.my_location_outlined,
+              icon: LucideIcons.locateFixed,
               title: '确认记录时获取定位',
               subtitle: '拍摄后在确认页面等待新定位，适合需要更准确位置时。',
               recommended: true,
@@ -70,7 +71,7 @@ class PhotoLocationChoiceSheet extends StatelessWidget {
             const SizedBox(height: 10),
             _PhotoLocationChoiceTile(
               key: const ValueKey('photo-location-choice-disabled'),
-              icon: Icons.location_off_outlined,
+              icon: LucideIcons.mapPinOff,
               title: '不记录定位',
               onTap: () =>
                   Navigator.of(context).pop(PhotoLocationStrategy.disabled),

--- a/lib/camera_reference/photo_location_status_panel.dart
+++ b/lib/camera_reference/photo_location_status_panel.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 
@@ -32,11 +33,7 @@ class PhotoLocationStatusPanel extends StatelessWidget {
               child: CircularProgressIndicator(strokeWidth: 2),
             )
           else
-            Icon(
-              Icons.location_on_outlined,
-              size: 18,
-              color: AppColors.textSecondary,
-            ),
+            Icon(LucideIcons.mapPin, size: 18, color: AppColors.textSecondary),
           const SizedBox(width: 10),
           Expanded(
             child: Text(

--- a/lib/camera_reference/visit_record_confirmation_screen.dart
+++ b/lib/camera_reference/visit_record_confirmation_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../data/anitabi_image_source_scope.dart';
@@ -233,7 +234,7 @@ class _VisitRecordConfirmationScreenState
           ScaffoldMessenger.of(context).showStatusSnack(
             kind: AppStatusBannerKind.running,
             title: '正在保存记录，请稍候。',
-            icon: Icons.save_outlined,
+            icon: LucideIcons.save,
           );
         }
       },
@@ -302,7 +303,7 @@ class _VisitRecordConfirmationScreenState
                       height: 18,
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
-                  : const Icon(Icons.save_outlined, size: 18),
+                  : const Icon(LucideIcons.save, size: 18),
               label: Text(_saving ? '保存中' : '保存记录'),
             ),
             const SizedBox(height: 8),
@@ -310,7 +311,7 @@ class _VisitRecordConfirmationScreenState
               onPressed: _saving || _locating
                   ? null
                   : () => _save(completePoint: true),
-              icon: const Icon(Icons.check_circle_outline, size: 18),
+              icon: const Icon(LucideIcons.circleCheckBig, size: 18),
               label: const Text('保存并标记完成'),
             ),
             const SizedBox(height: 8),
@@ -376,7 +377,7 @@ Future<void> _showGallerySaveSheet(
         children: [
           const SizedBox(height: 12),
           ListTile(
-            leading: const Icon(Icons.save_alt_outlined),
+            leading: const Icon(LucideIcons.download),
             title: const Text('保存到相册'),
             onTap: () => Navigator.of(context).pop('save'),
           ),
@@ -564,7 +565,7 @@ class _InfoPanel extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(Icons.layers_outlined, color: AppColors.textSecondary),
+          Icon(LucideIcons.layers, color: AppColors.textSecondary),
           const SizedBox(width: 8),
           Text(
             '参考模式',

--- a/lib/color_grading/color_grading_parameter_summary.dart
+++ b/lib/color_grading/color_grading_parameter_summary.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import 'color_grading_params.dart';
@@ -35,7 +36,7 @@ class ColorGradingParameterSummary extends StatelessWidget {
               OutlinedButton.icon(
                 onPressed: () => _showParameterSheet(context),
                 style: AppButtonStyles.compactOutlinedButton(),
-                icon: const Icon(Icons.tune, size: 18),
+                icon: const Icon(LucideIcons.slidersHorizontal, size: 18),
                 label: const Text('查看'),
               ),
             ],

--- a/lib/color_grading/color_grading_screen.dart
+++ b/lib/color_grading/color_grading_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:http/http.dart' as http;
 
 import '../app_theme.dart';
@@ -307,7 +308,7 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
           IconButton(
             tooltip: '重置',
             onPressed: _confirmReset,
-            icon: const Icon(Icons.restart_alt),
+            icon: const Icon(LucideIcons.rotateCcw),
           ),
         ],
       ),
@@ -374,7 +375,7 @@ class _ColorGradingScreenState extends State<ColorGradingScreen> {
                     color: Colors.white,
                   ),
                 )
-              : const Icon(Icons.auto_fix_high_outlined, size: 18),
+              : const Icon(LucideIcons.wandSparkles, size: 18),
           label: Text(_matching ? '匹配中...' : '自动匹配色调'),
         ),
         if (_targetParams != null) ...[
@@ -511,7 +512,7 @@ class _OriginalHoldButton extends StatelessWidget {
       onPointerCancel: enabled ? (_) => onChanged(false) : null,
       child: OutlinedButton.icon(
         onPressed: enabled ? () {} : null,
-        icon: Icon(showOriginal ? Icons.visibility : Icons.visibility_outlined),
+        icon: Icon(showOriginal ? LucideIcons.eye : LucideIcons.eye),
         label: Text(showOriginal ? '正在显示原图' : '按住显示原图'),
       ),
     );
@@ -607,7 +608,7 @@ class _ScorePanel extends StatelessWidget {
       child: beforeScore == null || afterScore == null
           ? Row(
               children: [
-                Icon(Icons.auto_fix_high_outlined, color: AppColors.accent),
+                Icon(LucideIcons.wandSparkles, color: AppColors.accent),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
@@ -638,13 +639,13 @@ class _ScorePanel extends StatelessWidget {
                   children: [
                     _ScoreValue(label: '原图', score: beforeScore!),
                     Icon(
-                      Icons.arrow_forward,
+                      LucideIcons.arrowRight,
                       size: 18,
                       color: AppColors.textSecondary,
                     ),
                     _ScoreValue(label: '当前', score: currentToneScore ?? 0),
                     Icon(
-                      Icons.arrow_forward,
+                      LucideIcons.arrowRight,
                       size: 18,
                       color: AppColors.textSecondary,
                     ),
@@ -793,7 +794,7 @@ class _SavePanel extends StatelessWidget {
                       color: Colors.white,
                     ),
                   )
-                : const Icon(Icons.save_outlined, size: 18),
+                : const Icon(LucideIcons.save, size: 18),
             label: Text(saving ? '保存中...' : '保存调色结果'),
           ),
         ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
@@ -171,7 +172,7 @@ class _DesktopStartupError extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Icon(
-                Icons.error_outline,
+                LucideIcons.circleAlert,
                 size: 52,
                 color: Theme.of(context).colorScheme.error,
               ),
@@ -189,7 +190,7 @@ class _DesktopStartupError extends StatelessWidget {
               FilledButton.icon(
                 key: const ValueKey('desktop-startup-retry'),
                 onPressed: onRetry,
-                icon: const Icon(Icons.refresh),
+                icon: const Icon(LucideIcons.refreshCw),
                 label: const Text('重试'),
               ),
               if (launcherInfo != null) ...[
@@ -201,12 +202,12 @@ class _DesktopStartupError extends StatelessWidget {
                   children: [
                     OutlinedButton.icon(
                       onPressed: () => _openDirectory(context, 'logs'),
-                      icon: const Icon(Icons.description_outlined),
+                      icon: const Icon(LucideIcons.fileText),
                       label: const Text('打开日志目录'),
                     ),
                     OutlinedButton.icon(
                       onPressed: () => _openDirectory(context, 'data'),
-                      icon: const Icon(Icons.folder_open_outlined),
+                      icon: const Icon(LucideIcons.folderOpen),
                       label: const Text('打开数据目录'),
                     ),
                   ],

--- a/lib/map/in_app_navigation_screen.dart
+++ b/lib/map/in_app_navigation_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:geolocator/geolocator.dart';
@@ -618,7 +619,7 @@ List<_PreviewStep> _stepsFor(NavigationRoute route) {
   if (route.maneuvers.isEmpty) {
     return const [
       _PreviewStep(
-        icon: Icons.straight_rounded,
+        icon: LucideIcons.arrowUp,
         distanceLabel: '路线中',
         instruction: '沿路线继续前行',
       ),
@@ -635,11 +636,11 @@ List<_PreviewStep> _stepsFor(NavigationRoute route) {
 }
 
 IconData _maneuverIcon(int type) => switch (type) {
-  3 => Icons.flag_rounded,
-  5 || 6 || 9 || 16 || 17 => Icons.turn_right_rounded,
-  7 || 8 || 11 || 18 || 19 => Icons.turn_left_rounded,
-  12 || 13 => Icons.u_turn_left_rounded,
-  _ => Icons.straight_rounded,
+  3 => LucideIcons.flag,
+  5 || 6 || 9 || 16 || 17 => LucideIcons.cornerUpRight,
+  7 || 8 || 11 || 18 || 19 => LucideIcons.cornerUpLeft,
+  12 || 13 => LucideIcons.undo2,
+  _ => LucideIcons.arrowUp,
 };
 
 String _distanceLabel(double kilometers) {
@@ -879,7 +880,7 @@ class _BottomPanel extends StatelessWidget {
                     const SizedBox(height: 16),
                     _InfoRow(
                       chrome: chrome,
-                      icon: Icons.location_on,
+                      icon: LucideIcons.mapPin,
                       iconColor: Colors.white,
                       iconBackground: _endRouteRed,
                       title: point.name,
@@ -889,7 +890,7 @@ class _BottomPanel extends StatelessWidget {
                     _InfoRow(
                       key: const ValueKey('in-app-navigation-all-stops'),
                       chrome: chrome,
-                      icon: Icons.list,
+                      icon: LucideIcons.list,
                       iconColor: chrome.primaryText,
                       iconBackground: chrome.detailsIconBackground,
                       title: '全部点位',
@@ -983,8 +984,8 @@ class _SheetHeader extends StatelessWidget {
                     height: 40,
                     child: Icon(
                       expanded
-                          ? Icons.keyboard_arrow_down_rounded
-                          : Icons.keyboard_arrow_up_rounded,
+                          ? LucideIcons.chevronDown
+                          : LucideIcons.chevronUp,
                       color: chrome.primaryText,
                     ),
                   ),
@@ -1207,7 +1208,7 @@ class _InfoRow extends StatelessWidget {
                 ),
               ),
               if (onTap != null)
-                Icon(Icons.chevron_right_rounded, color: chrome.secondaryText),
+                Icon(LucideIcons.chevronRight, color: chrome.secondaryText),
             ],
           ),
         ),
@@ -1238,7 +1239,11 @@ class _RecenterButton extends StatelessWidget {
           child: SizedBox(
             width: 44,
             height: 44,
-            child: Icon(Icons.navigation, color: AppColors.accent, size: 22),
+            child: Icon(
+              LucideIcons.navigation,
+              color: AppColors.accent,
+              size: 22,
+            ),
           ),
         ),
       ),
@@ -1353,7 +1358,7 @@ class _DestinationPin extends StatelessWidget {
             ),
           ],
         ),
-        child: const Icon(Icons.location_on, color: Colors.white, size: 18),
+        child: const Icon(LucideIcons.mapPin, color: Colors.white, size: 18),
       ),
     );
   }
@@ -1412,7 +1417,7 @@ class _ArrivalSheet extends StatelessWidget {
             const SizedBox(height: 12),
             _InfoRow(
               chrome: chrome,
-              icon: Icons.flag_rounded,
+              icon: LucideIcons.flag,
               iconColor: Colors.white,
               iconBackground: isLast ? _endRouteRed : AppColors.accent,
               title: arrived.name,
@@ -1422,7 +1427,7 @@ class _ArrivalSheet extends StatelessWidget {
             _InfoRow(
               key: const ValueKey('in-app-navigation-open-camera'),
               chrome: chrome,
-              icon: Icons.photo_camera_outlined,
+              icon: LucideIcons.camera,
               iconColor: chrome.primaryText,
               iconBackground: chrome.detailsIconBackground,
               title: '打开相机',
@@ -1433,7 +1438,7 @@ class _ArrivalSheet extends StatelessWidget {
               const SizedBox(height: 10),
               _InfoRow(
                 chrome: chrome,
-                icon: Icons.arrow_forward_rounded,
+                icon: LucideIcons.arrowRight,
                 iconColor: chrome.primaryText,
                 iconBackground: chrome.detailsIconBackground,
                 title: nextStop!.name,

--- a/lib/map/map_marker_clustering.dart
+++ b/lib/map/map_marker_clustering.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -200,7 +201,7 @@ class MapOverlapPointPager extends StatelessWidget {
           tooltip: '上一个重合点位',
           visualDensity: VisualDensity.compact,
           onPressed: onPrevious,
-          icon: const Icon(Icons.chevron_left),
+          icon: const Icon(LucideIcons.chevronLeft),
         ),
         Expanded(
           child: Text(
@@ -220,7 +221,7 @@ class MapOverlapPointPager extends StatelessWidget {
           tooltip: '下一个重合点位',
           visualDensity: VisualDensity.compact,
           onPressed: onNext,
-          icon: const Icon(Icons.chevron_right),
+          icon: const Icon(LucideIcons.chevronRight),
         ),
       ],
     );

--- a/lib/map/navigation_route_confirm_screen.dart
+++ b/lib/map/navigation_route_confirm_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -7,6 +8,7 @@ import '../plan/pilgrimage_models.dart';
 import '../plan/pilgrimage_plan_controller.dart';
 import '../plan/plan_group_utils.dart';
 import '../widgets/app_back_button.dart';
+import '../widgets/responsive_button.dart';
 import 'current_location_resolver.dart';
 import 'in_app_navigation_screen.dart';
 import 'map_navigation_launcher.dart';
@@ -272,24 +274,27 @@ class _NavigationRouteConfirmScreenState
                         ),
                       ),
                       const SizedBox(height: 10),
-                      Row(
-                        children: [
-                          Expanded(
-                            child: OutlinedButton.icon(
-                              onPressed: () => _loadRoute(remainingStops),
-                              icon: const Icon(Icons.refresh),
-                              label: const Text('重试'),
-                            ),
+                      ResponsiveTwoButtonRow(
+                        spacing: 10,
+                        stackBelowWidth: 220,
+                        first: OutlinedButton(
+                          onPressed: () => _loadRoute(remainingStops),
+                          child: const ResponsiveButtonContent(
+                            icon: LucideIcons.refreshCw,
+                            label: '重试',
+                            semanticLabel: '重新规划路线',
                           ),
-                          const SizedBox(width: 10),
-                          Expanded(
-                            child: OutlinedButton.icon(
-                              onPressed: _openExternalNavigation,
-                              icon: const Icon(Icons.open_in_new),
-                              label: Text(widget.settings.navigationApp.label),
-                            ),
+                        ),
+                        second: OutlinedButton(
+                          onPressed: _openExternalNavigation,
+                          child: ResponsiveButtonContent(
+                            icon: LucideIcons.externalLink,
+                            label: widget.settings.navigationApp.label,
+                            shortLabel: '外部导航',
+                            semanticLabel:
+                                '使用 ${widget.settings.navigationApp.label} 导航',
                           ),
-                        ],
+                        ),
                       ),
                     ] else if (canChainZone) ...[
                       _PrimaryZoneButton(
@@ -392,7 +397,7 @@ class _PrimaryZoneButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FilledButton.icon(
+    return FilledButton(
       key: ValueKey(
         singlePoint
             ? 'navigation-route-confirm-point'
@@ -403,11 +408,13 @@ class _PrimaryZoneButton extends StatelessWidget {
         minimumSize: const Size.fromHeight(46),
         padding: const EdgeInsets.symmetric(horizontal: 16),
       ),
-      icon: Icon(
-        singlePoint ? Icons.near_me_outlined : Icons.route_rounded,
-        size: 20,
+      child: ResponsiveButtonContent(
+        icon: singlePoint ? LucideIcons.navigation : LucideIcons.route,
+        iconSize: 20,
+        label: singlePoint ? '开始导航' : '串联整个片区导航',
+        shortLabel: '开始导航',
+        semanticLabel: singlePoint ? '开始导航' : '串联整个片区导航',
       ),
-      label: Text(singlePoint ? '开始导航' : '串联整个片区导航'),
     );
   }
 }
@@ -419,15 +426,20 @@ class _SecondaryPointButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return OutlinedButton.icon(
+    return OutlinedButton(
       key: const ValueKey('navigation-route-confirm-point'),
       onPressed: onTap,
       style: OutlinedButton.styleFrom(
         minimumSize: const Size.fromHeight(46),
         padding: const EdgeInsets.symmetric(horizontal: 16),
       ),
-      icon: const Icon(Icons.location_on_outlined, size: 20),
-      label: const Text('仅导航到选中点'),
+      child: const ResponsiveButtonContent(
+        icon: LucideIcons.mapPin,
+        iconSize: 20,
+        label: '仅导航到选中点',
+        shortLabel: '仅导航到点位',
+        semanticLabel: '仅导航到选中点',
+      ),
     );
   }
 }
@@ -595,7 +607,7 @@ class _DestinationPin extends StatelessWidget {
           shape: BoxShape.circle,
           border: Border.all(color: Colors.white, width: 2.5),
         ),
-        child: const Icon(Icons.location_on, color: Colors.white, size: 16),
+        child: const Icon(LucideIcons.mapPin, color: Colors.white, size: 16),
       ),
     );
   }

--- a/lib/map/pilgrimage_map_screen.dart
+++ b/lib/map/pilgrimage_map_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import 'map_marker_scale.dart';
@@ -393,6 +394,7 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
       onOpenRecords: () => _openPointRecords(point),
       onOpenRecord: _openRecordDetail,
       onEditPoint: () => _editPoint(point),
+      onDelete: _controller.deletePoint,
       navigationApp: widget.settings.navigationApp,
       settings: widget.settings,
       planController: _controller,
@@ -773,13 +775,13 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
                             height: 20,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : const Icon(Icons.my_location, size: 20),
+                        : const Icon(LucideIcons.locateFixed, size: 20),
                   ),
                   const SizedBox(height: 8),
                   _MapFloatingIconButton(
                     tooltip: '当前目标',
                     onTap: _moveToCurrentTarget,
-                    child: const Icon(Icons.flag_outlined, size: 20),
+                    child: const Icon(LucideIcons.flag, size: 20),
                   ),
                   const SizedBox(height: 8),
                   _MapFloatingIconButton(
@@ -803,8 +805,8 @@ class _PilgrimageMapScreenState extends State<PilgrimageMapScreen> {
                     },
                     child: Icon(
                       _showThumbnailMarkers
-                          ? Icons.location_on_outlined
-                          : Icons.image_outlined,
+                          ? LucideIcons.mapPin
+                          : LucideIcons.image,
                       size: 20,
                     ),
                   ),
@@ -902,7 +904,7 @@ class _MapGroupFilterBar extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
           child: Row(
             children: [
-              const Icon(Icons.folder_outlined, size: 18),
+              const Icon(LucideIcons.folder, size: 18),
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
@@ -915,7 +917,7 @@ class _MapGroupFilterBar extends StatelessWidget {
                   ),
                 ),
               ),
-              const Icon(Icons.expand_more, size: 18),
+              const Icon(LucideIcons.chevronDown, size: 18),
             ],
           ),
         ),
@@ -995,7 +997,9 @@ class _PointMarker extends StatelessWidget {
         ),
       ),
       icon: Icon(
-        status == VisitStatus.completed ? Icons.check : Icons.place,
+        status == VisitStatus.completed
+            ? LucideIcons.check
+            : LucideIcons.mapPin,
         size: 24,
       ),
     );
@@ -1020,6 +1024,9 @@ class _CurrentLocationMarker extends StatelessWidget {
     );
   }
 }
+
+const _mapPointActionExtent = 44.0;
+const _mapPointPrimaryActionWidth = 52.0;
 
 class _PointCard extends StatelessWidget {
   const _PointCard({
@@ -1146,62 +1153,63 @@ class _PointCard extends StatelessWidget {
           Row(
             children: [
               Expanded(
-                child: FilledButton.icon(
-                  key: const ValueKey('map-in-app-navigation-button'),
-                  onPressed: onOpenInAppNavigation,
-                  icon: const Icon(Icons.near_me_outlined, size: 18),
-                  label: Text(point.hasCoordinate ? '导航' : '坐标待补充'),
+                child: _SplitNavigationButton(
+                  inAppLabel: point.hasCoordinate ? '导航' : '坐标待补充',
+                  onOpenInAppNavigation: onOpenInAppNavigation,
+                  onOpenExternalNavigation: onOpenExternalNavigation,
                 ),
               ),
-              const SizedBox(width: 8),
-              IconButton.outlined(
-                key: const ValueKey('map-external-navigation-button'),
-                tooltip: '打开外部地图',
-                onPressed: onOpenExternalNavigation,
-                icon: const Icon(Icons.near_me_outlined),
-              ),
               const SizedBox(width: 4),
-              IconButton.outlined(
-                tooltip: '拍摄参考',
-                onPressed: onOpenCamera,
-                icon: SizedBox(
-                  width: 24,
-                  height: 24,
-                  child: Stack(
-                    clipBehavior: Clip.none,
-                    children: [
-                      const Center(child: Icon(Icons.photo_camera_outlined)),
-                      if (recordCount > 0)
-                        const Positioned(
-                          top: -5,
-                          right: -5,
-                          child: _MapRecordBadge(),
-                        ),
-                    ],
+              SizedBox(
+                width: _mapPointPrimaryActionWidth,
+                height: _mapPointActionExtent,
+                child: IconButton.outlined(
+                  tooltip: '拍摄参考',
+                  onPressed: onOpenCamera,
+                  icon: SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        const Center(child: Icon(LucideIcons.camera)),
+                        if (recordCount > 0)
+                          const Positioned(
+                            top: -5,
+                            right: -5,
+                            child: _MapRecordBadge(),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
               ),
               const SizedBox(width: 4),
-              if (status == VisitStatus.completed)
-                IconButton.outlined(
-                  tooltip: '撤回打卡',
+              SizedBox(
+                width: _mapPointPrimaryActionWidth,
+                height: _mapPointActionExtent,
+                child: IconButton.outlined(
+                  tooltip: status == VisitStatus.completed ? '撤回打卡' : '标记完成',
                   onPressed: onComplete,
-                  icon: const Icon(Icons.replay_outlined),
-                )
-              else
-                IconButton.outlined(
-                  tooltip: '标记完成',
-                  onPressed: onComplete,
-                  icon: const Icon(Icons.check_circle_outline),
+                  icon: Icon(
+                    status == VisitStatus.completed
+                        ? LucideIcons.undo2
+                        : LucideIcons.circleCheckBig,
+                  ),
                 ),
+              ),
               if (point.hasCoordinate &&
                   status != VisitStatus.current &&
                   status != VisitStatus.completed) ...[
                 const SizedBox(width: 4),
-                IconButton.outlined(
-                  tooltip: '设为当前目标',
-                  onPressed: onSetCurrent,
-                  icon: const Icon(Icons.flag_outlined),
+                SizedBox(
+                  width: _mapPointActionExtent,
+                  height: _mapPointActionExtent,
+                  child: IconButton.outlined(
+                    tooltip: '设为当前目标',
+                    onPressed: onSetCurrent,
+                    icon: const Icon(LucideIcons.flag),
+                  ),
                 ),
               ],
             ],
@@ -1229,6 +1237,85 @@ class _PointCard extends StatelessWidget {
           ? '${point.position.latitude.toStringAsFixed(5)},${point.position.longitude.toStringAsFixed(5)}'
           : '坐标待补充',
     ].where((value) => value.trim().isNotEmpty).join('\n');
+  }
+}
+
+class _SplitNavigationButton extends StatelessWidget {
+  const _SplitNavigationButton({
+    required this.inAppLabel,
+    required this.onOpenInAppNavigation,
+    required this.onOpenExternalNavigation,
+  });
+
+  final String inAppLabel;
+  final VoidCallback? onOpenInAppNavigation;
+  final VoidCallback? onOpenExternalNavigation;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final enabled =
+        onOpenInAppNavigation != null || onOpenExternalNavigation != null;
+    final foregroundColor = enabled
+        ? colorScheme.onPrimary
+        : colorScheme.onSurface.withValues(alpha: 0.38);
+    final backgroundColor = enabled
+        ? colorScheme.primary
+        : colorScheme.onSurface.withValues(alpha: 0.12);
+
+    return Material(
+      color: backgroundColor,
+      borderRadius: BorderRadius.circular(8),
+      clipBehavior: Clip.antiAlias,
+      child: SizedBox(
+        height: _mapPointActionExtent,
+        child: Row(
+          children: [
+            Expanded(
+              child: InkWell(
+                key: const ValueKey('map-in-app-navigation-button'),
+                onTap: onOpenInAppNavigation,
+                child: Center(
+                  child: IconTheme(
+                    data: IconThemeData(color: foregroundColor),
+                    child: Tooltip(
+                      message: '应用内导航：$inAppLabel',
+                      child: Semantics(
+                        label: '应用内导航：$inAppLabel',
+                        child: const Icon(Icons.directions_walk, size: 20),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Container(
+              key: const ValueKey('map-navigation-button-divider'),
+              width: 1,
+              height: 28,
+              color: foregroundColor.withValues(alpha: 0.38),
+            ),
+            Expanded(
+              child: Tooltip(
+                message: '打开外部地图',
+                child: InkWell(
+                  key: const ValueKey('map-external-navigation-button'),
+                  onTap: onOpenExternalNavigation,
+                  child: SizedBox(
+                    height: _mapPointActionExtent,
+                    child: Icon(
+                      LucideIcons.navigation,
+                      size: 21,
+                      color: foregroundColor,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 
@@ -1261,7 +1348,7 @@ class _PointThumbnail extends StatelessWidget {
                   localPath: point.referenceThumbnailPath,
                   imageUrl: remoteImageUrl,
                   placeholder: Icon(
-                    Icons.image_outlined,
+                    LucideIcons.image,
                     color: AppColors.accentDark,
                   ),
                 )
@@ -1271,7 +1358,7 @@ class _PointThumbnail extends StatelessWidget {
                   repository: repository,
                   onPlanUpdated: controller.replacePlan,
                   placeholder: Icon(
-                    Icons.image_outlined,
+                    LucideIcons.image,
                     color: AppColors.accentDark,
                   ),
                 ),
@@ -1303,11 +1390,7 @@ class _MapRecordBadge extends StatelessWidget {
           ),
         ],
       ),
-      child: Icon(
-        Icons.photo_library_outlined,
-        size: 10,
-        color: AppColors.accentDark,
-      ),
+      child: Icon(LucideIcons.images, size: 10, color: AppColors.accentDark),
     );
   }
 }
@@ -1331,7 +1414,7 @@ class _EmptyMapCard extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.map_outlined, color: AppColors.accent),
+          Icon(LucideIcons.map, color: AppColors.accent),
           const SizedBox(width: 10),
           Expanded(
             child: Column(

--- a/lib/plan/add_points_screen.dart
+++ b/lib/plan/add_points_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
@@ -20,6 +21,7 @@ import '../widgets/reference_thumbnail_stub.dart'
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/app_scaled_route.dart';
 import '../widgets/app_back_button.dart';
+import '../widgets/responsive_button.dart';
 import 'anitabi_map_import_screen.dart';
 import 'coordinate_parser.dart';
 import 'pilgrimage_work_dropdown.dart';
@@ -623,7 +625,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
                                     width: 40,
                                     height: 46,
                                   ),
-                                  icon: const Icon(Icons.clear, size: 19),
+                                  icon: const Icon(LucideIcons.x, size: 19),
                                 ),
                           suffixIconConstraints: const BoxConstraints.tightFor(
                             width: 40,
@@ -649,7 +651,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
                             height: 18,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : const Icon(Icons.search, size: 18),
+                        : const Icon(LucideIcons.search, size: 18),
                     label: Text(_isSearching ? '搜索中' : '搜索作品'),
                   ),
                 ),
@@ -682,7 +684,7 @@ class BangumiWorkSearchScreenState extends State<BangumiWorkSearchScreen> {
             const SizedBox(height: 12),
             if (_error != null)
               const _MessageCard(
-                icon: Icons.error_outline,
+                icon: LucideIcons.circleAlert,
                 text: 'Bangumi 搜索失败，请检查网络后重试。',
               )
             else if (_results.isNotEmpty)
@@ -875,7 +877,7 @@ class _BangumiTypeFilterDisclosure extends StatelessWidget {
                         turns: expanded ? 0.5 : 0,
                         duration: const Duration(milliseconds: 160),
                         child: Icon(
-                          Icons.keyboard_arrow_down_rounded,
+                          LucideIcons.chevronDown,
                           size: 20,
                           color: AppColors.textSecondary,
                         ),
@@ -1084,8 +1086,8 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
                         ),
                         icon: Icon(
                           hasLinkText
-                              ? Icons.clear
-                              : Icons.content_paste_outlined,
+                              ? LucideIcons.x
+                              : LucideIcons.clipboardPaste,
                           size: 20,
                         ),
                       ),
@@ -1135,10 +1137,7 @@ class _AnitabiLinkImportScreenState extends State<_AnitabiLinkImportScreen> {
                         padding: const EdgeInsets.symmetric(horizontal: 18),
                         alignment: Alignment.center,
                       ),
-                      icon: const Icon(
-                        Icons.add_location_alt_outlined,
-                        size: 21,
-                      ),
+                      icon: const Icon(LucideIcons.mapPinPlus, size: 21),
                       label: const Text(
                         '打开 Anitabi 点位',
                         style: TextStyle(
@@ -1526,7 +1525,7 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
             onPressed: () => Navigator.of(context).pop(_didAdd),
           ),
           actions: [
-            TextButton.icon(
+            TextButton(
               key: const ValueKey('manual-work-filling-guide'),
               onPressed: _showFillingGuide,
               style: TextButton.styleFrom(
@@ -1534,14 +1533,11 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
                 minimumSize: const Size(0, 40),
                 padding: const EdgeInsets.symmetric(horizontal: 10),
               ),
-              icon: const Icon(Icons.menu_book_outlined, size: 17),
-              label: const Text(
-                '填写指南',
-                style: TextStyle(
-                  fontSize: 12.5,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 0,
-                ),
+              child: const ResponsiveButtonContent(
+                icon: LucideIcons.bookOpen,
+                iconSize: 17,
+                label: '填写指南',
+                semanticLabel: '填写指南',
               ),
             ),
             const SizedBox(width: 4),
@@ -1605,10 +1601,7 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
                         ),
                         icon: const Padding(
                           padding: EdgeInsets.only(right: 8),
-                          child: Icon(
-                            Icons.keyboard_arrow_down_rounded,
-                            size: 20,
-                          ),
+                          child: Icon(LucideIcons.chevronDown, size: 20),
                         ),
                         selectedItemBuilder: (context) => [
                           for (final type in _manualWorkSubjectTypes)
@@ -1673,7 +1666,7 @@ class ManualWorkFormScreenState extends State<ManualWorkFormScreen> {
                         height: 18,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Icon(Icons.check_outlined, size: 18),
+                    : const Icon(LucideIcons.check, size: 18),
                 label: Text(_isSaving ? '保存中' : '保存作品'),
               ),
             ],
@@ -1712,7 +1705,7 @@ class _ManualPointFillingGuideSheet extends StatelessWidget {
             Row(
               children: [
                 Icon(
-                  Icons.add_location_alt_outlined,
+                  LucideIcons.mapPinPlus,
                   color: AppColors.accentDark,
                   size: 24,
                 ),
@@ -1731,7 +1724,7 @@ class _ManualPointFillingGuideSheet extends StatelessWidget {
                 IconButton(
                   tooltip: '关闭',
                   onPressed: () => Navigator.of(context).pop(),
-                  icon: const Icon(Icons.close, size: 20),
+                  icon: const Icon(LucideIcons.x, size: 20),
                 ),
               ],
             ),
@@ -1797,7 +1790,7 @@ class _ManualPointFillingGuideSheet extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Icon(
-                    Icons.location_searching_outlined,
+                    LucideIcons.locateFixed,
                     size: 19,
                     color: AppColors.accentDark,
                   ),
@@ -1851,7 +1844,7 @@ class _ManualWorkFillingGuideSheet extends StatelessWidget {
             Row(
               children: [
                 Icon(
-                  Icons.menu_book_outlined,
+                  LucideIcons.bookOpen,
                   color: AppColors.accentDark,
                   size: 24,
                 ),
@@ -1870,7 +1863,7 @@ class _ManualWorkFillingGuideSheet extends StatelessWidget {
                 IconButton(
                   tooltip: '关闭',
                   onPressed: () => Navigator.of(context).pop(),
-                  icon: const Icon(Icons.close, size: 20),
+                  icon: const Icon(LucideIcons.x, size: 20),
                 ),
               ],
             ),
@@ -1929,7 +1922,7 @@ class _ManualWorkFillingGuideSheet extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Icon(
-                    Icons.lightbulb_outline,
+                    LucideIcons.lightbulb,
                     size: 19,
                     color: AppColors.accentDark,
                   ),
@@ -2136,7 +2129,7 @@ class _ManualWorkTypeDropdownItemState
           children: [
             Expanded(child: Text(widget.type.label)),
             if (widget.selected)
-              Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+              Icon(LucideIcons.checkCircle, color: AppColors.accent, size: 18),
           ],
         ),
       ),
@@ -2380,7 +2373,7 @@ class _QuickManualPointFormScreenState
         leading: appBackButtonIfCanPop(context),
         title: const Text('快速手动添加点位'),
         actions: [
-          TextButton.icon(
+          TextButton(
             key: const ValueKey('quick-point-filling-guide'),
             onPressed: _showFillingGuide,
             style: TextButton.styleFrom(
@@ -2388,14 +2381,11 @@ class _QuickManualPointFormScreenState
               minimumSize: const Size(0, 40),
               padding: const EdgeInsets.symmetric(horizontal: 10),
             ),
-            icon: const Icon(Icons.menu_book_outlined, size: 17),
-            label: const Text(
-              '填写指南',
-              style: TextStyle(
-                fontSize: 12.5,
-                fontWeight: FontWeight.w800,
-                letterSpacing: 0,
-              ),
+            child: const ResponsiveButtonContent(
+              icon: LucideIcons.bookOpen,
+              iconSize: 17,
+              label: '填写指南',
+              semanticLabel: '填写指南',
             ),
           ),
           const SizedBox(width: 4),
@@ -2538,11 +2528,11 @@ class _QuickManualPointFormScreenState
                 Row(
                   children: [
                     Expanded(
-                      child: OutlinedButton.icon(
+                      child: OutlinedButton(
                         key: const ValueKey('quick-point-map-picker'),
                         onPressed: _pickCoordinateFromMap,
                         style: OutlinedButton.styleFrom(
-                          fixedSize: const Size.fromHeight(40),
+                          fixedSize: const Size.fromHeight(44),
                           padding: const EdgeInsets.symmetric(horizontal: 14),
                           foregroundColor: AppColors.accent,
                           backgroundColor: AppColors.accent.withValues(
@@ -2555,21 +2545,19 @@ class _QuickManualPointFormScreenState
                             borderRadius: BorderRadius.circular(8),
                           ),
                         ),
-                        icon: const Icon(Icons.location_on, size: 19),
-                        label: const Text(
-                          '从地图选择',
-                          style: TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w800,
-                            letterSpacing: 0,
-                          ),
+                        child: const ResponsiveButtonContent(
+                          icon: LucideIcons.mapPin,
+                          iconSize: 19,
+                          label: '从地图选择',
+                          shortLabel: '地图选择',
+                          semanticLabel: '从地图选择坐标',
                         ),
                       ),
                     ),
                     const SizedBox(width: 10),
                     SizedBox(
                       width: 44,
-                      height: 40,
+                      height: 44,
                       child: IconButton.outlined(
                         key: const ValueKey('quick-point-paste-coordinate'),
                         tooltip: '粘贴剪贴板坐标',
@@ -2581,7 +2569,7 @@ class _QuickManualPointFormScreenState
                             borderRadius: BorderRadius.circular(8),
                           ),
                         ),
-                        icon: const Icon(Icons.content_paste_outlined),
+                        icon: const Icon(LucideIcons.clipboardPaste),
                       ),
                     ),
                   ],
@@ -2592,7 +2580,7 @@ class _QuickManualPointFormScreenState
             FilledButton.icon(
               key: const ValueKey('quick-point-submit'),
               onPressed: _submit,
-              icon: const Icon(Icons.check_outlined, size: 18),
+              icon: const Icon(LucideIcons.check, size: 18),
               label: const Text('保存点位'),
             ),
           ],
@@ -2625,7 +2613,7 @@ class _QuickManualPointFillingGuideSheet extends StatelessWidget {
             Row(
               children: [
                 Icon(
-                  Icons.add_location_alt_outlined,
+                  LucideIcons.mapPinPlus,
                   color: AppColors.accentDark,
                   size: 24,
                 ),
@@ -2644,7 +2632,7 @@ class _QuickManualPointFillingGuideSheet extends StatelessWidget {
                 IconButton(
                   tooltip: '关闭',
                   onPressed: () => Navigator.of(context).pop(),
-                  icon: const Icon(Icons.close, size: 20),
+                  icon: const Icon(LucideIcons.x, size: 20),
                 ),
               ],
             ),
@@ -3077,7 +3065,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
             },
           ),
           actions: [
-            TextButton.icon(
+            TextButton(
               key: const ValueKey('manual-point-filling-guide'),
               onPressed: _showPointFillingGuide,
               style: TextButton.styleFrom(
@@ -3085,14 +3073,11 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                 minimumSize: const Size(0, 40),
                 padding: const EdgeInsets.symmetric(horizontal: 10),
               ),
-              icon: const Icon(Icons.menu_book_outlined, size: 17),
-              label: const Text(
-                '填写指南',
-                style: TextStyle(
-                  fontSize: 12.5,
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: 0,
-                ),
+              child: const ResponsiveButtonContent(
+                icon: LucideIcons.bookOpen,
+                iconSize: 17,
+                label: '填写指南',
+                semanticLabel: '填写指南',
               ),
             ),
             const SizedBox(width: 4),
@@ -3339,11 +3324,11 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                   Row(
                     children: [
                       Expanded(
-                        child: OutlinedButton.icon(
+                        child: OutlinedButton(
                           key: const ValueKey('point-form-map-picker'),
                           onPressed: _isSaving ? null : _pickCoordinateFromMap,
                           style: OutlinedButton.styleFrom(
-                            fixedSize: const Size.fromHeight(40),
+                            fixedSize: const Size.fromHeight(44),
                             padding: const EdgeInsets.symmetric(horizontal: 14),
                             foregroundColor: AppColors.accent,
                             backgroundColor: AppColors.accent.withValues(
@@ -3356,21 +3341,19 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                               borderRadius: BorderRadius.circular(8),
                             ),
                           ),
-                          icon: const Icon(Icons.location_on, size: 19),
-                          label: const Text(
-                            '从地图选择',
-                            style: TextStyle(
-                              fontSize: 15,
-                              fontWeight: FontWeight.w800,
-                              letterSpacing: 0,
-                            ),
+                          child: const ResponsiveButtonContent(
+                            icon: LucideIcons.mapPin,
+                            iconSize: 19,
+                            label: '从地图选择',
+                            shortLabel: '地图选择',
+                            semanticLabel: '从地图选择坐标',
                           ),
                         ),
                       ),
                       const SizedBox(width: 10),
                       SizedBox(
                         width: 44,
-                        height: 40,
+                        height: 44,
                         child: IconButton.outlined(
                           key: const ValueKey('point-form-paste-coordinate'),
                           tooltip: '粘贴剪贴板坐标',
@@ -3384,7 +3367,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                               borderRadius: BorderRadius.circular(8),
                             ),
                           ),
-                          icon: const Icon(Icons.content_paste_outlined),
+                          icon: const Icon(LucideIcons.clipboardPaste),
                         ),
                       ),
                     ],
@@ -3423,7 +3406,7 @@ class _ManualPointFormScreenState extends State<_ManualPointFormScreen> {
                         height: 18,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Icon(Icons.check_outlined, size: 18),
+                    : const Icon(LucideIcons.check, size: 18),
                 label: Text(_isSaving ? '保存中' : (_isEditing ? '保存修改' : '保存点位')),
               ),
             ],
@@ -3669,7 +3652,7 @@ class _ManualPointMapPickerScreenState
               bottom: false,
               child: _MapToolButton(
                 tooltip: _isPickMode ? '关闭地图选点' : '在地图上选点',
-                icon: Icons.ads_click_outlined,
+                icon: LucideIcons.mousePointerClick,
                 selected: _isPickMode,
                 onTap: () {
                   setState(() {
@@ -3706,7 +3689,7 @@ class _ManualPointPositionMarker extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: Colors.white, width: 3),
       ),
-      child: const Icon(Icons.add_location_alt, color: Colors.white),
+      child: const Icon(LucideIcons.mapPinPlus, color: Colors.white),
     );
   }
 }
@@ -3768,7 +3751,7 @@ class _ManualPointSelectionCard extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(Icons.add_location_alt_outlined, color: AppColors.accent),
+          Icon(LucideIcons.mapPinPlus, color: AppColors.accent),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -3893,7 +3876,7 @@ class _LinkedWorksPanel extends StatelessWidget {
                             ),
                             SizedBox(width: 2),
                             Icon(
-                              Icons.chevron_right_rounded,
+                              LucideIcons.chevronRight,
                               color: AppColors.accent,
                               size: 20,
                             ),
@@ -3957,7 +3940,7 @@ class _LinkedWorksPanel extends StatelessWidget {
                   Expanded(
                     child: _WorkCreationAction(
                       key: const ValueKey('add-points-bangumi-work'),
-                      icon: Icons.search_rounded,
+                      icon: LucideIcons.search,
                       title: '从Bangumi添加',
                       subtitle: '自动获取信息',
                       onTap: onBangumi,
@@ -3973,7 +3956,7 @@ class _LinkedWorksPanel extends StatelessWidget {
                   Expanded(
                     child: _WorkCreationAction(
                       key: const ValueKey('add-points-manual-work'),
-                      icon: Icons.add_rounded,
+                      icon: LucideIcons.plus,
                       title: '手动添加作品',
                       subtitle: '未收录时使用',
                       onTap: onManual,
@@ -4176,7 +4159,7 @@ class _ManualReferenceImagePicker extends StatelessWidget {
                       imageUrl: imageUrl,
                       fit: BoxFit.cover,
                       placeholder: Icon(
-                        Icons.image_outlined,
+                        LucideIcons.image,
                         color: AppColors.textSecondary,
                       ),
                     ),
@@ -4217,16 +4200,13 @@ class _ManualReferenceImagePicker extends StatelessWidget {
                     children: [
                       OutlinedButton.icon(
                         onPressed: onPick,
-                        icon: const Icon(
-                          Icons.photo_library_outlined,
-                          size: 18,
-                        ),
+                        icon: const Icon(LucideIcons.images, size: 18),
                         label: Text(hasImage ? '重新选择' : '上传参考图'),
                       ),
                       if (hasPendingSelection)
                         TextButton.icon(
                           onPressed: onRemove,
-                          icon: const Icon(Icons.close_outlined, size: 18),
+                          icon: const Icon(LucideIcons.x, size: 18),
                           label: const Text('移除'),
                         ),
                     ],
@@ -4456,11 +4436,7 @@ class _BangumiSearchHintContent extends StatelessWidget {
         Row(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Icon(
-              Icons.manage_search_rounded,
-              color: AppColors.accent,
-              size: 17,
-            ),
+            Icon(LucideIcons.search, color: AppColors.accent, size: 17),
             const SizedBox(width: 8),
             Text(
               '搜索说明',
@@ -4496,7 +4472,7 @@ class _BangumiSearchHintContent extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(top: 1),
                 child: Icon(
-                  Icons.info_outline_rounded,
+                  LucideIcons.info,
                   color: AppColors.accent,
                   size: 16,
                 ),
@@ -4579,7 +4555,7 @@ class _QuickImportPanel extends StatelessWidget {
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Icon(
-                            Icons.link_rounded,
+                            LucideIcons.link,
                             color: AppColors.accent,
                             size: 26,
                           ),
@@ -4637,7 +4613,7 @@ class _QuickImportPanel extends StatelessWidget {
                           ),
                         ),
                         Icon(
-                          Icons.chevron_right_rounded,
+                          LucideIcons.chevronRight,
                           color: enabled
                               ? AppColors.accent
                               : AppColors.textSecondary,
@@ -4711,7 +4687,7 @@ class _AddPointPanel extends StatelessWidget {
           ),
           _PointCreationAction(
             key: const ValueKey('add-points-anitabi-map'),
-            icon: Icons.map_outlined,
+            icon: LucideIcons.map,
             title: '从作品地图导入点位',
             subtitle: mapEnabled ? '在作品地图上选择并导入点位' : '请先通过 Bangumi 搜索添加作品',
             recommended: true,
@@ -4726,7 +4702,7 @@ class _AddPointPanel extends StatelessWidget {
           ),
           _PointCreationAction(
             key: const ValueKey('add-points-quick-manual-point'),
-            icon: Icons.add_location_alt_outlined,
+            icon: LucideIcons.mapPinPlus,
             title: '快速手动添加点位',
             subtitle: quickManualEnabled ? '只填写作品、名称和可选坐标' : '请先添加作品',
             enabled: quickManualEnabled,
@@ -4740,7 +4716,7 @@ class _AddPointPanel extends StatelessWidget {
           ),
           _PointCreationAction(
             key: const ValueKey('add-points-manual-point'),
-            icon: Icons.edit_location_alt_outlined,
+            icon: LucideIcons.mapPinPen,
             title: '手动添加点位',
             subtitle: '手动输入点位信息，逐个添加',
             enabled: manualEnabled,
@@ -4875,7 +4851,7 @@ class _PointCreationAction extends StatelessWidget {
                     ),
                   ),
                   Icon(
-                    Icons.chevron_right_rounded,
+                    LucideIcons.chevronRight,
                     color: enabled ? AppColors.accent : AppColors.textSecondary,
                     size: 22,
                   ),

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -27,6 +28,7 @@ import '../widgets/image_load_limiter.dart';
 import '../widgets/map_thumbnail_marker.dart';
 import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
+import '../widgets/responsive_button.dart';
 import '../widgets/app_scaled_route.dart';
 import '../widgets/app_back_button.dart';
 import '../utils/limited_concurrency.dart';
@@ -173,7 +175,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
     ScaffoldMessenger.of(context).showStatusSnack(
       kind: AppStatusBannerKind.running,
       title: '正在清除缓存并重新加载 Anitabi 点位...',
-      icon: Icons.cleaning_services_outlined,
+      icon: LucideIcons.brushCleaning,
     );
 
     final initialBangumiId = widget.initialBangumiId;
@@ -903,7 +905,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
       messenger.showStatusSnack(
         kind: AppStatusBannerKind.running,
         title: '正在导入 ${pilgrimagePoints.length} 个点位...',
-        icon: Icons.add_location_alt_outlined,
+        icon: LucideIcons.mapPinPlus,
       );
       var importedPlan = pilgrimagePoints.length == 1
           ? await widget.repository.addPointToPlan(
@@ -993,7 +995,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
             messenger.showStatusSnack(
               kind: AppStatusBannerKind.running,
               title: '正在缓存缩略图 $processed/${pilgrimagePoints.length}，成功 $cached',
-              icon: Icons.photo_library_outlined,
+              icon: LucideIcons.images,
               duration: const Duration(milliseconds: 1200),
             );
           }
@@ -1448,8 +1450,8 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                 onPressed: _toggleThumbnailMarkers,
                 icon: Icon(
                   _showThumbnailMarkers
-                      ? Icons.location_on_outlined
-                      : Icons.image_outlined,
+                      ? LucideIcons.mapPin
+                      : LucideIcons.image,
                 ),
               ),
             ),
@@ -1459,7 +1461,7 @@ class _AnitabiMapImportScreenState extends State<AnitabiMapImportScreen> {
                 onPressed: _isLoading || _isImporting
                     ? null
                     : _refreshAnitabiData,
-                icon: const Icon(Icons.refresh),
+                icon: const Icon(LucideIcons.refreshCw),
               ),
             ),
           ],
@@ -2056,7 +2058,7 @@ class _ImportMarker extends StatelessWidget {
           width: selected ? 2 : 1,
         ),
       ),
-      icon: Icon(imported ? Icons.check : Icons.place, size: 22),
+      icon: Icon(imported ? LucideIcons.check : LucideIcons.mapPin, size: 22),
     );
   }
 }
@@ -2113,7 +2115,7 @@ class _ImportSummary extends StatelessWidget {
                   child: CircularProgressIndicator(strokeWidth: 2),
                 )
               else
-                Icon(Icons.map_outlined, color: AppColors.accent),
+                Icon(LucideIcons.map, color: AppColors.accent),
               const SizedBox(width: 10),
               Expanded(
                 child: Text(
@@ -2136,45 +2138,41 @@ class _ImportSummary extends StatelessWidget {
             Row(
               children: [
                 SizedBox(
-                  width: 36,
-                  height: 36,
+                  width: 44,
+                  height: 44,
                   child: IconButton.outlined(
                     tooltip: '添加所有点位',
                     onPressed: isImporting || availableCount == 0
                         ? null
                         : onImportAll,
-                    icon: const Icon(Icons.playlist_add_check, size: 18),
+                    icon: const Icon(LucideIcons.listChecks, size: 18),
                     style: _summaryIconButtonStyle(false),
                   ),
                 ),
                 const SizedBox(width: 8),
                 SizedBox(
-                  width: 36,
-                  height: 36,
+                  width: 44,
+                  height: 44,
                   child: IconButton.outlined(
                     tooltip: boxSelectionEnabled ? '退出框选' : '框选点位',
                     isSelected: boxSelectionEnabled,
                     onPressed: isImporting ? null : onToggleBoxSelection,
-                    icon: const Icon(Icons.select_all_outlined, size: 18),
-                    selectedIcon: const Icon(Icons.select_all, size: 18),
+                    icon: const Icon(LucideIcons.scan, size: 18),
+                    selectedIcon: const Icon(LucideIcons.scan, size: 18),
                     style: _summaryIconButtonStyle(boxSelectionEnabled),
                   ),
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: SizedBox(
-                    height: 36,
-                    child: FilledButton.icon(
+                    height: 44,
+                    child: FilledButton(
                       onPressed:
                           isImporting ||
                               !boxSelectionEnabled ||
                               selectedBoxCount == 0
                           ? null
                           : onImportSelection,
-                      icon: const Icon(
-                        Icons.add_location_alt_outlined,
-                        size: 16,
-                      ),
                       style: FilledButton.styleFrom(
                         padding: const EdgeInsets.symmetric(horizontal: 10),
                         textStyle: const TextStyle(
@@ -2183,10 +2181,14 @@ class _ImportSummary extends StatelessWidget {
                           letterSpacing: 0,
                         ),
                       ),
-                      label: Text(
-                        selectedBoxCount == 0
-                            ? '添加框选'
-                            : '添加 $selectedBoxCount 个',
+                      child: ResponsiveButtonContent(
+                        icon: LucideIcons.mapPinPlus,
+                        iconSize: 16,
+                        label: selectedBoxCount == 0
+                            ? '导入框选结果'
+                            : '导入 $selectedBoxCount 个',
+                        shortLabel: '导入',
+                        semanticLabel: '导入框选结果',
                       ),
                     ),
                   ),
@@ -2372,129 +2374,136 @@ class _AnitabiPointCard extends StatelessWidget {
               onTap: openDetail,
               child: Padding(
                 padding: const EdgeInsets.all(14),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+                child: Column(
                   children: [
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: Material(
-                        color: AppColors.surfaceMuted,
-                        child: InkWell(
-                          onTap: fullImageUrl == null ? null : openFullImage,
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(8),
+                          child: Material(
+                            color: AppColors.surfaceMuted,
+                            child: InkWell(
+                              onTap: fullImageUrl == null
+                                  ? null
+                                  : openFullImage,
+                              child: SizedBox(
+                                key: ValueKey(
+                                  'anitabi-point-thumbnail-${point.id}',
+                                ),
+                                width: 80,
+                                height: 80,
+                                child: importedPoint == null
+                                    ? ReferenceThumbnail(
+                                        localPath: localThumbnailPath,
+                                        imageUrl: imageUrl,
+                                        placeholder: const Icon(
+                                          LucideIcons.image,
+                                        ),
+                                      )
+                                    : AutoCachingReferenceThumbnail(
+                                        planId: planId,
+                                        point: importedPoint!,
+                                        repository: repository,
+                                        onPlanUpdated: onPlanUpdated,
+                                        placeholder: const Icon(
+                                          LucideIcons.image,
+                                        ),
+                                      ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
                           child: SizedBox(
-                            width: 86,
-                            height: 86,
-                            child: importedPoint == null
-                                ? ReferenceThumbnail(
-                                    localPath: localThumbnailPath,
-                                    imageUrl: imageUrl,
-                                    placeholder: const Icon(
-                                      Icons.image_outlined,
-                                    ),
-                                  )
-                                : AutoCachingReferenceThumbnail(
-                                    planId: planId,
-                                    point: importedPoint!,
-                                    repository: repository,
-                                    onPlanUpdated: onPlanUpdated,
-                                    placeholder: const Icon(
-                                      Icons.image_outlined,
-                                    ),
+                            key: ValueKey('anitabi-point-text-${point.id}'),
+                            height: 80,
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                CopyableText(
+                                  text: point.name,
+                                  copyLabel: '点位名称',
+                                  onTap: openDetail,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.w800,
+                                    letterSpacing: 0,
                                   ),
+                                ),
+                                const SizedBox(height: 3),
+                                CopyableText(
+                                  text:
+                                      '${point.subtitle} / ${point.episodeLabel}',
+                                  copyText: _copySummary,
+                                  copyLabel: '点位信息',
+                                  onTap: openDetail,
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    color: AppColors.textSecondary,
+                                    fontSize: 12,
+                                    letterSpacing: 0,
+                                  ),
+                                ),
+                                const SizedBox(height: 3),
+                                CopyableText(
+                                  text: point.origin,
+                                  copyLabel: '来源',
+                                  onTap: openDetail,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    color: AppColors.textSecondary,
+                                    fontSize: 12,
+                                    letterSpacing: 0,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 10),
+                    ResponsiveTwoButtonRow(
+                      first: SizedBox(
+                        height: 40,
+                        child: OutlinedButton(
+                          key: ValueKey('anitabi-point-navigation-${point.id}'),
+                          onPressed: openNavigation,
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(horizontal: 20),
+                          ),
+                          child: const ResponsiveButtonContent(
+                            icon: LucideIcons.navigation,
+                            iconSize: 17,
+                            label: '导航',
+                            semanticLabel: '打开导航',
                           ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          CopyableText(
-                            text: point.name,
-                            copyLabel: '点位名称',
-                            onTap: openDetail,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: const TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.w800,
-                              letterSpacing: 0,
-                            ),
+                      second: SizedBox(
+                        height: 40,
+                        child: FilledButton(
+                          key: ValueKey('anitabi-point-import-${point.id}'),
+                          onPressed: imported || isImporting ? null : onImport,
+                          style: FilledButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(horizontal: 20),
                           ),
-                          const SizedBox(height: 3),
-                          CopyableText(
-                            text: '${point.subtitle} / ${point.episodeLabel}',
-                            copyText: _copySummary,
-                            copyLabel: '点位信息',
-                            onTap: openDetail,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              color: AppColors.textSecondary,
-                              fontSize: 12,
-                              letterSpacing: 0,
-                            ),
+                          child: ResponsiveButtonContent(
+                            icon: imported
+                                ? LucideIcons.check
+                                : LucideIcons.mapPinPlus,
+                            label: imported ? '已加入计划' : '加入计划',
+                            shortLabel: imported ? '已加入' : '加入',
+                            semanticLabel: imported ? '已加入计划' : '加入计划',
                           ),
-                          const SizedBox(height: 3),
-                          CopyableText(
-                            text: point.origin,
-                            copyLabel: '来源',
-                            onTap: openDetail,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              color: AppColors.textSecondary,
-                              fontSize: 12,
-                              letterSpacing: 0,
-                            ),
-                          ),
-                          const SizedBox(height: 10),
-                          Row(
-                            children: [
-                              SizedBox(
-                                height: 40,
-                                child: OutlinedButton.icon(
-                                  onPressed: openNavigation,
-                                  icon: const Icon(
-                                    Icons.navigation_outlined,
-                                    size: 17,
-                                  ),
-                                  label: const Text('导航'),
-                                  style: OutlinedButton.styleFrom(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 10,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              Expanded(
-                                child: SizedBox(
-                                  height: 40,
-                                  child: FilledButton.icon(
-                                    onPressed: imported || isImporting
-                                        ? null
-                                        : onImport,
-                                    icon: Icon(
-                                      imported
-                                          ? Icons.check
-                                          : Icons.add_location_alt_outlined,
-                                      size: 18,
-                                    ),
-                                    label: Text(imported ? '已加入' : '加入计划'),
-                                    style: FilledButton.styleFrom(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 10,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
+                        ),
                       ),
                     ),
                   ],
@@ -2606,7 +2615,7 @@ class _AnitabiPointDetailSheet extends StatelessWidget {
                             localPath: localThumbnailPath,
                             imageUrl: imageUrl,
                             fit: BoxFit.cover,
-                            placeholder: const Icon(Icons.image_outlined),
+                            placeholder: const Icon(LucideIcons.image),
                           ),
                         ),
                       ),
@@ -2630,27 +2639,27 @@ class _AnitabiPointDetailSheet extends StatelessWidget {
                         ),
                         const SizedBox(height: 8),
                         _AnitabiDetailInfoLine(
-                          icon: Icons.local_movies_outlined,
+                          icon: LucideIcons.film,
                           label: '场景',
                           value: '${point.subtitle} / ${point.episodeLabel}',
                         ),
                         if (point.note?.trim().isNotEmpty == true) ...[
                           const SizedBox(height: 6),
                           _AnitabiDetailInfoLine(
-                            icon: Icons.sticky_note_2_outlined,
+                            icon: LucideIcons.stickyNote,
                             label: '备注',
                             value: point.note!,
                           ),
                         ],
                         const SizedBox(height: 6),
                         _AnitabiDetailInfoLine(
-                          icon: Icons.source_outlined,
+                          icon: LucideIcons.fileCode,
                           label: '来源',
                           value: point.origin,
                         ),
                         const SizedBox(height: 6),
                         _AnitabiDetailInfoLine(
-                          icon: Icons.location_on_outlined,
+                          icon: LucideIcons.mapPin,
                           label: '坐标',
                           value:
                               '${point.position.latitude.toStringAsFixed(5)}, ${point.position.longitude.toStringAsFixed(5)}',
@@ -2664,18 +2673,19 @@ class _AnitabiPointDetailSheet extends StatelessWidget {
               SizedBox(
                 width: double.infinity,
                 height: 44,
-                child: FilledButton.icon(
+                child: FilledButton(
                   onPressed: imported || isImporting
                       ? null
                       : () {
                           Navigator.of(context).pop();
                           onImport();
                         },
-                  icon: Icon(
-                    imported ? Icons.check : Icons.add_location_alt_outlined,
-                    size: 18,
+                  child: ResponsiveButtonContent(
+                    icon: imported ? LucideIcons.check : LucideIcons.mapPinPlus,
+                    label: imported ? '已加入计划' : '加入计划',
+                    shortLabel: imported ? '已加入' : '加入',
+                    semanticLabel: imported ? '已加入计划' : '加入计划',
                   ),
-                  label: Text(imported ? '已加入计划' : '加入计划'),
                 ),
               ),
             ],
@@ -2761,7 +2771,7 @@ class _NoPointSelectedCard extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(Icons.touch_app_outlined, color: AppColors.accent),
+          Icon(LucideIcons.pointer, color: AppColors.accent),
           SizedBox(width: 10),
           Expanded(
             child: Text(
@@ -2817,7 +2827,7 @@ class _EmptyImportState extends StatelessWidget {
             children: [
               Row(
                 children: [
-                  Icon(Icons.movie_filter_outlined, color: AppColors.accent),
+                  Icon(LucideIcons.clapperboard, color: AppColors.accent),
                   const SizedBox(width: 8),
                   Text(
                     '还没有作品',
@@ -2841,7 +2851,7 @@ class _EmptyImportState extends StatelessWidget {
                     minimumSize: const Size.fromHeight(46),
                     padding: const EdgeInsets.symmetric(horizontal: 16),
                   ),
-                  icon: const Icon(Icons.movie_filter_outlined, size: 20),
+                  icon: const Icon(LucideIcons.clapperboard, size: 20),
                   label: const Text('作品管理'),
                 ),
               ),
@@ -3045,7 +3055,7 @@ class _ImportErrorState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.map_outlined, color: AppColors.textSecondary, size: 32),
+            Icon(LucideIcons.map, color: AppColors.textSecondary, size: 32),
             const SizedBox(height: 12),
             Text(
               message,
@@ -3069,7 +3079,7 @@ class _ImportErrorState extends StatelessWidget {
             const SizedBox(height: 16),
             OutlinedButton.icon(
               onPressed: onRetry,
-              icon: const Icon(Icons.refresh),
+              icon: const Icon(LucideIcons.refreshCw),
               label: const Text('清除缓存并重新加载 Anitabi 点位'),
             ),
           ],

--- a/lib/plan/group_anchor_picker_screen.dart
+++ b/lib/plan/group_anchor_picker_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -178,14 +179,14 @@ class _GroupAnchorPickerScreenState extends State<GroupAnchorPickerScreen> {
                         _manualPickMode = !_manualPickMode;
                       });
                     },
-                    icon: Icons.ads_click_outlined,
+                    icon: LucideIcons.mousePointerClick,
                   ),
                   const SizedBox(height: 8),
                   _MapToolButton(
                     tooltip: '输入经纬度',
                     selected: false,
                     onTap: _showCoordinateInput,
-                    icon: Icons.edit_location_alt_outlined,
+                    icon: LucideIcons.mapPinPen,
                   ),
                 ],
               ),
@@ -315,7 +316,7 @@ class _AnchorPointMarker extends StatelessWidget {
           width: selected ? 2 : 1,
         ),
       ),
-      icon: const Icon(Icons.place, size: 21),
+      icon: const Icon(LucideIcons.mapPin, size: 21),
     );
   }
 }
@@ -331,7 +332,7 @@ class _ManualAnchorMarker extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: Colors.white, width: 3),
       ),
-      child: const Icon(Icons.add_location_alt, color: Colors.white),
+      child: const Icon(LucideIcons.mapPinPlus, color: Colors.white),
     );
   }
 }
@@ -399,7 +400,7 @@ class _AnchorSelectionCard extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(Icons.flag_outlined, color: AppColors.accent, size: 28),
+          Icon(LucideIcons.flag, color: AppColors.accent, size: 28),
           const SizedBox(width: 12),
           Expanded(
             child: Column(

--- a/lib/plan/nearest_group_assign_screen.dart
+++ b/lib/plan/nearest_group_assign_screen.dart
@@ -1,10 +1,12 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../app_theme.dart';
+import '../widgets/responsive_button.dart';
 import '../data/pilgrimage_repository.dart';
 import '../map/map_marker_scale.dart';
 import '../map/map_tile_config.dart';
@@ -366,6 +368,7 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
       groups: _plan.groups,
       groupBuckets: planGroupBuckets(_plan, _plan.completedPointIds),
       onMoveToGroup: _movePointToGroup,
+      onDelete: _deletePoint,
       navigationApp: widget.settings.navigationApp,
       settings: widget.settings,
     );
@@ -398,6 +401,21 @@ class _NearestGroupAssignScreenState extends State<NearestGroupAssignScreen> {
       planId: _plan.id,
       pointIds: {point.id},
       groupId: groupId,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _plan = updatedPlan;
+      _selectedPoint = null;
+      _didUpdate = true;
+    });
+  }
+
+  Future<void> _deletePoint(PilgrimagePoint point) async {
+    final updatedPlan = await widget.repository.deletePointFromPlan(
+      planId: _plan.id,
+      pointId: point.id,
     );
     if (!mounted) {
       return;
@@ -820,6 +838,7 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
       groups: _plan.groups,
       groupBuckets: planGroupBuckets(_plan, _plan.completedPointIds),
       onMoveToGroup: _movePointToGroup,
+      onDelete: _deletePoint,
       navigationApp: widget.settings.navigationApp,
       settings: widget.settings,
     );
@@ -852,6 +871,21 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
       planId: _plan.id,
       pointIds: {point.id},
       groupId: groupId,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _plan = updatedPlan;
+      _selectedPoint = null;
+      _didUpdate = true;
+    });
+  }
+
+  Future<void> _deletePoint(PilgrimagePoint point) async {
+    final updatedPlan = await widget.repository.deletePointFromPlan(
+      planId: _plan.id,
+      pointId: point.id,
     );
     if (!mounted) {
       return;
@@ -945,7 +979,7 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
                     padding: const EdgeInsets.symmetric(horizontal: 14),
                     child: Row(
                       children: [
-                        const Icon(Icons.folder_outlined, size: 19),
+                        const Icon(LucideIcons.folder, size: 19),
                         const SizedBox(width: 10),
                         Expanded(
                           child: Text(
@@ -960,8 +994,8 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
                         ),
                         Icon(
                           _isOpen
-                              ? Icons.keyboard_arrow_up
-                              : Icons.keyboard_arrow_down,
+                              ? LucideIcons.chevronUp
+                              : LucideIcons.chevronDown,
                           size: 20,
                         ),
                       ],
@@ -1026,7 +1060,7 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
                                   leadingIcon:
                                       group.id == widget.selectedGroup?.id
                                       ? Icon(
-                                          Icons.check,
+                                          LucideIcons.check,
                                           color: accentColor,
                                           size: 19,
                                         )
@@ -1102,7 +1136,7 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
                               }
                             : null,
                         leadingIcon: Icon(
-                          Icons.add,
+                          LucideIcons.plus,
                           color: accentColor,
                           size: 20,
                         ),
@@ -1254,15 +1288,17 @@ class _BoxAssignPanel extends StatelessWidget {
                 SizedBox(
                   key: const ValueKey('box-assign-toggle-button'),
                   width: actionButtonWidth,
-                  height: AppButtonStyles.compactHeight,
-                  child: OutlinedButton.icon(
+                  height: 44,
+                  child: OutlinedButton(
                     onPressed: isSaving ? null : onToggleBoxSelection,
                     style: AppButtonStyles.compactOutlinedButton(),
-                    icon: Icon(
-                      isBoxSelecting ? Icons.close : Icons.select_all_outlined,
-                      size: 17,
+                    child: ResponsiveButtonContent(
+                      icon: isBoxSelecting ? LucideIcons.x : LucideIcons.scan,
+                      iconSize: 17,
+                      label: isBoxSelecting ? '结束框选' : '框选',
+                      shortLabel: isBoxSelecting ? '结束' : '框选',
+                      semanticLabel: isBoxSelecting ? '结束框选' : '开始框选',
                     ),
-                    label: Text(isBoxSelecting ? '结束框选' : '框选'),
                   ),
                 ),
               ],
@@ -1287,14 +1323,19 @@ class _BoxAssignPanel extends StatelessWidget {
                 SizedBox(
                   key: const ValueKey('box-assign-submit-button'),
                   width: actionButtonWidth,
-                  height: AppButtonStyles.compactHeight,
+                  height: 44,
                   child: FilledButton(
                     onPressed:
                         isSaving || targetGroup == null || selectedCount == 0
                         ? null
                         : onAssign,
                     style: AppButtonStyles.compactFilledButton(),
-                    child: Text(isSaving ? '分配中' : '分配'),
+                    child: ResponsiveButtonContent(
+                      icon: LucideIcons.folderInput,
+                      iconSize: 17,
+                      label: isSaving ? '分配中' : '分配',
+                      semanticLabel: isSaving ? '正在分配' : '分配选中点位',
+                    ),
                   ),
                 ),
               ],
@@ -1374,7 +1415,7 @@ class _NearestAssignPanel extends StatelessWidget {
           children: [
             Row(
               children: [
-                const Icon(Icons.auto_fix_high_outlined, size: 20),
+                const Icon(LucideIcons.wandSparkles, size: 20),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
@@ -1454,7 +1495,7 @@ class _NearestAssignPointCard extends StatelessWidget {
           child: Row(
             children: [
               Icon(
-                assignable ? Icons.check_circle_outline : Icons.info_outline,
+                assignable ? LucideIcons.circleCheckBig : LucideIcons.info,
                 color: assignable ? AppColors.accentDark : AppColors.warning,
               ),
               const SizedBox(width: 10),
@@ -1564,7 +1605,7 @@ class _AssignPointMarker extends StatelessWidget {
           width: selected ? 2 : 1,
         ),
       ),
-      icon: const Icon(Icons.place, size: 20),
+      icon: const Icon(LucideIcons.mapPin, size: 20),
     );
   }
 }
@@ -1591,7 +1632,7 @@ class _AnchorMarker extends StatelessWidget {
             ),
           ],
         ),
-        child: Icon(Icons.flag_outlined, color: AppColors.accentDark),
+        child: Icon(LucideIcons.flag, color: AppColors.accentDark),
       ),
     );
   }

--- a/lib/plan/pilgrimage_plan_controller.dart
+++ b/lib/plan/pilgrimage_plan_controller.dart
@@ -227,6 +227,22 @@ class PilgrimagePlanController extends ChangeNotifier {
     _replacePlanState(updatedPlan);
   }
 
+  Future<void> deletePoint(PilgrimagePoint point) async {
+    final repository = _repository;
+    if (repository == null) {
+      return;
+    }
+
+    final updatedPlan = await repository.deletePointFromPlan(
+      planId: _plan.id,
+      pointId: point.id,
+    );
+    _visitRecords = _visitRecords
+        .where((record) => record.pointId != point.id)
+        .toList(growable: false);
+    _replacePlanState(updatedPlan);
+  }
+
   Future<void> updatePlanMemo(String memo) async {
     final repository = _repository;
     if (repository == null) {

--- a/lib/plan/pilgrimage_work_cover.dart
+++ b/lib/plan/pilgrimage_work_cover.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import 'pilgrimage_models.dart';
@@ -60,7 +61,7 @@ class _WorkCoverFallback extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: Icon(
-        Icons.movie_filter_outlined,
+        LucideIcons.clapperboard,
         size: 22,
         color: AppColors.textSecondary,
       ),

--- a/lib/plan/pilgrimage_work_dropdown.dart
+++ b/lib/plan/pilgrimage_work_dropdown.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../widgets/app_scaled_route.dart';
@@ -49,7 +50,7 @@ class PilgrimageWorkDropdown extends StatelessWidget {
         menuMaxHeight: appScaledOverlayExtent(settings, 360),
         icon: const Padding(
           padding: EdgeInsets.only(right: 8),
-          child: Icon(Icons.keyboard_arrow_down_rounded, size: 20),
+          child: Icon(LucideIcons.chevronDown, size: 20),
         ),
         selectedItemBuilder: (context) => [
           for (final work in works) _WorkDropdownItem(work: work),
@@ -200,7 +201,7 @@ class _WorkDropdownItemState extends State<_WorkDropdownItem> {
             ),
             if (selected) ...[
               const SizedBox(width: 8),
-              Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+              Icon(LucideIcons.checkCircle, color: AppColors.accent, size: 18),
             ],
           ],
         ),

--- a/lib/plan/plan_group_manager_screen.dart
+++ b/lib/plan/plan_group_manager_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
@@ -488,7 +489,7 @@ class _CreateGroupFab extends StatelessWidget {
         child: const Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.add, size: 24),
+            Icon(LucideIcons.plus, size: 24),
             SizedBox(height: 2),
             Text(
               '新建',
@@ -599,7 +600,7 @@ class _PlanGroupCard extends StatelessWidget {
                 child: SizedBox(
                   width: 42,
                   child: Icon(
-                    Icons.drag_indicator,
+                    LucideIcons.gripVertical,
                     color: AppColors.textSecondary,
                   ),
                 ),
@@ -660,7 +661,7 @@ class _PlanGroupCard extends StatelessWidget {
                 key: ValueKey('plan-group-actions-${group.id}'),
                 tooltip: '片区操作',
                 enabled: !isBusy,
-                icon: const Icon(Icons.more_vert),
+                icon: const Icon(LucideIcons.ellipsisVertical),
                 position: PopupMenuPosition.under,
                 offset: const Offset(0, 6),
                 elevation: 8,
@@ -690,7 +691,7 @@ class _PlanGroupCard extends StatelessWidget {
                     height: 42,
                     padding: EdgeInsets.symmetric(horizontal: 8),
                     child: _GroupActionRow(
-                      icon: Icons.edit_outlined,
+                      icon: LucideIcons.edit,
                       label: '重命名',
                     ),
                   ),
@@ -699,7 +700,7 @@ class _PlanGroupCard extends StatelessWidget {
                     height: 42,
                     padding: EdgeInsets.symmetric(horizontal: 8),
                     child: _GroupActionRow(
-                      icon: Icons.flag_outlined,
+                      icon: LucideIcons.flag,
                       label: '设置关键点',
                     ),
                   ),
@@ -708,7 +709,7 @@ class _PlanGroupCard extends StatelessWidget {
                     height: 42,
                     padding: const EdgeInsets.symmetric(horizontal: 8),
                     child: _GroupActionRow(
-                      icon: Icons.sort_outlined,
+                      icon: LucideIcons.arrowUpDown,
                       label: group.orderMode == PlanGroupOrderMode.manual
                           ? '切换为无序'
                           : '切换为手动排序',
@@ -720,7 +721,7 @@ class _PlanGroupCard extends StatelessWidget {
                     height: 42,
                     padding: EdgeInsets.symmetric(horizontal: 8),
                     child: _GroupActionRow(
-                      icon: Icons.delete_outline,
+                      icon: LucideIcons.trash2,
                       label: '删除片区',
                       destructive: true,
                     ),
@@ -829,7 +830,7 @@ class _UngroupedGroupCard extends StatelessWidget {
           ),
           child: Row(
             children: [
-              Icon(Icons.inbox_outlined, color: AppColors.textSecondary),
+              Icon(LucideIcons.inbox, color: AppColors.textSecondary),
               const SizedBox(width: 12),
               Expanded(
                 child: Column(
@@ -863,7 +864,7 @@ class _UngroupedGroupCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 4),
-              Icon(Icons.chevron_right, color: AppColors.textSecondary),
+              Icon(LucideIcons.chevronRight, color: AppColors.textSecondary),
             ],
           ),
         ),

--- a/lib/plan/plan_group_picker_sheet.dart
+++ b/lib/plan/plan_group_picker_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import 'pilgrimage_models.dart';
@@ -95,7 +96,7 @@ Future<void> showPlanGroupPickerSheet({
                                 });
                             });
                           },
-                          icon: const Icon(Icons.create_new_folder_outlined),
+                          icon: const Icon(LucideIcons.folderPlus),
                         ),
                     ],
                   ),
@@ -210,15 +211,44 @@ class _PlanGroupPickerTile extends StatelessWidget {
                           child: Stack(
                             alignment: Alignment.center,
                             children: [
+                              Positioned(
+                                left: 3,
+                                top: 4,
+                                width: 11,
+                                height: 7,
+                                child: DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: accentColor,
+                                    borderRadius: const BorderRadius.vertical(
+                                      top: Radius.circular(2),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              Positioned(
+                                left: 3,
+                                right: 3,
+                                top: 8,
+                                bottom: 3,
+                                child: DecoratedBox(
+                                  key: ValueKey(
+                                    'plan-group-picker-completed-fill-${group.id}',
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: accentColor,
+                                    borderRadius: BorderRadius.circular(2),
+                                  ),
+                                ),
+                              ),
                               Icon(
-                                Icons.folder,
-                                color: AppColors.accentDark,
+                                LucideIcons.folder,
+                                color: accentColor,
                                 size: 28,
                               ),
                               const Padding(
                                 padding: EdgeInsets.only(top: 2),
                                 child: Icon(
-                                  Icons.check,
+                                  LucideIcons.check,
                                   color: Colors.white,
                                   size: 14,
                                 ),
@@ -232,11 +262,11 @@ class _PlanGroupPickerTile extends StatelessWidget {
                           child: Icon(
                             group.isUngrouped
                                 ? (selected
-                                      ? Icons.inventory_2
-                                      : Icons.inventory_2_outlined)
+                                      ? LucideIcons.package
+                                      : LucideIcons.package)
                                 : (selected
-                                      ? Icons.folder
-                                      : Icons.folder_outlined),
+                                      ? LucideIcons.folder
+                                      : LucideIcons.folder),
                             color: selected
                                 ? accentColor
                                 : AppColors.textSecondary,
@@ -428,7 +458,7 @@ Future<String?> showPlanGroupSelectionSheet({
                             child: Row(
                               children: [
                                 const SizedBox(width: 8),
-                                Icon(Icons.add, color: AppColors.accent),
+                                Icon(LucideIcons.plus, color: AppColors.accent),
                                 const SizedBox(width: 12),
                                 Text(
                                   '新建片区',
@@ -513,8 +543,8 @@ class _PlanGroupSelectionTileState extends State<_PlanGroupSelectionTile> {
                       children: [
                         Icon(
                           widget.selected
-                              ? Icons.check_circle
-                              : Icons.radio_button_unchecked,
+                              ? LucideIcons.checkCircle
+                              : LucideIcons.circle,
                           key: ValueKey(
                             'plan-point-group-selection-${widget.option.title}',
                           ),

--- a/lib/plan/plan_manager_screen.dart
+++ b/lib/plan/plan_manager_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
@@ -310,7 +311,9 @@ class _PlanManagerScreenState extends State<PlanManagerScreen> {
                       dimension: 20,
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
-                  : Icon(_sorting ? Icons.done : Icons.sort),
+                  : Icon(
+                      _sorting ? LucideIcons.check : LucideIcons.arrowUpDown,
+                    ),
             ),
         ],
       ),
@@ -420,7 +423,7 @@ class _CreatePlanButton extends StatelessWidget {
         side: BorderSide(color: AppColors.accent, width: 1.2),
         minimumSize: const Size.fromHeight(46),
       ),
-      icon: const Icon(Icons.add, size: 19),
+      icon: const Icon(LucideIcons.plus, size: 19),
       label: const Text('新建计划'),
     );
   }
@@ -622,10 +625,10 @@ class _PlanCardState extends State<_PlanCard> {
                         children: [
                           Icon(
                             widget.reorderIndex != null
-                                ? Icons.sort
+                                ? LucideIcons.arrowUpDown
                                 : selected
-                                ? Icons.check_circle
-                                : Icons.swap_horiz,
+                                ? LucideIcons.checkCircle
+                                : LucideIcons.arrowLeftRight,
                             color: selected
                                 ? AppColors.accent
                                 : AppColors.textSecondary.withValues(
@@ -678,7 +681,7 @@ class _PlanCardState extends State<_PlanCard> {
                         message: '拖动排序',
                         child: Center(
                           child: Icon(
-                            Icons.drag_indicator,
+                            LucideIcons.gripVertical,
                             size: 22,
                             color: AppColors.textSecondary.withValues(
                               alpha: widget.reorderEnabled ? 0.7 : 0.35,
@@ -703,7 +706,7 @@ class _PlanCardState extends State<_PlanCard> {
                         key: ValueKey('plan-card-edit-${plan.id}'),
                         tooltip: '编辑计划信息',
                         onPressed: widget.onRename,
-                        icon: Icons.edit_outlined,
+                        icon: LucideIcons.edit,
                         iconSize: 21,
                       ),
                       const SizedBox(width: 2),
@@ -821,7 +824,7 @@ class _PlanMoreButtonState extends State<_PlanMoreButton> {
             _controller.open();
           }
         },
-        icon: Icons.more_horiz,
+        icon: LucideIcons.ellipsis,
         iconSize: 20,
       ),
     );
@@ -860,21 +863,21 @@ class _PlanActionsMenuPanel extends StatelessWidget {
                   _PlanMenuActionItem(
                     actionKey: const ValueKey('plan-menu-action-transfer'),
                     label: '导入导出',
-                    icon: Icons.import_export_outlined,
+                    icon: LucideIcons.import,
                     onPressed: onExport,
                   ),
                   const SizedBox(height: 6),
                   _PlanMenuActionItem(
                     actionKey: const ValueKey('plan-menu-action-copy'),
                     label: '复制计划',
-                    icon: Icons.copy_outlined,
+                    icon: LucideIcons.copy,
                     onPressed: onDuplicate,
                   ),
                   Divider(height: 17, color: AppColors.border),
                   _PlanMenuActionItem(
                     actionKey: const ValueKey('plan-menu-action-delete'),
                     label: '删除计划',
-                    icon: Icons.delete_outline,
+                    icon: LucideIcons.trash2,
                     onPressed: canDelete ? onDelete : null,
                     isDangerous: true,
                   ),
@@ -1172,7 +1175,7 @@ class _ErrorState extends StatelessWidget {
     return Center(
       child: OutlinedButton.icon(
         onPressed: onRetry,
-        icon: const Icon(Icons.refresh),
+        icon: const Icon(LucideIcons.refreshCw),
         label: const Text('重新加载计划'),
       ),
     );

--- a/lib/plan/plan_memo_screen.dart
+++ b/lib/plan/plan_memo_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -380,7 +381,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
                           height: 16,
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
-                      : const Icon(Icons.save_outlined),
+                      : const Icon(LucideIcons.save),
                   label: const Text('保存'),
                 ),
               )
@@ -388,7 +389,7 @@ class _PlanMemoScreenState extends State<PlanMemoScreen> {
               IconButton(
                 tooltip: '编辑',
                 onPressed: _startEditing,
-                icon: const Icon(Icons.edit_outlined),
+                icon: const Icon(LucideIcons.edit),
               ),
           ],
         ),
@@ -507,42 +508,42 @@ class _MarkdownToolbar extends StatelessWidget {
     const tools = [
       _MarkdownToolSpec(
         action: _MarkdownAction.heading,
-        icon: Icons.title,
+        icon: LucideIcons.heading,
         tooltip: '标题',
       ),
       _MarkdownToolSpec(
         action: _MarkdownAction.bold,
-        icon: Icons.format_bold,
+        icon: LucideIcons.bold,
         tooltip: '加粗',
       ),
       _MarkdownToolSpec(
         action: _MarkdownAction.list,
-        icon: Icons.format_list_bulleted,
+        icon: LucideIcons.list,
         tooltip: '列表',
       ),
       _MarkdownToolSpec(
         action: _MarkdownAction.task,
-        icon: Icons.check_box_outlined,
+        icon: LucideIcons.squareCheckBig,
         tooltip: '待办',
       ),
       _MarkdownToolSpec(
         action: _MarkdownAction.quote,
-        icon: Icons.format_quote,
+        icon: LucideIcons.quote,
         tooltip: '引用',
       ),
       _MarkdownToolSpec(
         action: _MarkdownAction.divider,
-        icon: Icons.horizontal_rule,
+        icon: LucideIcons.minus,
         tooltip: '分割线',
       ),
       _MarkdownToolSpec(
         action: _MarkdownAction.link,
-        icon: Icons.link,
+        icon: LucideIcons.link,
         tooltip: '链接',
       ),
       _MarkdownToolSpec(
         action: _MarkdownAction.code,
-        icon: Icons.code,
+        icon: LucideIcons.code,
         tooltip: '代码',
       ),
     ];
@@ -739,7 +740,7 @@ class _TaskCheckboxBuilder {
             width: 28,
             height: 28,
             child: Icon(
-              value ? Icons.check_box : Icons.check_box_outline_blank,
+              value ? LucideIcons.squareCheckBig : LucideIcons.square,
               size: 25,
               color: value ? AppColors.accentDark : AppColors.textSecondary,
             ),
@@ -809,7 +810,7 @@ class _UnsupportedMarkdownImage extends StatelessWidget {
       ),
       child: Row(
         children: [
-          const Icon(Icons.image_not_supported_outlined, size: 20),
+          const Icon(LucideIcons.imageOff, size: 20),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
@@ -836,27 +837,11 @@ class _EmptyPlanMemo extends StatelessWidget {
   final VoidCallback onStart;
 
   static const _suggestions = [
-    (
-      icon: Icons.directions_transit_outlined,
-      label: '交通安排',
-      detail: '如车次、换乘方案、出发时间等',
-    ),
-    (icon: Icons.hotel_outlined, label: '酒店预约', detail: '酒店地址、入住时间、联系方式等'),
-    (
-      icon: Icons.confirmation_number_outlined,
-      label: '活动门票',
-      detail: '活动门票、预约时间、注意事项等',
-    ),
-    (
-      icon: Icons.photo_camera_outlined,
-      label: '拍摄计划',
-      detail: '拍摄地点、时间、天气备选方案等',
-    ),
-    (
-      icon: Icons.notifications_none_rounded,
-      label: '注意事项',
-      detail: '携带物品、预算、当地注意事项等',
-    ),
+    (icon: LucideIcons.trainFront, label: '交通安排', detail: '如车次、换乘方案、出发时间等'),
+    (icon: LucideIcons.hotel, label: '酒店预约', detail: '酒店地址、入住时间、联系方式等'),
+    (icon: LucideIcons.ticket, label: '活动门票', detail: '活动门票、预约时间、注意事项等'),
+    (icon: LucideIcons.camera, label: '拍摄计划', detail: '拍摄地点、时间、天气备选方案等'),
+    (icon: LucideIcons.bell, label: '注意事项', detail: '携带物品、预算、当地注意事项等'),
   ];
 
   @override
@@ -879,7 +864,7 @@ class _EmptyPlanMemo extends StatelessWidget {
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Icon(
-                    Icons.sticky_note_2_outlined,
+                    LucideIcons.stickyNote,
                     color: AppColors.accentDark,
                     size: 34,
                   ),
@@ -922,7 +907,7 @@ class _EmptyPlanMemo extends StatelessWidget {
                         Row(
                           children: [
                             Icon(
-                              Icons.lightbulb_outline_rounded,
+                              LucideIcons.lightbulb,
                               color: AppColors.accent,
                               size: 18,
                             ),
@@ -967,7 +952,7 @@ class _EmptyPlanMemo extends StatelessWidget {
                         minimumSize: const Size.fromHeight(46),
                         padding: const EdgeInsets.symmetric(horizontal: 16),
                       ),
-                      icon: const Icon(Icons.edit_note_rounded, size: 20),
+                      icon: const Icon(LucideIcons.notebookPen, size: 20),
                       label: const Text('开始记录'),
                     ),
                   ),

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import '../app_theme.dart';
@@ -326,14 +327,16 @@ class _PlanScreenState extends State<PlanScreen> {
             key: const ValueKey('plan-switch-button'),
             tooltip: '切换计划',
             onPressed: widget.onOpenPlanManager,
-            icon: const Icon(Icons.swap_horiz),
+            icon: const Icon(LucideIcons.arrowLeftRight),
           ),
           IconButton(
             key: const ValueKey('plan-actions-toggle'),
             tooltip: _showPlanActions ? '收起计划操作' : '展开计划操作',
             onPressed: _togglePlanActions,
             icon: Icon(
-              _showPlanActions ? Icons.expand_less : Icons.expand_more,
+              _showPlanActions
+                  ? LucideIcons.chevronUp
+                  : LucideIcons.chevronDown,
             ),
           ),
         ],
@@ -521,6 +524,7 @@ class _PlanScreenState extends State<PlanScreen> {
       onOpenRecords: () => _openPointRecords(context, point),
       onOpenRecord: (record) => _openRecordDetail(context, record),
       onEditPoint: () => _editPoint(context, point),
+      onDelete: controller.deletePoint,
       navigationApp: settings.navigationApp,
       settings: settings,
       planController: controller,
@@ -769,8 +773,54 @@ class _PlanActionsPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final showSubtitles =
-            constraints.maxWidth >= _planActionSubtitleMinPanelWidth;
+        final compact = constraints.maxWidth < _planActionSubtitleMinPanelWidth;
+        final items = [
+          _PlanActionItem(
+            key: const ValueKey('plan-action-add-points'),
+            icon: const Icon(LucideIcons.mapPinPlus, size: 20),
+            title: '添加点位',
+            subtitle: '加入巡礼场景',
+            compact: compact,
+            onTap: onAddPoints,
+          ),
+          _PlanActionItem(
+            key: const ValueKey('plan-action-manage-points'),
+            icon: const Icon(LucideIcons.slidersHorizontal, size: 20),
+            title: '管理计划',
+            subtitle: '整理片区点位',
+            compact: compact,
+            onTap: onManagePoints,
+          ),
+          _PlanActionItem(
+            key: const ValueKey('plan-action-cache-references'),
+            icon: isCachingReferences
+                ? const SizedBox.square(
+                    dimension: 19,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(LucideIcons.cloudDownload, size: 20),
+            title: '缓存参考图',
+            subtitle: '保存完整图片',
+            compact: compact,
+            onTap: onCacheReferences,
+          ),
+          _PlanActionItem(
+            key: const ValueKey('plan-action-memo'),
+            icon: const Icon(LucideIcons.stickyNote, size: 20),
+            title: '计划备忘录',
+            subtitle: '记录行程要点',
+            compact: compact,
+            onTap: onOpenMemo,
+          ),
+          _PlanActionItem(
+            key: const ValueKey('plan-action-import-export'),
+            icon: const Icon(LucideIcons.import, size: 20),
+            title: '导入导出',
+            subtitle: '备份迁移计划',
+            compact: compact,
+            onTap: onImportExport,
+          ),
+        ];
         return Container(
           key: const ValueKey('plan-actions-panel'),
           clipBehavior: Clip.antiAlias,
@@ -779,102 +829,34 @@ class _PlanActionsPanel extends StatelessWidget {
             borderRadius: BorderRadius.circular(8),
             border: Border.all(color: AppColors.border),
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              IntrinsicHeight(
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
+          child: compact
+              ? _planActionRow(items)
+              : Column(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    Expanded(
-                      child: _PlanActionItem(
-                        key: const ValueKey('plan-action-add-points'),
-                        icon: const Icon(
-                          Icons.add_location_alt_outlined,
-                          size: 20,
-                        ),
-                        title: '添加点位',
-                        subtitle: '加入巡礼场景',
-                        showSubtitle: showSubtitles,
-                        onTap: onAddPoints,
-                      ),
-                    ),
-                    const _PlanActionDivider(),
-                    Expanded(
-                      child: _PlanActionItem(
-                        key: const ValueKey('plan-action-manage-points'),
-                        icon: const Icon(Icons.tune_outlined, size: 20),
-                        title: '管理计划',
-                        subtitle: '整理片区点位',
-                        showSubtitle: showSubtitles,
-                        onTap: onManagePoints,
-                      ),
-                    ),
+                    _planActionRow(items.sublist(0, 2)),
+                    const AppHairline(),
+                    _planActionRow(items.sublist(2)),
                   ],
                 ),
-              ),
-              const AppHairline(),
-              IntrinsicHeight(
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Expanded(
-                      child: _PlanActionItem(
-                        key: const ValueKey('plan-action-cache-references'),
-                        icon: isCachingReferences
-                            ? const SizedBox.square(
-                                dimension: 19,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                ),
-                              )
-                            : const Icon(
-                                Icons.download_for_offline_outlined,
-                                size: 20,
-                              ),
-                        title: '缓存参考图',
-                        subtitle: '保存完整图片',
-                        showSubtitle: showSubtitles,
-                        onTap: onCacheReferences,
-                      ),
-                    ),
-                    const _PlanActionDivider(),
-                    Expanded(
-                      child: _PlanActionItem(
-                        key: const ValueKey('plan-action-memo'),
-                        icon: const Icon(
-                          Icons.sticky_note_2_outlined,
-                          size: 20,
-                        ),
-                        title: '计划备忘录',
-                        subtitle: '记录行程要点',
-                        showSubtitle: showSubtitles,
-                        onTap: onOpenMemo,
-                      ),
-                    ),
-                    const _PlanActionDivider(),
-                    Expanded(
-                      child: _PlanActionItem(
-                        key: const ValueKey('plan-action-import-export'),
-                        icon: const Icon(
-                          Icons.import_export_outlined,
-                          size: 20,
-                        ),
-                        title: '导入导出',
-                        subtitle: '备份迁移计划',
-                        showSubtitle: showSubtitles,
-                        onTap: onImportExport,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
         );
       },
     );
   }
+}
+
+Widget _planActionRow(List<Widget> items) {
+  return IntrinsicHeight(
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (var i = 0; i < items.length; i++) ...[
+          if (i > 0) const _PlanActionDivider(),
+          Expanded(child: items[i]),
+        ],
+      ],
+    ),
+  );
 }
 
 class _PlanActionItem extends StatelessWidget {
@@ -882,7 +864,7 @@ class _PlanActionItem extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.subtitle,
-    required this.showSubtitle,
+    required this.compact,
     required this.onTap,
     super.key,
   });
@@ -890,63 +872,95 @@ class _PlanActionItem extends StatelessWidget {
   final Widget icon;
   final String title;
   final String subtitle;
-  final bool showSubtitle;
+  final bool compact;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
+    final themedIcon = IconTheme(
+      data: IconThemeData(color: AppColors.accentDark),
+      child: icon,
+    );
     return Material(
       color: Colors.transparent,
       child: InkWell(
         onTap: onTap,
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(minHeight: 64),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
-            child: Row(
-              children: [
-                IconTheme(
-                  data: IconThemeData(color: AppColors.accentDark),
-                  child: icon,
+        child: compact
+            ? Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 4,
+                  vertical: 10,
                 ),
-                const SizedBox(width: 7),
-                Expanded(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    themedIcon,
+                    const SizedBox(height: 6),
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Text(
                         title,
-                        maxLines: showSubtitle ? 1 : 2,
+                        maxLines: 1,
+                        softWrap: false,
+                        textAlign: TextAlign.center,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
                           color: AppColors.textPrimary,
-                          fontSize: 12,
+                          fontSize: 11,
                           fontWeight: FontWeight.w800,
                           letterSpacing: 0,
                         ),
                       ),
-                      if (showSubtitle) ...[
-                        const SizedBox(height: 2),
-                        Text(
-                          subtitle,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            color: AppColors.textSecondary,
-                            fontSize: 10,
-                            fontWeight: FontWeight.w500,
-                            letterSpacing: 0,
-                          ),
+                    ),
+                  ],
+                ),
+              )
+            : ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 64),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 9,
+                  ),
+                  child: Row(
+                    children: [
+                      themedIcon,
+                      const SizedBox(width: 7),
+                      Expanded(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                color: AppColors.textPrimary,
+                                fontSize: 12,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              subtitle,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                color: AppColors.textSecondary,
+                                fontSize: 10,
+                                fontWeight: FontWeight.w500,
+                                letterSpacing: 0,
+                              ),
+                            ),
+                          ],
                         ),
-                      ],
+                      ),
                     ],
                   ),
                 ),
-              ],
-            ),
-          ),
-        ),
+              ),
       ),
     );
   }
@@ -992,7 +1006,7 @@ class _GroupSwitcher extends StatelessWidget {
             onPressed: selectedIndex == 0
                 ? null
                 : () => onSelectGroup(groups[selectedIndex - 1]),
-            icon: const Icon(Icons.chevron_left),
+            icon: const Icon(LucideIcons.chevronLeft),
             tooltip: '上一个片区',
           ),
           Expanded(
@@ -1015,7 +1029,7 @@ class _GroupSwitcher extends StatelessWidget {
             onPressed: selectedIndex == groups.length - 1
                 ? null
                 : () => onSelectGroup(groups[selectedIndex + 1]),
-            icon: const Icon(Icons.chevron_right),
+            icon: const Icon(LucideIcons.chevronRight),
             tooltip: '下一个片区',
           ),
         ],
@@ -1111,7 +1125,10 @@ class _PlanGroupControls extends StatelessWidget {
                   minimumSize: const Size(74, 40),
                   padding: const EdgeInsets.symmetric(horizontal: 12),
                 ),
-                icon: Icon(showMap ? Icons.map : Icons.map_outlined, size: 18),
+                icon: Icon(
+                  showMap ? LucideIcons.map : LucideIcons.map,
+                  size: 18,
+                ),
                 label: Text(showMap ? '收起地图' : '地图'),
               ),
             ],
@@ -1184,7 +1201,7 @@ class _SortOrderControl extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(horizontal: 10),
                       child: Row(
                         children: [
-                          const Icon(Icons.sort_outlined, size: 18),
+                          const Icon(LucideIcons.arrowUpDown, size: 18),
                           const SizedBox(width: 6),
                           Expanded(
                             child: Text(
@@ -1198,7 +1215,7 @@ class _SortOrderControl extends StatelessWidget {
                               ),
                             ),
                           ),
-                          const Icon(Icons.expand_more, size: 18),
+                          const Icon(LucideIcons.chevronDown, size: 18),
                         ],
                       ),
                     ),
@@ -1206,12 +1223,12 @@ class _SortOrderControl extends StatelessWidget {
                 },
                 menuChildren: [
                   MenuItemButton(
-                    leadingIcon: const Icon(Icons.format_list_numbered),
+                    leadingIcon: const Icon(LucideIcons.listOrdered),
                     onPressed: () => onChanged(PointSortMode.plan),
                     child: const Text('默认计划顺序'),
                   ),
                   MenuItemButton(
-                    leadingIcon: const Icon(Icons.near_me_outlined),
+                    leadingIcon: const Icon(LucideIcons.navigation),
                     onPressed: () => onChanged(PointSortMode.distance),
                     child: const Text('按距离当前位置'),
                   ),
@@ -1233,7 +1250,7 @@ class _SortOrderControl extends StatelessWidget {
                   width: 40,
                   height: 40,
                   child: Icon(
-                    descending ? Icons.south_outlined : Icons.north_outlined,
+                    descending ? LucideIcons.arrowDown : LucideIcons.arrowUp,
                     size: 18,
                   ),
                 ),
@@ -1440,8 +1457,8 @@ class _PlanInlineMapState extends State<_PlanInlineMap> {
                   icon: widget.isLocating
                       ? null
                       : widget.showVirtualLocation
-                      ? Icons.my_location
-                      : Icons.my_location_outlined,
+                      ? LucideIcons.locateFixed
+                      : LucideIcons.locateFixed,
                   onTap: widget.isLocating
                       ? null
                       : widget.onToggleVirtualLocation,
@@ -1569,7 +1586,7 @@ class _MapPointMarker extends StatelessWidget {
         ],
       ),
       child: Icon(
-        completed ? Icons.check : Icons.place,
+        completed ? LucideIcons.check : LucideIcons.mapPin,
         size: selected ? 19 : 15,
         color: Colors.white,
       ),
@@ -1660,7 +1677,7 @@ class _EmptyPlanCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(Icons.inventory_2_rounded, color: AppColors.accent),
+              Icon(LucideIcons.package, color: AppColors.accent),
               const SizedBox(width: 10),
               Text(
                 '还没有点位',
@@ -1685,7 +1702,7 @@ class _EmptyPlanCard extends StatelessWidget {
                 minimumSize: const Size.fromHeight(46),
                 padding: const EdgeInsets.symmetric(horizontal: 16),
               ),
-              icon: const Icon(Icons.add_location_alt_outlined, size: 20),
+              icon: const Icon(LucideIcons.mapPinPlus, size: 20),
               label: const Text('添加点位'),
             ),
           ),
@@ -1838,10 +1855,7 @@ class _WorkHeader extends StatelessWidget {
               color: AppColors.surfaceMuted,
               borderRadius: BorderRadius.circular(8),
             ),
-            child: Icon(
-              Icons.movie_filter_outlined,
-              color: AppColors.accentDark,
-            ),
+            child: Icon(LucideIcons.clapperboard, color: AppColors.accentDark),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -1978,8 +1992,8 @@ class _PlanPointTile extends StatelessWidget {
                     : onComplete,
                 icon: Icon(
                   status == VisitStatus.completed
-                      ? Icons.restart_alt
-                      : Icons.check_outlined,
+                      ? LucideIcons.rotateCcw
+                      : LucideIcons.check,
                 ),
               ),
               IconButton(
@@ -1991,7 +2005,7 @@ class _PlanPointTile extends StatelessWidget {
                   child: Stack(
                     clipBehavior: Clip.none,
                     children: [
-                      const Center(child: Icon(Icons.photo_camera_outlined)),
+                      const Center(child: Icon(LucideIcons.camera)),
                       if (recordCount > 0)
                         const Positioned(
                           top: -5,
@@ -2015,19 +2029,19 @@ class _PlanPointTile extends StatelessWidget {
         background: AppColors.accent,
         foreground: Colors.white,
         border: AppColors.accent,
-        icon: Icons.flag,
+        icon: LucideIcons.flag,
       ),
       VisitStatus.completed => _PointStatusColors(
         background: AppColors.surfaceMuted,
         foreground: AppColors.textSecondary,
         border: AppColors.border,
-        icon: Icons.check_circle_outline,
+        icon: LucideIcons.circleCheckBig,
       ),
       VisitStatus.pending => _PointStatusColors(
         background: AppColors.surfaceMuted,
         foreground: AppColors.accentDark,
         border: AppColors.border,
-        icon: Icons.place_outlined,
+        icon: LucideIcons.mapPin,
       ),
     };
   }
@@ -2089,11 +2103,7 @@ class _PointRecordBadge extends StatelessWidget {
           ),
         ],
       ),
-      child: Icon(
-        Icons.photo_library_outlined,
-        size: 10,
-        color: AppColors.accentDark,
-      ),
+      child: Icon(LucideIcons.images, size: 10, color: AppColors.accentDark),
     );
   }
 }

--- a/lib/plan/point_manager_screen.dart
+++ b/lib/plan/point_manager_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -124,7 +125,7 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
               IconButton(
                 tooltip: '片区管理',
                 onPressed: _openGroupManager,
-                icon: const Icon(Icons.account_tree_outlined),
+                icon: const Icon(LucideIcons.network),
               ),
             if (!_isSaving && _plan.points.isNotEmpty)
               IconButton(
@@ -138,14 +139,14 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
                         height: 20,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Icon(Icons.download_for_offline_outlined),
+                    : const Icon(LucideIcons.cloudDownload),
               ),
             if (!_isSaving && _plan.points.isNotEmpty)
               IconButton(
                 tooltip: _selectionMode ? '退出多选' : '多选',
                 onPressed: _toggleSelectionMode,
                 icon: Icon(
-                  _selectionMode ? Icons.close : Icons.checklist_rtl_outlined,
+                  _selectionMode ? LucideIcons.x : LucideIcons.listChecks,
                 ),
               ),
           ],
@@ -631,6 +632,7 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       onMoveToGroup: _movePointToGroup,
       onCreateGroup: _createGroupFromPicker,
       onEditPoint: () => _editPoint(currentPoint),
+      onDelete: _deletePoint,
       navigationApp: widget.settings.navigationApp,
       settings: widget.settings,
     );
@@ -655,6 +657,28 @@ class _PointManagerScreenState extends State<PointManagerScreen> {
       _didUpdate = true;
       _selectedPointIds.clear();
       _selectionMode = false;
+    });
+  }
+
+  Future<void> _deletePoint(PilgrimagePoint point) async {
+    final updatedPlan = await widget.repository.deletePointFromPlan(
+      planId: _plan.id,
+      pointId: point.id,
+    );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _plan = updatedPlan;
+      _selectedPointIds.remove(point.id);
+      if (_selectedPointIds.isEmpty) {
+        _selectionMode = false;
+      }
+      final groups = _groups;
+      if (_selectedGroupIndex >= groups.length) {
+        _selectedGroupIndex = groups.isEmpty ? 0 : groups.length - 1;
+      }
+      _didUpdate = true;
     });
   }
 
@@ -1160,7 +1184,7 @@ class _PlanManagerHeader extends StatelessWidget {
               IconButton(
                 tooltip: '上一个片区',
                 onPressed: selectionMode ? null : onPreviousGroup,
-                icon: const Icon(Icons.chevron_left),
+                icon: const Icon(LucideIcons.chevronLeft),
               ),
               Expanded(
                 child: FilledButton.tonal(
@@ -1182,7 +1206,7 @@ class _PlanManagerHeader extends StatelessWidget {
               IconButton(
                 tooltip: '下一个片区',
                 onPressed: selectionMode ? null : onNextGroup,
-                icon: const Icon(Icons.chevron_right),
+                icon: const Icon(LucideIcons.chevronRight),
               ),
             ],
           ),
@@ -1207,7 +1231,11 @@ class _PlanManagerHeader extends StatelessWidget {
                         padding: const EdgeInsets.fromLTRB(12, 0, 8, 0),
                         child: Row(
                           children: [
-                            Icon(Icons.flag, size: 18, color: AppColors.accent),
+                            Icon(
+                              LucideIcons.flag,
+                              size: 18,
+                              color: AppColors.accent,
+                            ),
                             const SizedBox(width: 8),
                             Expanded(
                               child: Text(
@@ -1232,7 +1260,7 @@ class _PlanManagerHeader extends StatelessWidget {
                               ),
                             ),
                             Icon(
-                              Icons.chevron_right,
+                              LucideIcons.chevronRight,
                               size: 18,
                               color: AppColors.textSecondary,
                             ),
@@ -1347,7 +1375,7 @@ class _UngroupedActionRow extends StatelessWidget {
       children: [
         Expanded(
           child: _HeaderPillButton(
-            icon: Icons.auto_fix_high_outlined,
+            icon: LucideIcons.wandSparkles,
             label: '最近分配',
             onTap: () => onNearestAssign(),
           ),
@@ -1355,7 +1383,7 @@ class _UngroupedActionRow extends StatelessWidget {
         const SizedBox(width: 8),
         Expanded(
           child: _HeaderPillButton(
-            icon: Icons.select_all_outlined,
+            icon: LucideIcons.scan,
             label: '框选分配',
             onTap: () => onBoxAssign(),
           ),
@@ -1528,7 +1556,7 @@ class _GroupOrderModeButtonState extends State<_GroupOrderModeButton> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Icon(
-                  Icons.swap_vert,
+                  LucideIcons.arrowUpDown,
                   size: 16,
                   color: widget.enabled
                       ? AppColors.textPrimary
@@ -1542,7 +1570,7 @@ class _GroupOrderModeButtonState extends State<_GroupOrderModeButton> {
                 ),
                 const SizedBox(width: 2),
                 Icon(
-                  _isOpen ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
+                  _isOpen ? LucideIcons.chevronUp : LucideIcons.chevronDown,
                   size: 16,
                   color: widget.enabled
                       ? AppColors.textPrimary
@@ -1581,7 +1609,11 @@ class _GroupOrderModeButtonState extends State<_GroupOrderModeButton> {
                       key: ValueKey('point-manager-order-option-${option.$3}'),
                       onPressed: () => widget.onSelected(option.$1),
                       leadingIcon: option.$1 == widget.mode
-                          ? Icon(Icons.check, color: accentColor, size: 18)
+                          ? Icon(
+                              LucideIcons.check,
+                              color: accentColor,
+                              size: 18,
+                            )
                           : const SizedBox(width: 18),
                       style: ButtonStyle(
                         minimumSize: const WidgetStatePropertyAll(Size(0, 42)),
@@ -1757,7 +1789,7 @@ class _PointManagerTile extends StatelessWidget {
                   key: ValueKey('point-manager-actions-${point.id}'),
                   tooltip: '点位操作',
                   enabled: !isBusy,
-                  icon: const Icon(Icons.more_vert),
+                  icon: const Icon(LucideIcons.ellipsisVertical),
                   position: PopupMenuPosition.under,
                   offset: const Offset(0, 6),
                   elevation: 8,
@@ -1789,7 +1821,7 @@ class _PointManagerTile extends StatelessWidget {
                       height: 42,
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: const _PointActionRow(
-                        icon: Icons.drive_file_move_outlined,
+                        icon: LucideIcons.folderInput,
                         label: '移动到片区',
                       ),
                     ),
@@ -1799,7 +1831,7 @@ class _PointManagerTile extends StatelessWidget {
                         height: 42,
                         padding: const EdgeInsets.symmetric(horizontal: 8),
                         child: const _PointActionRow(
-                          icon: Icons.flag_outlined,
+                          icon: LucideIcons.flag,
                           label: '设为当前目标',
                         ),
                       ),
@@ -1809,8 +1841,8 @@ class _PointManagerTile extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: _PointActionRow(
                         icon: status == VisitStatus.completed
-                            ? Icons.restart_alt
-                            : Icons.check_outlined,
+                            ? LucideIcons.rotateCcw
+                            : LucideIcons.check,
                         label: status == VisitStatus.completed
                             ? '取消完成'
                             : '标记完成',
@@ -1822,7 +1854,7 @@ class _PointManagerTile extends StatelessWidget {
                       height: 42,
                       padding: const EdgeInsets.symmetric(horizontal: 8),
                       child: const _PointActionRow(
-                        icon: Icons.delete_outline,
+                        icon: LucideIcons.trash2,
                         label: '删除点位',
                         destructive: true,
                       ),
@@ -1958,7 +1990,7 @@ class _PointLeadingControl extends StatelessWidget {
       child: SizedBox(
         width: 42,
         child: Center(
-          child: Icon(Icons.drag_indicator, color: AppColors.textSecondary),
+          child: Icon(LucideIcons.gripVertical, color: AppColors.textSecondary),
         ),
       ),
     );
@@ -2017,8 +2049,8 @@ class _BatchActionBar extends StatelessWidget {
                       : onSelectAll,
                   icon: Icon(
                     allSelected
-                        ? Icons.check_box
-                        : Icons.check_box_outline_blank,
+                        ? LucideIcons.squareCheckBig
+                        : LucideIcons.square,
                   ),
                 ),
                 Text(
@@ -2027,22 +2059,22 @@ class _BatchActionBar extends StatelessWidget {
                 ),
                 const Spacer(),
                 _BatchActionButton(
-                  icon: Icons.drive_file_move_outlined,
+                  icon: LucideIcons.folderInput,
                   label: '移动',
                   onPressed: isBusy || !hasSelection ? null : onMove,
                 ),
                 _BatchActionButton(
-                  icon: Icons.check_outlined,
+                  icon: LucideIcons.check,
                   label: '完成',
                   onPressed: isBusy || !hasSelection ? null : onComplete,
                 ),
                 _BatchActionButton(
-                  icon: Icons.restart_alt,
+                  icon: LucideIcons.rotateCcw,
                   label: '重置',
                   onPressed: isBusy || !hasSelection ? null : onReopen,
                 ),
                 _BatchActionButton(
-                  icon: Icons.delete_outline,
+                  icon: LucideIcons.trash2,
                   label: '删除',
                   color: AppColors.error,
                   onPressed: isBusy || !hasSelection ? null : onDelete,
@@ -2265,14 +2297,14 @@ class _GroupAnchorMapPickerScreenState
                         _manualPickMode = !_manualPickMode;
                       });
                     },
-                    icon: Icons.ads_click_outlined,
+                    icon: LucideIcons.mousePointerClick,
                   ),
                   const SizedBox(height: 8),
                   _MapToolButton(
                     tooltip: '输入经纬度',
                     selected: false,
                     onTap: _showCoordinateInput,
-                    icon: Icons.edit_location_alt_outlined,
+                    icon: LucideIcons.mapPinPen,
                   ),
                 ],
               ),
@@ -2402,7 +2434,7 @@ class _AnchorPointMarker extends StatelessWidget {
           width: selected ? 2 : 1,
         ),
       ),
-      icon: const Icon(Icons.place, size: 21),
+      icon: const Icon(LucideIcons.mapPin, size: 21),
     );
   }
 }
@@ -2418,7 +2450,7 @@ class _ManualAnchorMarker extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: Colors.white, width: 3),
       ),
-      child: const Icon(Icons.add_location_alt, color: Colors.white),
+      child: const Icon(LucideIcons.mapPinPlus, color: Colors.white),
     );
   }
 }
@@ -2486,7 +2518,7 @@ class _AnchorSelectionCard extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(Icons.flag_outlined, color: AppColors.accent, size: 28),
+          Icon(LucideIcons.flag, color: AppColors.accent, size: 28),
           const SizedBox(width: 12),
           Expanded(
             child: Column(

--- a/lib/plan/reference_cache_progress_dialog.dart
+++ b/lib/plan/reference_cache_progress_dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../widgets/app_status_banner.dart';
@@ -183,7 +184,7 @@ class _CacheBannerCard extends StatelessWidget {
     return AppStatusBanner(
       key: bannerKey,
       kind: kind,
-      icon: status == _CacheDialogStatus.running ? Icons.cached_outlined : null,
+      icon: status == _CacheDialogStatus.running ? LucideIcons.refreshCw : null,
       title: _titleFor(status),
       subtitle: status == _CacheDialogStatus.running
           ? null
@@ -211,7 +212,7 @@ class _CacheBannerCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Icon(
-                  Icons.info_outline,
+                  LucideIcons.info,
                   size: 15,
                   color: AppColors.textSecondary,
                 ),

--- a/lib/plan/work_manager_screen.dart
+++ b/lib/plan/work_manager_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../data/bangumi_api_client.dart';
@@ -211,7 +212,7 @@ class _AddWorkPanel extends StatelessWidget {
             Expanded(
               child: _AddWorkAction(
                 key: const ValueKey('work-manager-bangumi-work'),
-                icon: Icons.search_rounded,
+                icon: LucideIcons.search,
                 title: '从Bangumi添加',
                 subtitle: '自动获取信息',
                 onTap: onBangumi,
@@ -226,7 +227,7 @@ class _AddWorkPanel extends StatelessWidget {
             Expanded(
               child: _AddWorkAction(
                 key: const ValueKey('work-manager-manual-work'),
-                icon: Icons.edit_rounded,
+                icon: LucideIcons.edit,
                 title: '手动添加作品',
                 subtitle: '未收录时使用',
                 onTap: onManual,
@@ -405,7 +406,7 @@ class _WorkManageCardState extends State<_WorkManageCard> {
             key: ValueKey('work-manage-more-${work.id}'),
             tooltip: '更多操作',
             enabled: !widget.disabled,
-            icon: const Icon(Icons.more_horiz),
+            icon: const Icon(LucideIcons.ellipsis),
             iconSize: 20,
             padding: EdgeInsets.zero,
             position: PopupMenuPosition.under,
@@ -437,11 +438,7 @@ class _WorkManageCardState extends State<_WorkManageCard> {
                 padding: const EdgeInsets.symmetric(horizontal: 12),
                 child: Row(
                   children: [
-                    Icon(
-                      Icons.delete_outline,
-                      size: 18,
-                      color: AppColors.error,
-                    ),
+                    Icon(LucideIcons.trash2, size: 18, color: AppColors.error),
                     const SizedBox(width: 9),
                     Text(
                       '删除作品',
@@ -544,7 +541,7 @@ class _EmptyWorkPanel extends StatelessWidget {
         children: [
           Row(
             children: [
-              Icon(Icons.movie_filter_outlined, color: AppColors.accent),
+              Icon(LucideIcons.clapperboard, color: AppColors.accent),
               const SizedBox(width: 8),
               Text(
                 '还没有作品',

--- a/lib/plan_transfer/import_export_screen.dart
+++ b/lib/plan_transfer/import_export_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:file_selector/file_selector.dart' as file_selector;
 
 import '../app_theme.dart';
@@ -78,7 +79,7 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
             _PlanExportSummary(plan: widget.plan),
             const SizedBox(height: 16),
             _SectionTitle(
-              icon: Icons.import_export_outlined,
+              icon: LucideIcons.import,
               title: '导入',
               subtitle: _usesExternalIosImport
                   ? '从文件、聊天、浏览器或网盘等位置用 MiriaGo 打开 .sjhplan。'
@@ -87,10 +88,10 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
             const SizedBox(height: 10),
             _ActionTile(
               icon: _importing
-                  ? Icons.hourglass_empty_outlined
+                  ? LucideIcons.hourglass
                   : _usesExternalIosImport
-                  ? Icons.open_in_new_outlined
-                  : Icons.import_export_outlined,
+                  ? LucideIcons.externalLink
+                  : LucideIcons.import,
               title: _importing
                   ? '读取中...'
                   : _usesExternalIosImport
@@ -106,7 +107,7 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
             ),
             const SizedBox(height: 20),
             _SectionTitle(
-              icon: Icons.inventory_2_outlined,
+              icon: LucideIcons.package,
               title: 'MiriaGo 数据包',
               subtitle: '新版 .sjhplan，内部为 zip，包含 manifest.json。',
             ),
@@ -129,15 +130,13 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
             ),
             const SizedBox(height: 20),
             _SectionTitle(
-              icon: Icons.map_outlined,
+              icon: LucideIcons.map,
               title: 'Google My Maps',
               subtitle: '导出点位 CSV。图片写成链接，可按 Type 列设置样式。',
             ),
             const SizedBox(height: 10),
             _ActionTile(
-              icon: _exporting
-                  ? Icons.hourglass_empty_outlined
-                  : Icons.table_chart_outlined,
+              icon: _exporting ? LucideIcons.hourglass : LucideIcons.table2,
               title: '导出 My Maps CSV',
               subtitle: '前 6 列贴近示例格式，作品、集数、来源等拆成独立列。',
               enabled: !_exporting && !_importing,
@@ -158,7 +157,7 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
         appStatusSnackBar(
           kind: AppStatusBannerKind.running,
           title: '已取消导出',
-          icon: Icons.cancel_outlined,
+          icon: LucideIcons.circleX,
         ),
       );
     }
@@ -410,7 +409,7 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
       appStatusSnackBar(
         kind: AppStatusBannerKind.running,
         title: '正在导出...',
-        icon: Icons.ios_share_outlined,
+        icon: LucideIcons.share2,
       ),
     );
     try {
@@ -423,7 +422,7 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
           appStatusSnackBar(
             kind: AppStatusBannerKind.running,
             title: '已取消导出',
-            icon: Icons.cancel_outlined,
+            icon: LucideIcons.circleX,
           ),
         );
         return;
@@ -437,7 +436,7 @@ class _ImportExportScreenState extends State<ImportExportScreen> {
         appStatusSnackBar(
           kind: AppStatusBannerKind.running,
           title: '已取消导出',
-          icon: Icons.cancel_outlined,
+          icon: LucideIcons.circleX,
         ),
       );
     } on _ExportAbortedException {
@@ -550,7 +549,7 @@ class _PlanExportSummary extends StatelessWidget {
               color: AppColors.accent.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(8),
             ),
-            child: Icon(Icons.archive_outlined, color: AppColors.accentDark),
+            child: Icon(LucideIcons.archive, color: AppColors.accentDark),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -665,23 +664,31 @@ class _BackupOptions extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          SegmentedButton<PlanExportV2Mode>(
-            segments: const [
-              ButtonSegment(
-                value: PlanExportV2Mode.planOnly,
-                icon: Icon(Icons.route_outlined),
-                label: Text('纯计划'),
-              ),
-              ButtonSegment(
-                value: PlanExportV2Mode.planWithRecords,
-                icon: Icon(Icons.collections_bookmark_outlined),
-                label: Text('计划+记录'),
-              ),
-            ],
-            selected: {mode},
-            onSelectionChanged: exporting
-                ? null
-                : (values) => onModeChanged(values.first),
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final textScale = MediaQuery.textScalerOf(context).scale(1);
+              return SegmentedButton<PlanExportV2Mode>(
+                direction: constraints.maxWidth < 260 * textScale
+                    ? Axis.vertical
+                    : Axis.horizontal,
+                segments: const [
+                  ButtonSegment(
+                    value: PlanExportV2Mode.planOnly,
+                    icon: Icon(LucideIcons.route),
+                    label: Text('纯计划'),
+                  ),
+                  ButtonSegment(
+                    value: PlanExportV2Mode.planWithRecords,
+                    icon: Icon(LucideIcons.folders),
+                    label: Text('计划+记录'),
+                  ),
+                ],
+                selected: {mode},
+                onSelectionChanged: exporting
+                    ? null
+                    : (values) => onModeChanged(values.first),
+              );
+            },
           ),
           const SizedBox(height: 10),
           SwitchListTile(
@@ -708,7 +715,7 @@ class _BackupOptions extends StatelessWidget {
                     height: 16,
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
-                : const Icon(Icons.ios_share_outlined, size: 18),
+                : const Icon(LucideIcons.share2, size: 18),
             label: Text(exporting ? '导出中...' : '导出 MiriaGo 数据包'),
           ),
         ],
@@ -737,11 +744,7 @@ class _ExportSizeEstimateRow extends StatelessWidget {
             child: CircularProgressIndicator(strokeWidth: 2),
           )
         else
-          Icon(
-            Icons.inventory_2_outlined,
-            size: 18,
-            color: AppColors.textSecondary,
-          ),
+          Icon(LucideIcons.package, size: 18, color: AppColors.textSecondary),
         const SizedBox(width: 8),
         Expanded(
           child: Text(
@@ -822,7 +825,7 @@ class _ActionTile extends StatelessWidget {
                 ),
               ),
               Icon(
-                Icons.chevron_right,
+                LucideIcons.chevronRight,
                 color: enabled ? AppColors.textSecondary : AppColors.border,
               ),
             ],

--- a/lib/plan_transfer/plan_import_preview_screen.dart
+++ b/lib/plan_transfer/plan_import_preview_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
@@ -46,13 +47,13 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
           _StatsGrid(importPackage: _package),
           const SizedBox(height: 18),
           _SectionTitle(
-            icon: Icons.fact_check_outlined,
+            icon: LucideIcons.listChecks,
             title: '选择导入内容',
             subtitle: '导入前不会修改当前数据。',
           ),
           const SizedBox(height: 10),
           _ImportOptionTile(
-            icon: Icons.route_outlined,
+            icon: LucideIcons.route,
             title: '计划结构',
             subtitle: '作品、片区、点位、完成状态和当前目标。',
             value: true,
@@ -61,7 +62,7 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
           ),
           const SizedBox(height: 8),
           _ImportOptionTile(
-            icon: Icons.collections_bookmark_outlined,
+            icon: LucideIcons.folders,
             title: '拍摄记录',
             subtitle: _package.isLegacyJson
                 ? 'v1 文件不包含照片资源，仅导入计划结构。'
@@ -74,7 +75,7 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
           ),
           const SizedBox(height: 8),
           _ImportOptionTile(
-            icon: Icons.photo_library_outlined,
+            icon: LucideIcons.images,
             title: '图片和资源文件',
             subtitle: _assetImportSubtitle,
             value: _includeAssets,
@@ -87,7 +88,7 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
           if (_package.warnings.isNotEmpty) ...[
             const SizedBox(height: 18),
             _SectionTitle(
-              icon: Icons.warning_amber_outlined,
+              icon: LucideIcons.triangleAlert,
               title: '包内提示',
               subtitle: '导出时记录的缺失或兼容信息。',
             ),
@@ -118,7 +119,7 @@ class _PlanImportPreviewScreenState extends State<PlanImportPreviewScreen> {
                     height: 16,
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
-                : const Icon(Icons.download_done_outlined),
+                : const Icon(LucideIcons.download),
             label: Text(_importing ? '导入中...' : '导入所选内容'),
           ),
         ),
@@ -204,10 +205,7 @@ class _PackageHeader extends StatelessWidget {
               color: AppColors.accent.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(8),
             ),
-            child: Icon(
-              Icons.inventory_2_outlined,
-              color: AppColors.accentDark,
-            ),
+            child: Icon(LucideIcons.package, color: AppColors.accentDark),
           ),
           const SizedBox(width: 12),
           Expanded(

--- a/lib/point_detail/point_detail_sheet.dart
+++ b/lib/point_detail/point_detail_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:image_picker/image_picker.dart';
 
 import '../app_theme.dart';
@@ -14,7 +15,9 @@ import '../plan/plan_group_utils.dart';
 import '../records/visit_record_photo_stub.dart'
     if (dart.library.io) '../records/visit_record_photo_io.dart';
 import '../widgets/copyable_text.dart';
+import '../widgets/confirm_action_dialog.dart';
 import '../widgets/image_viewer_screen.dart';
+import '../widgets/responsive_button.dart';
 import '../plan/reference_image_status.dart';
 import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
@@ -38,6 +41,7 @@ class PointDetailSheet extends StatelessWidget {
     this.onOpenRecords,
     this.onOpenRecord,
     this.onEditPoint,
+    this.onDelete,
     this.navigationApp = NavigationApp.googleMaps,
     this.navigationLauncher = const MapNavigationLauncher(),
     this.settings = const AppSettings(),
@@ -65,6 +69,7 @@ class PointDetailSheet extends StatelessWidget {
   final VoidCallback? onOpenRecords;
   final ValueChanged<PilgrimageVisitRecord>? onOpenRecord;
   final VoidCallback? onEditPoint;
+  final Future<void> Function(PilgrimagePoint point)? onDelete;
   final NavigationApp navigationApp;
   final MapNavigationLauncher navigationLauncher;
   final AppSettings settings;
@@ -92,6 +97,7 @@ class PointDetailSheet extends StatelessWidget {
     VoidCallback? onOpenRecords,
     ValueChanged<PilgrimageVisitRecord>? onOpenRecord,
     VoidCallback? onEditPoint,
+    Future<void> Function(PilgrimagePoint point)? onDelete,
     NavigationApp navigationApp = NavigationApp.googleMaps,
     AppSettings settings = const AppSettings(),
     PilgrimagePlanController? planController,
@@ -118,6 +124,7 @@ class PointDetailSheet extends StatelessWidget {
           onOpenRecords: onOpenRecords,
           onOpenRecord: onOpenRecord,
           onEditPoint: onEditPoint,
+          onDelete: onDelete,
           navigationApp: navigationApp,
           settings: settings,
           planController: planController,
@@ -137,7 +144,7 @@ class PointDetailSheet extends StatelessWidget {
     messenger.showStatusSnack(
       kind: AppStatusBannerKind.running,
       title: '正在替换参考图...',
-      icon: Icons.swap_horiz_outlined,
+      icon: LucideIcons.arrowLeftRight,
     );
     final stored = await storeUserReferenceImage(
       sourcePath: picked.path,
@@ -186,6 +193,41 @@ class PointDetailSheet extends StatelessWidget {
       return;
     }
     await _showPlanMoveGroupSheet(context, moveToGroup);
+  }
+
+  Future<void> _deletePoint(BuildContext context) async {
+    final deletePoint = onDelete;
+    if (deletePoint == null) {
+      return;
+    }
+
+    final confirmed = await showConfirmActionDialog(
+      context,
+      title: '删除点位',
+      message: '将从计划中删除“${point.name}”。',
+      confirmLabel: '删除点位',
+      destructive: true,
+      notice: '删除后无法撤销',
+      emphasizedValues: [point.name],
+    );
+    if (!confirmed || !context.mounted) {
+      return;
+    }
+
+    try {
+      await deletePoint(point);
+      if (context.mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (_) {
+      if (!context.mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.error,
+        title: '删除点位失败，请稍后重试。',
+      );
+    }
   }
 
   Future<void> _showPlanMoveGroupSheet(
@@ -258,7 +300,46 @@ class PointDetailSheet extends StatelessWidget {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          _StatusBadge(status: status),
+                          Row(
+                            children: [
+                              _StatusBadge(status: status),
+                              const Spacer(),
+                              if (onDelete != null)
+                                Tooltip(
+                                  message: '删除点位',
+                                  child: Semantics(
+                                    button: true,
+                                    label: '删除点位',
+                                    child: IconButton(
+                                      key: const ValueKey(
+                                        'point-detail-delete',
+                                      ),
+                                      onPressed: () => _deletePoint(context),
+                                      style: IconButton.styleFrom(
+                                        fixedSize: const Size(36, 36),
+                                        minimumSize: const Size(36, 36),
+                                        maximumSize: const Size(36, 36),
+                                        padding: EdgeInsets.zero,
+                                        tapTargetSize:
+                                            MaterialTapTargetSize.shrinkWrap,
+                                        visualDensity: VisualDensity.compact,
+                                      ),
+                                      constraints:
+                                          const BoxConstraints.tightFor(
+                                            width: 36,
+                                            height: 36,
+                                          ),
+                                      padding: EdgeInsets.zero,
+                                      icon: Icon(
+                                        LucideIcons.trash2,
+                                        size: 18,
+                                        color: AppColors.error,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          ),
                           const SizedBox(height: 8),
                           CopyableText(
                             text: point.name,
@@ -289,19 +370,19 @@ class PointDetailSheet extends StatelessWidget {
                 ),
                 const SizedBox(height: 16),
                 _InfoRow(
-                  icon: Icons.movie_filter_outlined,
+                  icon: LucideIcons.clapperboard,
                   label: '作品',
                   value: '${point.work.title} / ${point.work.subtitle}',
                 ),
                 const SizedBox(height: 8),
                 _InfoRow(
-                  icon: Icons.local_movies_outlined,
+                  icon: LucideIcons.film,
                   label: '场景',
                   value: point.displayEpisodeLabel,
                 ),
                 const SizedBox(height: 8),
                 _InfoRow(
-                  icon: Icons.location_on_outlined,
+                  icon: LucideIcons.mapPin,
                   label: '坐标',
                   value: point.hasCoordinate
                       ? '${point.position.latitude.toStringAsFixed(5)}, ${point.position.longitude.toStringAsFixed(5)}'
@@ -317,20 +398,20 @@ class PointDetailSheet extends StatelessWidget {
                 ),
                 const SizedBox(height: 8),
                 _InfoRow(
-                  icon: Icons.image_outlined,
+                  icon: LucideIcons.image,
                   label: '参考',
                   value: point.referenceLabel,
                 ),
                 const SizedBox(height: 8),
                 _InfoRow(
-                  icon: Icons.source_outlined,
+                  icon: LucideIcons.fileCode,
                   label: '来源',
                   value: _sourceText,
                 ),
                 if (point.sourceId != null) ...[
                   const SizedBox(height: 8),
                   _InfoRow(
-                    icon: Icons.tag_outlined,
+                    icon: LucideIcons.tag,
                     label: 'ID',
                     value: point.sourceId!,
                   ),
@@ -338,7 +419,7 @@ class PointDetailSheet extends StatelessWidget {
                 if (point.sourceUrl != null) ...[
                   const SizedBox(height: 8),
                   _InfoRow(
-                    icon: Icons.link_outlined,
+                    icon: LucideIcons.link,
                     label: '链接',
                     value: point.sourceUrl!,
                   ),
@@ -346,7 +427,7 @@ class PointDetailSheet extends StatelessWidget {
                 if (point.note?.trim().isNotEmpty == true) ...[
                   const SizedBox(height: 8),
                   _InfoRow(
-                    icon: Icons.sticky_note_2_outlined,
+                    icon: LucideIcons.stickyNote,
                     label: '备注',
                     value: point.note!,
                   ),
@@ -415,17 +496,17 @@ class PointDetailSheet extends StatelessWidget {
     return switch (status) {
       VisitStatus.completed => _PointStatusAction(
         label: '撤回打卡',
-        icon: Icons.replay_outlined,
+        icon: LucideIcons.undo2,
         onTap: onComplete!,
       ),
       VisitStatus.current => _PointStatusAction(
         label: '标记完成',
-        icon: Icons.check_circle_outline,
+        icon: LucideIcons.circleCheckBig,
         onTap: onComplete!,
       ),
       VisitStatus.pending => _PointStatusAction(
         label: '标记完成',
-        icon: Icons.check_circle_outline,
+        icon: LucideIcons.circleCheckBig,
         onTap: onComplete!,
       ),
     };
@@ -485,21 +566,23 @@ class _PointDetailActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final primaryActions = <Widget>[
-      Expanded(
-        child: FilledButton.icon(
-          key: const ValueKey('point-detail-in-app-navigation-button'),
-          onPressed: onOpenNavigation,
-          icon: const Icon(Icons.near_me_outlined, size: 18),
-          label: Text(onOpenNavigation == null ? '坐标待补充' : '导航'),
+      FilledButton(
+        key: const ValueKey('point-detail-in-app-navigation-button'),
+        onPressed: onOpenNavigation,
+        child: ResponsiveButtonContent(
+          icon: LucideIcons.navigation,
+          label: onOpenNavigation == null ? '坐标待补充' : '导航',
+          semanticLabel: '应用内导航',
         ),
       ),
       if (scope == PointDetailActionScope.visit && onOpenCamera != null) ...[
-        const SizedBox(width: 8),
-        Expanded(
-          child: OutlinedButton.icon(
-            onPressed: onOpenCamera,
-            icon: const Icon(Icons.photo_camera_outlined, size: 18),
-            label: const Text('拍摄参考'),
+        OutlinedButton(
+          onPressed: onOpenCamera,
+          child: const ResponsiveButtonContent(
+            icon: LucideIcons.camera,
+            label: '拍摄参考',
+            shortLabel: '拍摄',
+            semanticLabel: '拍摄参考',
           ),
         ),
       ],
@@ -507,23 +590,25 @@ class _PointDetailActions extends StatelessWidget {
 
     final managementActions = <Widget>[
       if (scope != PointDetailActionScope.assign && onSetCurrent != null)
-        Expanded(
-          child: OutlinedButton.icon(
-            onPressed: status == VisitStatus.current ? null : onSetCurrent,
-            icon: const Icon(Icons.flag_outlined, size: 18),
-            label: const Text('设为当前'),
+        OutlinedButton(
+          onPressed: status == VisitStatus.current ? null : onSetCurrent,
+          child: const ResponsiveButtonContent(
+            icon: LucideIcons.flag,
+            label: '设为当前',
+            shortLabel: '当前',
+            semanticLabel: '设为当前目标',
           ),
         ),
       if (scope != PointDetailActionScope.assign && statusAction != null) ...[
-        if (onSetCurrent != null) const SizedBox(width: 8),
-        Expanded(
-          child: OutlinedButton.icon(
-            onPressed: () {
-              Navigator.of(context).pop();
-              statusAction!.onTap();
-            },
-            icon: Icon(statusAction!.icon, size: 18),
-            label: Text(statusAction!.label),
+        OutlinedButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+            statusAction!.onTap();
+          },
+          child: ResponsiveButtonContent(
+            icon: statusAction!.icon,
+            label: statusAction!.label,
+            semanticLabel: statusAction!.label,
           ),
         ),
       ],
@@ -531,10 +616,10 @@ class _PointDetailActions extends StatelessWidget {
 
     return Column(
       children: [
-        Row(children: primaryActions),
+        _buildActionRow(primaryActions),
         if (managementActions.isNotEmpty) ...[
           const SizedBox(height: 8),
-          Row(children: managementActions),
+          _buildActionRow(managementActions),
         ],
         if (onEditPoint != null) ...[
           const SizedBox(height: 8),
@@ -543,13 +628,20 @@ class _PointDetailActions extends StatelessWidget {
             child: OutlinedButton.icon(
               key: const ValueKey('point-detail-edit'),
               onPressed: onEditPoint,
-              icon: const Icon(Icons.edit_outlined, size: 18),
+              icon: const Icon(LucideIcons.edit, size: 18),
               label: const Text('编辑点位'),
             ),
           ),
         ],
       ],
     );
+  }
+
+  Widget _buildActionRow(List<Widget> actions) {
+    if (actions.length == 1) {
+      return SizedBox(width: double.infinity, child: actions.single);
+    }
+    return ResponsiveTwoButtonRow(first: actions[0], second: actions[1]);
   }
 }
 
@@ -611,11 +703,7 @@ class _ReferenceColumn extends StatelessWidget {
                   localPath: point.referenceThumbnailPath,
                   imageUrl: remoteImageUrl,
                   fit: BoxFit.cover,
-                  placeholder: Icon(
-                    Icons.image_outlined,
-                    color: color,
-                    size: 28,
-                  ),
+                  placeholder: Icon(LucideIcons.image, color: color, size: 28),
                 ),
               ),
             ),
@@ -658,11 +746,7 @@ class _GroupInfoRow extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Icon(
-          Icons.grid_view_outlined,
-          color: AppColors.textSecondary,
-          size: 19,
-        ),
+        Icon(LucideIcons.grid2X2, color: AppColors.textSecondary, size: 19),
         const SizedBox(width: 8),
         SizedBox(
           width: 42,
@@ -831,11 +915,7 @@ class _PointRecordsPreview extends StatelessWidget {
       children: [
         Row(
           children: [
-            Icon(
-              Icons.collections_bookmark_outlined,
-              color: AppColors.textSecondary,
-              size: 18,
-            ),
+            Icon(LucideIcons.folders, color: AppColors.textSecondary, size: 18),
             const SizedBox(width: 6),
             Text(
               '本点记录 ${records.length}',
@@ -849,7 +929,7 @@ class _PointRecordsPreview extends StatelessWidget {
             if (onOpenRecords != null)
               TextButton.icon(
                 onPressed: onOpenRecords,
-                icon: const Icon(Icons.chevron_right, size: 18),
+                icon: const Icon(LucideIcons.chevronRight, size: 18),
                 label: const Text('全部'),
               ),
           ],

--- a/lib/records/comparison_export_config_editor.dart
+++ b/lib/records/comparison_export_config_editor.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import 'comparison_export_config.dart';
@@ -28,10 +29,6 @@ class ComparisonExportConfigEditor extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _CurrentConfigSummary(config: config),
-        const SizedBox(height: 18),
-        const _SectionDivider(),
-        const SizedBox(height: 18),
         const _SectionLabel('外观'),
         const SizedBox(height: 12),
         ComparisonAppearanceSection(
@@ -102,6 +99,7 @@ class ComparisonAppearanceSection extends StatelessWidget {
         SliderTheme(
           data: SliderTheme.of(context).copyWith(
             trackHeight: 4,
+            tickMarkShape: SliderTickMarkShape.noTickMark,
             thumbShape: const RoundSliderThumbShape(
               enabledThumbRadius: 7,
               pressedElevation: 3,
@@ -183,67 +181,6 @@ class ComparisonAppearanceSection extends StatelessWidget {
           onChanged: (value) => onChanged(config.copyWith(showLabels: value)),
         ),
       ],
-    );
-  }
-}
-
-class _CurrentConfigSummary extends StatelessWidget {
-  const _CurrentConfigSummary({required this.config});
-
-  final ComparisonExportConfig config;
-
-  @override
-  Widget build(BuildContext context) {
-    final borderLabel = config.borderWidthPercent == 0
-        ? '无边框'
-        : '${config.borderWidthPercent.toStringAsFixed(1)}% 边框';
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const _SectionLabel('当前配置'),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            _SummaryChip(
-              label: config.outputWidth == ComparisonOutputWidth.auto
-                  ? '自动宽度'
-                  : config.outputWidth.label,
-            ),
-            _SummaryChip(label: borderLabel),
-            _SummaryChip(label: config.showLabels ? '显示标签' : '隐藏标签'),
-          ],
-        ),
-      ],
-    );
-  }
-}
-
-class _SummaryChip extends StatelessWidget {
-  const _SummaryChip({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      decoration: BoxDecoration(
-        color: AppColors.surfaceMuted,
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: AppColors.border),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: AppColors.textSecondary,
-          fontSize: 12,
-          fontWeight: FontWeight.w600,
-          letterSpacing: 0,
-        ),
-      ),
     );
   }
 }
@@ -601,12 +538,12 @@ class _MetadataFilterChip extends StatelessWidget {
 
 IconData _metadataFieldIcon(ComparisonMetadataField field) {
   return switch (field) {
-    ComparisonMetadataField.capturedAt => Icons.access_time_rounded,
-    ComparisonMetadataField.pointName => Icons.place_rounded,
-    ComparisonMetadataField.workTitle => Icons.article_rounded,
-    ComparisonMetadataField.episodeLabel => Icons.landscape_outlined,
-    ComparisonMetadataField.coordinates => Icons.my_location_rounded,
-    ComparisonMetadataField.anitabiId => Icons.badge_outlined,
+    ComparisonMetadataField.capturedAt => LucideIcons.clock,
+    ComparisonMetadataField.pointName => LucideIcons.mapPin,
+    ComparisonMetadataField.workTitle => LucideIcons.fileText,
+    ComparisonMetadataField.episodeLabel => LucideIcons.mountain,
+    ComparisonMetadataField.coordinates => LucideIcons.locateFixed,
+    ComparisonMetadataField.anitabiId => LucideIcons.badge,
   };
 }
 
@@ -699,7 +636,7 @@ class _ColorOption extends StatelessWidget {
                   ),
                   child: selected
                       ? Icon(
-                          Icons.check,
+                          LucideIcons.check,
                           key: const ValueKey('selected'),
                           size: 14,
                           color: color.computeLuminance() > 0.55

--- a/lib/records/comparison_export_sheet.dart
+++ b/lib/records/comparison_export_sheet.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../data/pilgrimage_repository.dart';
 import '../plan/pilgrimage_models.dart';
 import '../widgets/image_viewer_screen.dart';
+import '../widgets/responsive_button.dart';
 import '../widgets/snackbar_helper.dart';
 import 'comparison_export_config.dart';
 import 'comparison_export_config_editor.dart';
@@ -202,7 +204,7 @@ class _SheetHeader extends StatelessWidget {
           IconButton(
             tooltip: '关闭',
             onPressed: exporting ? null : () => Navigator.of(context).pop(),
-            icon: const Icon(Icons.close),
+            icon: const Icon(LucideIcons.x),
           ),
         ],
       ),
@@ -230,36 +232,34 @@ class _SheetFooter extends StatelessWidget {
       ),
       child: Padding(
         padding: EdgeInsets.fromLTRB(20, 12, 20, 12 + bottomInset),
-        child: Row(
-          children: [
-            Expanded(
-              child: OutlinedButton(
-                onPressed: exporting ? null : () => Navigator.of(context).pop(),
-                child: const Text('取消'),
-              ),
+        child: ResponsiveTwoButtonRow(
+          spacing: 12,
+          stackBelowWidth: 250,
+          first: OutlinedButton(
+            onPressed: exporting ? null : () => Navigator.of(context).pop(),
+            child: const Text('取消'),
+          ),
+          second: FilledButton(
+            onPressed: exporting ? null : onExport,
+            style: FilledButton.styleFrom(
+              minimumSize: const Size.fromHeight(46),
             ),
-            const SizedBox(width: 12),
-            Expanded(
-              flex: 2,
-              child: FilledButton.icon(
-                onPressed: exporting ? null : onExport,
-                icon: exporting
-                    ? const SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: Colors.white,
-                        ),
-                      )
-                    : const Icon(Icons.download, size: 18),
-                label: Text(exporting ? '导出中...' : '导出'),
-                style: FilledButton.styleFrom(
-                  minimumSize: const Size.fromHeight(46),
-                ),
-              ),
-            ),
-          ],
+            child: exporting
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                : const ResponsiveButtonContent(
+                    icon: LucideIcons.download,
+                    label: '导出对比图',
+                    shortLabel: '导出',
+                    semanticLabel: '导出对比图',
+                  ),
+          ),
         ),
       ),
     );

--- a/lib/records/point_visit_records_screen.dart
+++ b/lib/records/point_visit_records_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../plan/pilgrimage_models.dart';
@@ -113,10 +114,7 @@ class _PointRecordsHeader extends StatelessWidget {
               color: AppColors.accent.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(8),
             ),
-            child: Icon(
-              Icons.collections_bookmark_outlined,
-              color: AppColors.accent,
-            ),
+            child: Icon(LucideIcons.folders, color: AppColors.accent),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -194,11 +192,7 @@ class _EmptyPointRecords extends StatelessWidget {
       ),
       child: Column(
         children: [
-          Icon(
-            Icons.photo_library_outlined,
-            color: AppColors.textSecondary,
-            size: 34,
-          ),
+          Icon(LucideIcons.images, color: AppColors.textSecondary, size: 34),
           SizedBox(height: 10),
           Text(
             '这个点位还没有拍摄记录',
@@ -223,7 +217,7 @@ class _PointRecordsListLabel extends StatelessWidget {
       padding: EdgeInsets.zero,
       child: Row(
         children: [
-          Icon(Icons.schedule, color: AppColors.accent, size: 15),
+          Icon(LucideIcons.calendarClock, color: AppColors.accent, size: 15),
           const SizedBox(width: 6),
           Text(
             '拍摄记录',
@@ -324,12 +318,12 @@ class _PointVisitRecordCard extends StatelessWidget {
                         runSpacing: 6,
                         children: [
                           _RecordMetaChip(
-                            icon: Icons.layers_outlined,
+                            icon: LucideIcons.layers,
                             label: record.referenceMode,
                           ),
                           if (record.hasColorGrading)
                             const _RecordMetaChip(
-                              icon: Icons.auto_fix_high_outlined,
+                              icon: LucideIcons.wandSparkles,
                               label: '已调色',
                             ),
                         ],
@@ -341,7 +335,7 @@ class _PointVisitRecordCard extends StatelessWidget {
               Padding(
                 padding: EdgeInsets.only(right: 10),
                 child: Icon(
-                  Icons.chevron_right,
+                  LucideIcons.chevronRight,
                   color: AppColors.textSecondary,
                 ),
               ),

--- a/lib/records/records_screen.dart
+++ b/lib/records/records_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../plan/pilgrimage_models.dart';
@@ -82,7 +83,9 @@ class _RecordsScreenState extends State<RecordsScreen> {
                     });
                   },
             icon: Icon(
-              allSectionsExpanded ? Icons.unfold_less : Icons.unfold_more,
+              allSectionsExpanded
+                  ? LucideIcons.chevronsUp
+                  : LucideIcons.chevronsDown,
             ),
           ),
           const SizedBox(width: 16),
@@ -312,7 +315,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
           id: group.id,
           title: group.name,
           subtitle: _groupAnchorLabel(group),
-          icon: Icons.folder_outlined,
+          icon: LucideIcons.folder,
           entries: _sortEntries(entries),
         ),
       );
@@ -325,7 +328,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
           id: _ungroupedRecordFilterId,
           title: '未分组',
           subtitle: '还没有放入片区的记录',
-          icon: Icons.inventory_2_outlined,
+          icon: LucideIcons.package,
           entries: _sortEntries(ungroupedEntries),
         ),
       );
@@ -337,7 +340,7 @@ class _RecordsScreenState extends State<RecordsScreen> {
           id: _orphanRecordFilterId,
           title: '孤立记录',
           subtitle: '对应点位已不在当前计划中',
-          icon: Icons.link_off_outlined,
+          icon: LucideIcons.link2Off,
           entries: _sortEntries(orphanRecords),
         ),
       );
@@ -507,7 +510,7 @@ class _RecordFilters extends StatelessWidget {
                 backgroundColor: AppColors.surface,
                 side: BorderSide(color: AppColors.border),
               ),
-              icon: const Icon(Icons.tune),
+              icon: const Icon(LucideIcons.slidersHorizontal),
             ),
           ),
         ),
@@ -714,7 +717,11 @@ class _RecordScopeEntry extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12),
             child: Row(
               children: [
-                Icon(Icons.check_circle, color: AppColors.accent, size: 20),
+                Icon(
+                  LucideIcons.checkCircle,
+                  color: AppColors.accent,
+                  size: 20,
+                ),
                 const SizedBox(width: 10),
                 Expanded(
                   child: Text(
@@ -728,7 +735,7 @@ class _RecordScopeEntry extends StatelessWidget {
                     ),
                   ),
                 ),
-                Icon(Icons.chevron_right, color: AppColors.textSecondary),
+                Icon(LucideIcons.chevronRight, color: AppColors.textSecondary),
               ],
             ),
           ),
@@ -819,7 +826,7 @@ class _RecordScopeOptionSheetState extends State<_RecordScopeOptionSheet> {
                           key: ValueKey('records-scope-back-${widget.kind}'),
                           tooltip: '返回筛选记录',
                           onPressed: () => Navigator.of(context).pop(),
-                          icon: const Icon(Icons.chevron_left),
+                          icon: const Icon(LucideIcons.chevronLeft),
                         ),
                       ),
                     ),
@@ -1141,7 +1148,11 @@ class _RecordStatusPickerState extends State<_RecordStatusPicker> {
                 padding: const EdgeInsets.symmetric(horizontal: 10),
                 child: Row(
                   children: [
-                    Icon(Icons.filter_alt, color: AppColors.accent, size: 20),
+                    Icon(
+                      LucideIcons.listFilter,
+                      color: AppColors.accent,
+                      size: 20,
+                    ),
                     const SizedBox(width: 6),
                     Expanded(
                       child: Text(
@@ -1156,9 +1167,7 @@ class _RecordStatusPickerState extends State<_RecordStatusPicker> {
                       ),
                     ),
                     Icon(
-                      _isOpen
-                          ? Icons.keyboard_arrow_up
-                          : Icons.keyboard_arrow_down,
+                      _isOpen ? LucideIcons.chevronUp : LucideIcons.chevronDown,
                       color: AppColors.accentDark,
                       size: 20,
                     ),
@@ -1197,7 +1206,11 @@ class _RecordStatusPickerState extends State<_RecordStatusPicker> {
                       key: ValueKey('records-status-option-${option.$3}'),
                       onPressed: () => widget.onSelected(option.$1),
                       leadingIcon: option.$1 == widget.statusFilter
-                          ? Icon(Icons.check, color: accentColor, size: 19)
+                          ? Icon(
+                              LucideIcons.check,
+                              color: accentColor,
+                              size: 19,
+                            )
                           : const SizedBox(width: 19),
                       style: ButtonStyle(
                         minimumSize: const WidgetStatePropertyAll(
@@ -1308,7 +1321,7 @@ class _ExpandedRecordFiltersState extends State<_ExpandedRecordFilters> {
             letterSpacing: 0,
           ),
           prefixIcon: const Icon(
-            Icons.search,
+            LucideIcons.search,
             key: ValueKey('records-search-prefix-icon'),
             size: 20,
           ),
@@ -1345,7 +1358,7 @@ class _ExpandedRecordFiltersState extends State<_ExpandedRecordFilters> {
                       widget.onSearchChanged('');
                       setState(() {});
                     },
-                    icon: const Icon(Icons.close, size: 18),
+                    icon: const Icon(LucideIcons.x, size: 18),
                   ),
           ),
         ),
@@ -1567,14 +1580,18 @@ class _RecordGroupHeaderState extends State<_RecordGroupHeader> {
                         const SizedBox(width: 8),
                         Icon(
                           widget.expanded
-                              ? Icons.expand_less
-                              : Icons.expand_more,
+                              ? LucideIcons.chevronUp
+                              : LucideIcons.chevronDown,
                           color: AppColors.textSecondary,
                           size: 24,
                         ),
                       ],
                     ),
                   ),
+                  if (!widget.expanded)
+                    AppHairline(
+                      key: ValueKey('records-group-divider-${section.id}'),
+                    ),
                 ],
               ),
             ),
@@ -1586,12 +1603,12 @@ class _RecordGroupHeaderState extends State<_RecordGroupHeader> {
 
   IconData _sectionIcon(_RecordGroup section, bool expanded) {
     if (section.id == _ungroupedRecordFilterId) {
-      return expanded ? Icons.inventory_2 : Icons.inventory_2_outlined;
+      return expanded ? LucideIcons.package : LucideIcons.package;
     }
     if (section.id == _orphanRecordFilterId) {
-      return Icons.link_off;
+      return LucideIcons.link2Off;
     }
-    return expanded ? Icons.location_on : Icons.location_on_outlined;
+    return expanded ? LucideIcons.mapPin : LucideIcons.mapPin;
   }
 }
 
@@ -1806,7 +1823,7 @@ class _VisitRecordCard extends StatelessWidget {
                         key: ValueKey('record-captured-row-${record.id}'),
                         children: [
                           Icon(
-                            Icons.schedule_outlined,
+                            LucideIcons.calendarClock,
                             size: 15,
                             color: AppColors.textSecondary,
                           ),
@@ -1826,7 +1843,7 @@ class _VisitRecordCard extends StatelessWidget {
                   ),
                 ),
                 Icon(
-                  Icons.chevron_right,
+                  LucideIcons.chevronRight,
                   color: AppColors.textSecondary,
                   size: 25,
                 ),
@@ -1860,10 +1877,10 @@ class _EmptyRecords extends StatelessWidget {
     final hasFilterResult =
         hasAnyRecords && !hasSearchQuery && hasActiveFilters;
     final icon = hasSearchQuery
-        ? Icons.search_off_rounded
+        ? LucideIcons.searchX
         : hasFilterResult
-        ? Icons.filter_alt_off_rounded
-        : Icons.photo_library_outlined;
+        ? LucideIcons.listFilter
+        : LucideIcons.images;
     final title = hasSearchQuery
         ? '没有找到相关记录'
         : hasFilterResult
@@ -1924,14 +1941,14 @@ class _EmptyRecords extends StatelessWidget {
                         TextButton.icon(
                           key: const ValueKey('records-empty-clear-search'),
                           onPressed: onClearSearch,
-                          icon: const Icon(Icons.close, size: 18),
+                          icon: const Icon(LucideIcons.x, size: 18),
                           label: const Text('清除搜索'),
                         ),
                       if (hasActiveFilters)
                         TextButton.icon(
                           key: const ValueKey('records-empty-reset-filters'),
                           onPressed: onResetFilters,
-                          icon: const Icon(Icons.filter_alt_off, size: 18),
+                          icon: const Icon(LucideIcons.listFilter, size: 18),
                           label: const Text('重置筛选'),
                         ),
                     ],

--- a/lib/records/visit_record_detail_screen.dart
+++ b/lib/records/visit_record_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter/foundation.dart';
 
 import '../app_theme.dart';
@@ -73,7 +74,7 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
           IconButton(
             tooltip: '删除记录',
             onPressed: () => _confirmDelete(context),
-            icon: const Icon(Icons.delete_outline),
+            icon: const Icon(LucideIcons.trash2),
           ),
         ],
       ),
@@ -101,18 +102,18 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
                 : () => _showPointDetail(resolvedPoint),
             children: [
               _DetailRow(
-                icon: Icons.schedule,
+                icon: LucideIcons.calendarClock,
                 label: '拍摄时间',
                 value: _formatDateTime(_record.capturedAt),
               ),
               if (resolvedPoint != null) ...[
                 _DetailRow(
-                  icon: Icons.grid_view_outlined,
+                  icon: LucideIcons.grid2X2,
                   label: '片区',
                   value: _groupName(resolvedPoint, group),
                 ),
                 _DetailRow(
-                  icon: Icons.local_movies_outlined,
+                  icon: LucideIcons.film,
                   label: '场景',
                   value: resolvedPoint.displayEpisodeLabel,
                 ),
@@ -157,6 +158,7 @@ class _VisitRecordDetailScreenState extends State<VisitRecordDetailScreen> {
       records: widget.controller.recordsForPoint(point.id),
       onOpenRecords: () => _openPointRecords(point),
       onOpenRecord: _openRelatedRecord,
+      onDelete: widget.controller.deletePoint,
       navigationApp: widget.settings.navigationApp,
       settings: widget.settings,
     );
@@ -596,7 +598,7 @@ class _OrphanRecordNotice extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(Icons.link_off_outlined, color: AppColors.warning, size: 19),
+          Icon(LucideIcons.link2Off, color: AppColors.warning, size: 19),
           SizedBox(width: 8),
           Expanded(
             child: Text(
@@ -672,7 +674,7 @@ class _RecordInfoDashboard extends StatelessWidget {
                   if (onHeaderTap != null) ...[
                     const SizedBox(width: 12),
                     Icon(
-                      Icons.chevron_right,
+                      LucideIcons.chevronRight,
                       color: AppColors.textSecondary,
                       size: 24,
                     ),
@@ -739,7 +741,7 @@ class _RecordActionPanel extends StatelessWidget {
           children: [
             Expanded(
               child: _RecordAction(
-                icon: Icons.auto_fix_high_outlined,
+                icon: LucideIcons.wandSparkles,
                 title: '自动调色',
                 subtitle: '优化巡礼照片',
                 onTap: onColorGrading,
@@ -753,7 +755,7 @@ class _RecordActionPanel extends StatelessWidget {
             ),
             Expanded(
               child: _RecordAction(
-                icon: Icons.ios_share_outlined,
+                icon: LucideIcons.share2,
                 title: '导出对比图',
                 subtitle: '生成分享图片',
                 onTap: onExportComparison,

--- a/lib/records/visit_record_photo_io.dart
+++ b/lib/records/visit_record_photo_io.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../data/app_managed_file_paths_io.dart';
@@ -86,7 +87,7 @@ class VisitRecordPhoto extends StatelessWidget {
     return ColoredBox(
       color: AppColors.surfaceMuted,
       child: Center(
-        child: Icon(Icons.broken_image_outlined, color: AppColors.accentDark),
+        child: Icon(LucideIcons.imageOff, color: AppColors.accentDark),
       ),
     );
   }

--- a/lib/records/visit_record_photo_stub.dart
+++ b/lib/records/visit_record_photo_stub.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../desktop/desktop_asset_image.dart';
@@ -77,7 +78,7 @@ class _PhotoPlaceholder extends StatelessWidget {
   Widget build(BuildContext context) {
     return ColoredBox(
       color: AppColors.surfaceMuted,
-      child: const Center(child: Icon(Icons.photo_outlined)),
+      child: const Center(child: Icon(LucideIcons.image)),
     );
   }
 }

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:http/http.dart' as http;
 
 import '../app_theme.dart';
@@ -24,6 +25,7 @@ import '../widgets/app_scaled_route.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/copyable_text.dart';
 import '../widgets/input_dialog.dart';
+import '../widgets/responsive_button.dart';
 import '../widgets/snackbar_helper.dart';
 
 bool get _showCacheCleanupSettings => isReferenceCacheCleanupSupported;
@@ -125,7 +127,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             key: const ValueKey('settings-reset-button'),
             tooltip: '恢复初始设置',
             onPressed: _confirmResetSettings,
-            icon: const Icon(Icons.restart_alt_outlined),
+            icon: const Icon(LucideIcons.rotateCcw),
           ),
           const SizedBox(width: 16),
         ],
@@ -136,7 +138,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           _SettingsCard(
             key: const ValueKey('settings-appearance-card'),
             header: _SettingsCardHeader(
-              icon: Icons.palette_outlined,
+              icon: LucideIcons.palette,
               title: '外观设置',
               subtitle: '主题色、深浅色、缩放、显示等',
               onTap: () => _pushDetail(
@@ -150,7 +152,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               _SummaryGrid(
                 children: [
                   _SummaryTile(
-                    icon: Icons.circle,
+                    icon: LucideIcons.circle,
                     title: '主题色',
                     value: settings.themePalette.label,
                     swatch: _ThemeSwatch(
@@ -165,7 +167,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     ),
                   ),
                   _SummaryTile(
-                    icon: Icons.dark_mode_outlined,
+                    icon: LucideIcons.moon,
                     title: '主题模式',
                     value: settings.themeMode.label,
                     onTap: () => _pushDetail(
@@ -182,7 +184,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 12),
           _SettingsCard(
             header: _SettingsCardHeader(
-              icon: Icons.photo_camera_outlined,
+              icon: LucideIcons.camera,
               title: '拍摄设置',
               subtitle: '照片比例、参考图比例、备份等',
               onTap: () => _pushDetail(
@@ -197,7 +199,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               _SummaryGrid(
                 children: [
                   _SummaryTile(
-                    icon: Icons.crop_outlined,
+                    icon: LucideIcons.crop,
                     title: '拍摄图片比例',
                     value: settings.cameraCaptureAspectRatio.label,
                     onTap: () => _pushDetail(
@@ -209,7 +211,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     ),
                   ),
                   _SummaryTile(
-                    icon: Icons.view_sidebar_outlined,
+                    icon: LucideIcons.panelRight,
                     title: '相机缩放',
                     value:
                         '${settings.cameraMinZoom.toStringAsFixed(1)}x-${settings.cameraMaxZoom.toStringAsFixed(1)}x',
@@ -225,7 +227,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               if (_shouldShowMobileGallerySettings)
                 _SummarySwitchTile(
-                  icon: Icons.cloud_upload_outlined,
+                  icon: LucideIcons.cloudUpload,
                   title: '照片备份',
                   subtitle: '保存巡礼照片到相册',
                   value: settings.saveVisitPhotoToGallery,
@@ -240,7 +242,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 12),
           _SettingsCard(
             header: _SettingsCardHeader(
-              icon: Icons.compare_arrows_outlined,
+              icon: LucideIcons.arrowLeftRight,
               title: '对比图设置',
               subtitle: '导出样式、自动保存到相册',
               onTap: () => _openComparisonStyleSettings(settings),
@@ -248,7 +250,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             children: [
               if (_shouldShowMobileGallerySettings) ...[
                 _SummarySwitchTile(
-                  icon: Icons.photo_library_outlined,
+                  icon: LucideIcons.images,
                   title: '自动保存对比图',
                   subtitle: '保存记录时保存到相册',
                   value: settings.autoSaveComparisonToGallery,
@@ -264,7 +266,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 12),
           _SettingsCard(
             header: _SettingsCardHeader(
-              icon: Icons.map_outlined,
+              icon: LucideIcons.map,
               title: '数据源设置',
               subtitle: '地图源、图片源等',
               onTap: () => _pushDetail(
@@ -279,7 +281,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 12),
           _SettingsCard(
             header: _SettingsCardHeader(
-              icon: Icons.layers_outlined,
+              icon: LucideIcons.layers,
               title: '地图显示',
               subtitle: '点位、片区、聚合与缩略图',
               onTap: () => _pushDetail(
@@ -294,7 +296,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             const SizedBox(height: 12),
             _SettingsCard(
               header: _SettingsCardHeader(
-                icon: Icons.cleaning_services_outlined,
+                icon: LucideIcons.brushCleaning,
                 title: '清除缓存',
                 subtitle: '完整参考图缓存',
                 onTap: () => _pushDetail(
@@ -307,7 +309,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           if (_shouldShowDesktopSection) ...[
             _SettingsCard(
               header: _SettingsCardHeader(
-                icon: Icons.desktop_windows_outlined,
+                icon: LucideIcons.monitor,
                 title: '桌面端',
                 subtitle: '启动器、数据目录等',
                 onTap: () => _pushDetail(
@@ -322,7 +324,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ],
           _SettingsCard(
             header: _SettingsCardHeader(
-              icon: Icons.info_outline,
+              icon: LucideIcons.info,
               title: '关于 MiriaGo',
               subtitle: '版本信息、开源许可等',
               onTap: () => _pushDetail(
@@ -540,7 +542,7 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                     Expanded(
                       child: _ModeButton(
                         key: const ValueKey('appearance-theme-mode-light'),
-                        icon: Icons.wb_sunny_outlined,
+                        icon: LucideIcons.sun,
                         label: '浅色',
                         selected: settings.themeMode == AppThemeMode.light,
                         onTap: () {
@@ -554,7 +556,7 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                     Expanded(
                       child: _ModeButton(
                         key: const ValueKey('appearance-theme-mode-dark'),
-                        icon: Icons.dark_mode_outlined,
+                        icon: LucideIcons.moon,
                         label: '深色',
                         selected: settings.themeMode == AppThemeMode.dark,
                         onTap: () {
@@ -568,7 +570,7 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                     Expanded(
                       child: _ModeButton(
                         key: const ValueKey('appearance-theme-mode-system'),
-                        icon: Icons.phone_iphone_outlined,
+                        icon: LucideIcons.smartphone,
                         label: '跟随系统',
                         selected: settings.themeMode == AppThemeMode.system,
                         onTap: () {
@@ -644,7 +646,7 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                 Row(
                   children: [
                     Icon(
-                      Icons.fit_screen_outlined,
+                      LucideIcons.maximize,
                       color: AppColors.textSecondary,
                       size: 20,
                     ),
@@ -737,7 +739,7 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                 key: const ValueKey('plan-group-progress-toggle'),
                 contentPadding: EdgeInsets.zero,
                 secondary: Icon(
-                  Icons.linear_scale_outlined,
+                  LucideIcons.moveHorizontal,
                   color: AppColors.textSecondary,
                 ),
                 title: Text('显示片区进度条', style: _titleTextStyle),
@@ -762,7 +764,7 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
                 ),
                 contentPadding: EdgeInsets.zero,
                 secondary: Icon(
-                  Icons.touch_app_outlined,
+                  LucideIcons.pointer,
                   color: AppColors.textSecondary,
                 ),
                 title: Text('点击空白收回计划操作', style: _titleTextStyle),
@@ -1040,7 +1042,7 @@ class _CameraSettingsPageState extends State<_CameraSettingsPage> {
               SwitchListTile(
                 contentPadding: EdgeInsets.zero,
                 secondary: Icon(
-                  Icons.cloud_upload_outlined,
+                  LucideIcons.cloudUpload,
                   color: AppColors.textSecondary,
                 ),
                 title: Text('保存巡礼照片到相册', style: _titleTextStyle),
@@ -1121,7 +1123,7 @@ class _PhotoLocationStrategyDropdown extends StatelessWidget {
         menuMaxHeight: appScaledOverlayExtent(settings, 360),
         icon: const Padding(
           padding: EdgeInsets.only(right: 8),
-          child: Icon(Icons.keyboard_arrow_down_rounded, size: 20),
+          child: Icon(LucideIcons.chevronDown, size: 20),
         ),
         selectedItemBuilder: (context) => [
           for (final strategy in _strategies)
@@ -1266,7 +1268,7 @@ class _PhotoLocationStrategyDropdownItemState
             ),
             if (selected) ...[
               const SizedBox(width: 8),
-              Icon(Icons.check_circle, color: AppColors.accent, size: 18),
+              Icon(LucideIcons.checkCircle, color: AppColors.accent, size: 18),
             ],
           ],
         ),
@@ -1472,7 +1474,7 @@ class _AnitabiServiceSettingsPageState
         >[
           (
             key: const ValueKey('anitabi-site-base-url'),
-            icon: Icons.public_outlined,
+            icon: LucideIcons.globe,
             title: '主站地址',
             value: settings.anitabiSiteBaseUrl,
             onSaved: (value) =>
@@ -1480,7 +1482,7 @@ class _AnitabiServiceSettingsPageState
           ),
           (
             key: const ValueKey('anitabi-static-data-base-url'),
-            icon: Icons.data_object_outlined,
+            icon: LucideIcons.braces,
             title: '静态地图数据',
             value: settings.anitabiStaticDataBaseUrl,
             onSaved: (value) =>
@@ -1488,7 +1490,7 @@ class _AnitabiServiceSettingsPageState
           ),
           (
             key: const ValueKey('anitabi-api-base-url'),
-            icon: Icons.api_outlined,
+            icon: LucideIcons.webhook,
             title: '数据 API',
             value: settings.anitabiApiBaseUrl,
             onSaved: (value) =>
@@ -1496,7 +1498,7 @@ class _AnitabiServiceSettingsPageState
           ),
           (
             key: const ValueKey('anitabi-official-image-base-url'),
-            icon: Icons.image_outlined,
+            icon: LucideIcons.image,
             title: '官方图片服务',
             value: settings.anitabiOfficialImageBaseUrl,
             onSaved: (value) =>
@@ -1504,7 +1506,7 @@ class _AnitabiServiceSettingsPageState
           ),
           (
             key: const ValueKey('anitabi-mirror-image-base-url'),
-            icon: Icons.cloud_outlined,
+            icon: LucideIcons.cloud,
             title: '备用图片服务',
             value: settings.anitabiMirrorImageBaseUrl,
             onSaved: (value) =>
@@ -1550,7 +1552,7 @@ class _AnitabiServiceSettingsPageState
                         dimension: 18,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Icon(Icons.network_check_outlined),
+                    : const Icon(LucideIcons.wifi),
                 label: Text(_testing ? '正在测试连接' : '测试全部连接'),
               ),
             ),
@@ -1560,7 +1562,7 @@ class _AnitabiServiceSettingsPageState
               child: OutlinedButton.icon(
                 key: const ValueKey('anitabi-service-restore-defaults'),
                 onPressed: _testing ? null : _restoreDefaults,
-                icon: const Icon(Icons.restore),
+                icon: const Icon(LucideIcons.history),
                 label: const Text('恢复默认地址'),
               ),
             ),
@@ -1753,7 +1755,7 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
             if (settings.mapTileProvider == MapTileProvider.openFreeMap) ...[
               const SizedBox(height: 12),
               _SettingsSubheading(
-                icon: Icons.layers_outlined,
+                icon: LucideIcons.layers,
                 title:
                     'OpenFreeMap 样式 ${openFreeMapStyleOption(settings.openFreeMapStyle).label}',
               ),
@@ -1773,7 +1775,7 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
             if (settings.mapTileProvider == MapTileProvider.customXyz) ...[
               const SizedBox(height: 12),
               _MapUrlRow(
-                icon: Icons.grid_3x3_outlined,
+                icon: LucideIcons.grid3X3,
                 label: settings.customXyzTileUrl.trim().isEmpty
                     ? '未设置自定义 XYZ URL'
                     : settings.customXyzTileUrl.trim(),
@@ -1793,7 +1795,7 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
                 MapTileProvider.customMapLibreStyle) ...[
               const SizedBox(height: 12),
               _MapUrlRow(
-                icon: Icons.data_object_outlined,
+                icon: LucideIcons.braces,
                 label: settings.customMapLibreStyleUrl.trim().isEmpty
                     ? '未设置 MapLibre style URL'
                     : settings.customMapLibreStyleUrl.trim(),
@@ -1818,7 +1820,7 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
             if (validateMapTileSettings(settings) != null) ...[
               const SizedBox(height: 10),
               _InfoRow(
-                icon: Icons.error_outline,
+                icon: LucideIcons.circleAlert,
                 text: validateMapTileSettings(settings)!,
               ),
             ],
@@ -1886,7 +1888,7 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
           title: '步行路径规划',
           children: [
             _MapUrlRow(
-              icon: Icons.route_outlined,
+              icon: LucideIcons.route,
               label: settings.valhallaBaseUrl,
               onTap: () => widget.showMapUrlDialog(
                 title: 'Valhalla 服务地址',
@@ -1903,36 +1905,36 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
               ),
             ),
             const SizedBox(height: 10),
-            Row(
-              children: [
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed: _testingValhalla ? null : _testValhalla,
-                    icon: _testingValhalla
-                        ? const SizedBox.square(
-                            dimension: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.wifi_tethering_outlined, size: 18),
-                    label: const Text('测试连接'),
-                  ),
+            ResponsiveTwoButtonRow(
+              first: OutlinedButton(
+                onPressed: _testingValhalla ? null : _testValhalla,
+                child: _testingValhalla
+                    ? const SizedBox.square(
+                        dimension: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const ResponsiveButtonContent(
+                        icon: LucideIcons.radio,
+                        label: '测试连接',
+                        shortLabel: '测试',
+                        semanticLabel: '测试 Valhalla 连接',
+                      ),
+              ),
+              second: OutlinedButton(
+                onPressed: settings.valhallaBaseUrl == defaultValhallaBaseUrl
+                    ? null
+                    : () => _update(
+                        settings.copyWith(
+                          valhallaBaseUrl: defaultValhallaBaseUrl,
+                        ),
+                      ),
+                child: const ResponsiveButtonContent(
+                  icon: LucideIcons.history,
+                  label: '恢复默认',
+                  shortLabel: '恢复',
+                  semanticLabel: '恢复默认 Valhalla 地址',
                 ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: OutlinedButton.icon(
-                    onPressed:
-                        settings.valhallaBaseUrl == defaultValhallaBaseUrl
-                        ? null
-                        : () => _update(
-                            settings.copyWith(
-                              valhallaBaseUrl: defaultValhallaBaseUrl,
-                            ),
-                          ),
-                    icon: const Icon(Icons.restore, size: 18),
-                    label: const Text('恢复默认'),
-                  ),
-                ),
-              ],
+              ),
             ),
             const SizedBox(height: 8),
             Text('仅发送路线坐标，不会上传计划、作品或照片信息。', style: _secondaryTextStyle),
@@ -1943,7 +1945,7 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
           title: '图片加载',
           children: [
             _NumberStepperSetting(
-              icon: Icons.download_for_offline_outlined,
+              icon: LucideIcons.cloudDownload,
               title: '图片同时请求数',
               subtitle: '用于地图缩略图显示、导入点位时缓存缩略图，以及批量缓存参考图。数值越大速度可能越快，但网络压力也更高。',
               value: settings.mapThumbnailConcurrentLoads,
@@ -2008,7 +2010,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Icon(
-                  Icons.zoom_in_outlined,
+                  LucideIcons.zoomIn,
                   color: AppColors.textSecondary,
                   size: 22,
                 ),
@@ -2086,7 +2088,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
                 key: const ValueKey('hide-completed-points-on-map-toggle'),
                 contentPadding: EdgeInsets.zero,
                 secondary: Icon(
-                  Icons.visibility_off_outlined,
+                  LucideIcons.eyeOff,
                   color: AppColors.textSecondary,
                 ),
                 title: Text('隐藏已完成点位', style: _titleTextStyle),
@@ -2105,7 +2107,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Icon(
-                  Icons.location_on_outlined,
+                  LucideIcons.mapPin,
                   color: AppColors.textSecondary,
                   size: 22,
                 ),
@@ -2143,7 +2145,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
           title: '片区范围',
           children: [
             _NumberStepperSetting(
-              icon: Icons.gesture_outlined,
+              icon: LucideIcons.hand,
               title: '片区范围半径',
               subtitle: '每个点位向外扩张的距离，用于生成地图上的片区轮廓。',
               value: settings.mapGroupAreaRadiusMeters,
@@ -2166,7 +2168,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
               child: SwitchListTile(
                 contentPadding: EdgeInsets.zero,
                 secondary: Icon(
-                  Icons.hub_outlined,
+                  LucideIcons.gitBranch,
                   color: AppColors.textSecondary,
                 ),
                 title: Text('自动聚合密集点位', style: _titleTextStyle),
@@ -2183,7 +2185,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
             if (settings.mapMarkerClusteringEnabled) ...[
               const SizedBox(height: 8),
               _NumberStepperSetting(
-                icon: Icons.blur_circular_outlined,
+                icon: LucideIcons.circleDashed,
                 title: '聚合范围',
                 subtitle: '屏幕上相距较近的点位会合并为一个带数量的聚合标记。',
                 value: settings.mapMarkerClusterRadius,
@@ -2197,7 +2199,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
               ),
               const SizedBox(height: 12),
               _NumberStepperSetting(
-                icon: Icons.zoom_in_map_outlined,
+                icon: LucideIcons.maximize,
                 title: '停止聚合级别',
                 subtitle: '地图放大超过该级别后显示每个原始点位。',
                 value: settings.mapMarkerClusterMaxZoom,
@@ -2217,7 +2219,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
           title: '地图缩略图',
           children: [
             _NumberStepperSetting(
-              icon: Icons.photo_size_select_large_outlined,
+              icon: LucideIcons.maximize,
               title: '缩略图显示阈值',
               subtitle:
                   '视图内点位不超过 ${settings.mapThumbnailVisibleThreshold} 个时显示缩略图；超过时仅显示圆点。',
@@ -2289,7 +2291,10 @@ class _CacheCleanupSettingsPageState extends State<_CacheCleanupSettingsPage> {
               return _SettingsSection(
                 title: '计划',
                 children: [
-                  const _InfoRow(icon: Icons.error_outline, text: '计划列表读取失败'),
+                  const _InfoRow(
+                    icon: LucideIcons.circleAlert,
+                    text: '计划列表读取失败',
+                  ),
                   const SizedBox(height: 12),
                   OutlinedButton.icon(
                     onPressed: () {
@@ -2297,7 +2302,7 @@ class _CacheCleanupSettingsPageState extends State<_CacheCleanupSettingsPage> {
                         _plansFuture = widget.repository.loadPlans();
                       });
                     },
-                    icon: const Icon(Icons.refresh, size: 18),
+                    icon: const Icon(LucideIcons.refreshCw, size: 18),
                     label: const Text('重试'),
                   ),
                 ],
@@ -2330,7 +2335,7 @@ class _CacheCleanupSettingsPageState extends State<_CacheCleanupSettingsPage> {
                                 ..addAll(plans.map((plan) => plan.id));
                             });
                           },
-                          icon: const Icon(Icons.select_all_outlined),
+                          icon: const Icon(LucideIcons.scan),
                         ),
                         IconButton(
                           tooltip: '清空',
@@ -2341,7 +2346,7 @@ class _CacheCleanupSettingsPageState extends State<_CacheCleanupSettingsPage> {
                                     _selectedPlanIds.clear();
                                   });
                                 },
-                          icon: const Icon(Icons.deselect_outlined),
+                          icon: const Icon(LucideIcons.square),
                         ),
                       ],
                     ),
@@ -2387,7 +2392,7 @@ class _CacheCleanupSettingsPageState extends State<_CacheCleanupSettingsPage> {
                             dimension: 18,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : const Icon(Icons.cleaning_services_outlined),
+                        : const Icon(LucideIcons.brushCleaning),
                     label: Text(
                       _busy && _total > 0
                           ? '正在清理 $_completed / $_total'
@@ -2510,18 +2515,18 @@ class _DesktopSettingsPage extends StatelessWidget {
           title: '启动器',
           children: [
             _InfoRow(
-              icon: Icons.desktop_windows_outlined,
+              icon: LucideIcons.monitor,
               text: desktopLauncherStatusText,
             ),
             if (desktopLauncherInfo != null) ...[
               const SizedBox(height: 10),
               _InfoRow(
-                icon: Icons.folder_outlined,
+                icon: LucideIcons.folder,
                 text: desktopLauncherInfo!.dataDir,
               ),
               const SizedBox(height: 10),
               _InfoRow(
-                icon: Icons.inventory_2_outlined,
+                icon: LucideIcons.package,
                 text: desktopLauncherInfo!.assetsDir,
               ),
             ],
@@ -2580,27 +2585,27 @@ class _AboutSettingsPage extends StatelessWidget {
             ),
             const SizedBox(height: 14),
             _AboutInfoTile(
-              icon: Icons.new_releases_outlined,
+              icon: LucideIcons.badge,
               label: '当前版本',
               value: appVersionLabel ?? '读取中',
             ),
             const _AboutInfoTile(
-              icon: Icons.person_outline,
+              icon: LucideIcons.user,
               label: '作者',
               value: 'BilyHurington',
             ),
             const _AboutInfoTile(
-              icon: Icons.mail_outline,
+              icon: LucideIcons.mail,
               label: '联系邮箱',
               value: 'bilyhurington@gmail.com',
             ),
             const _AboutInfoTile(
-              icon: Icons.code_outlined,
+              icon: LucideIcons.code,
               label: '开源仓库',
               value: 'github.com/BilyHurington/MiriaGo',
             ),
             const _AboutInfoTile(
-              icon: Icons.balance_outlined,
+              icon: LucideIcons.scale,
               label: '开源许可',
               value: 'MIT License',
             ),
@@ -2611,27 +2616,27 @@ class _AboutSettingsPage extends StatelessWidget {
           title: '数据与版权',
           children: [
             _AboutDataItem(
-              icon: Icons.map_outlined,
+              icon: LucideIcons.map,
               label: '地图',
               description: '可使用 OpenFreeMap、OpenStreetMap 或自定义地图服务。',
             ),
             _AboutDataItem(
-              icon: Icons.search_outlined,
+              icon: LucideIcons.search,
               label: '作品',
               description: '作品搜索数据来自 Bangumi。',
             ),
             _AboutDataItem(
-              icon: Icons.place_outlined,
+              icon: LucideIcons.mapPin,
               label: '巡礼内容',
               description: '巡礼点位与参考图来自 Anitabi。',
             ),
             _AboutDataItem(
-              icon: Icons.image_outlined,
+              icon: LucideIcons.image,
               label: '图片源',
               description: '图片源设置只影响访问域名，远端链接统一保留 Anitabi 默认格式。',
             ),
             _AboutDataItem(
-              icon: Icons.copyright_outlined,
+              icon: LucideIcons.copyright,
               label: '版权归属',
               description: '第三方数据、截图和图片版权归原平台、贡献者或权利方所有。',
               bottomSpacing: 0,
@@ -2831,7 +2836,11 @@ class _SettingsCardHeader extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 12),
-            Icon(Icons.chevron_right, color: scheme.onSurfaceVariant, size: 30),
+            Icon(
+              LucideIcons.chevronRight,
+              color: scheme.onSurfaceVariant,
+              size: 30,
+            ),
           ],
         ),
       ),
@@ -3084,7 +3093,7 @@ class _NumberStepperSetting extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             _NumberStepperIconButton(
-              icon: Icons.remove,
+              icon: LucideIcons.minus,
               tooltip: '减少',
               onTap: canDecrease
                   ? () => onChanged((value - step).clamp(min, max))
@@ -3113,7 +3122,7 @@ class _NumberStepperSetting extends StatelessWidget {
               ),
             ),
             _NumberStepperIconButton(
-              icon: Icons.add,
+              icon: LucideIcons.plus,
               tooltip: '增加',
               onTap: canIncrease
                   ? () => onChanged((value + step).clamp(min, max))
@@ -3220,7 +3229,7 @@ class _FullReferenceCacheSection extends StatelessWidget {
       title: '\u7f13\u5b58\u5185\u5bb9',
       children: [
         _CacheTargetCard(
-          icon: Icons.photo_library_outlined,
+          icon: LucideIcons.images,
           title: '\u5b8c\u6574\u53c2\u8003\u56fe\u7f13\u5b58',
           subtitle:
               '\u6e05\u9664\u76f8\u673a\u53c2\u8003\u548c\u5927\u56fe\u67e5\u770b\u4f7f\u7528\u7684\u5b8c\u6574\u53c2\u8003\u56fe\u3002\u7f29\u7565\u56fe\u7f13\u5b58\u4f1a\u4fdd\u7559\uff0c\u4ee5\u4fdd\u6301\u5217\u8868\u548c\u5730\u56fe\u52a0\u8f7d\u901f\u5ea6\u3002',
@@ -3481,7 +3490,7 @@ class _AspectRatioOption extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 if (selected) ...[
-                  Icon(Icons.check, size: 13, color: AppColors.onAccent),
+                  Icon(LucideIcons.check, size: 13, color: AppColors.onAccent),
                   const SizedBox(width: 4),
                 ],
                 Flexible(
@@ -3611,7 +3620,7 @@ class _CustomThemeColorOption extends StatelessWidget {
       color: Color(color.value),
       label: color.name,
       selected: selected,
-      icon: selected ? Icons.check : null,
+      icon: selected ? LucideIcons.check : null,
       onTap: onTap,
     );
   }
@@ -3636,7 +3645,7 @@ class _AddThemeColorOption extends StatelessWidget {
       color: Color(colorValue),
       label: label.trim().isEmpty ? '\u81ea\u5b9a\u4e49' : label.trim(),
       selected: selected,
-      icon: Icons.add,
+      icon: LucideIcons.plus,
       onTap: onTap,
     );
   }
@@ -4155,7 +4164,7 @@ class _ScaleStepper extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _StepperIconButton(icon: Icons.remove, onTap: onDecrease),
+          _StepperIconButton(icon: LucideIcons.minus, onTap: onDecrease),
           Container(
             width: 72,
             alignment: Alignment.center,
@@ -4173,7 +4182,7 @@ class _ScaleStepper extends StatelessWidget {
               ),
             ),
           ),
-          _StepperIconButton(icon: Icons.add, onTap: onIncrease),
+          _StepperIconButton(icon: LucideIcons.plus, onTap: onIncrease),
         ],
       ),
     );
@@ -4399,7 +4408,11 @@ class _AnitabiServiceRow extends StatelessWidget {
               ),
             ],
             const SizedBox(width: 2),
-            Icon(Icons.chevron_right, color: AppColors.textSecondary, size: 22),
+            Icon(
+              LucideIcons.chevronRight,
+              color: AppColors.textSecondary,
+              size: 22,
+            ),
           ],
         ),
       ),
@@ -4439,7 +4452,7 @@ class _AnitabiServiceEntryRow extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 6),
         child: Row(
           children: [
-            Icon(Icons.dns_outlined, color: AppColors.textSecondary),
+            Icon(LucideIcons.network, color: AppColors.textSecondary),
             const SizedBox(width: 10),
             Expanded(
               child: Column(
@@ -4467,7 +4480,11 @@ class _AnitabiServiceEntryRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 10),
-            Icon(Icons.chevron_right, color: AppColors.textSecondary, size: 22),
+            Icon(
+              LucideIcons.chevronRight,
+              color: AppColors.textSecondary,
+              size: 22,
+            ),
           ],
         ),
       ),
@@ -4506,7 +4523,7 @@ class _MapUrlRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 10),
-            Icon(Icons.edit_outlined, color: AppColors.textSecondary, size: 20),
+            Icon(LucideIcons.edit, color: AppColors.textSecondary, size: 20),
           ],
         ),
       ),
@@ -4566,7 +4583,7 @@ class _OpenFreeMapStyleGrid extends StatelessWidget {
           _CompactOptionChip(
             label: option.label,
             selected: selectedStyle == option.style,
-            icon: Icons.layers_outlined,
+            icon: LucideIcons.layers,
             onTap: () => onSelected(option.style),
           ),
       ],
@@ -4642,7 +4659,7 @@ class _CompactOptionChip extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
-              selected ? Icons.check : icon,
+              selected ? LucideIcons.check : icon,
               color: selected ? AppColors.onAccent : AppColors.textSecondary,
               size: 18,
             ),
@@ -4693,7 +4710,7 @@ class _MapSourceOptionCard extends StatelessWidget {
         child: Row(
           children: [
             Icon(
-              selected ? Icons.check : _mapProviderIcon(option.provider),
+              selected ? LucideIcons.check : _mapProviderIcon(option.provider),
               color: selected ? AppColors.onAccent : AppColors.textSecondary,
               size: 18,
             ),
@@ -4805,7 +4822,7 @@ class _NavigationAppOptionCard extends StatelessWidget {
         child: Row(
           children: [
             Icon(
-              selected ? Icons.check : _navigationAppIcon(app),
+              selected ? LucideIcons.check : _navigationAppIcon(app),
               color: selected ? AppColors.onAccent : AppColors.textSecondary,
               size: 18,
             ),
@@ -4854,19 +4871,19 @@ class _NavigationAppOptionCard extends StatelessWidget {
 
 IconData _mapProviderIcon(MapTileProvider provider) {
   return switch (provider) {
-    MapTileProvider.openFreeMap => Icons.map_outlined,
-    MapTileProvider.openStreetMap => Icons.public_outlined,
-    MapTileProvider.customXyz => Icons.grid_3x3_outlined,
-    MapTileProvider.customMapLibreStyle => Icons.data_object_outlined,
+    MapTileProvider.openFreeMap => LucideIcons.map,
+    MapTileProvider.openStreetMap => LucideIcons.globe,
+    MapTileProvider.customXyz => LucideIcons.grid3X3,
+    MapTileProvider.customMapLibreStyle => LucideIcons.braces,
   };
 }
 
 IconData _navigationAppIcon(NavigationApp app) {
   return switch (app) {
-    NavigationApp.googleMaps => Icons.explore_outlined,
-    NavigationApp.amap => Icons.near_me_outlined,
-    NavigationApp.appleMaps => Icons.map_outlined,
-    NavigationApp.baiduMaps => Icons.assistant_direction_outlined,
+    NavigationApp.googleMaps => LucideIcons.compass,
+    NavigationApp.amap => LucideIcons.navigation,
+    NavigationApp.appleMaps => LucideIcons.map,
+    NavigationApp.baiduMaps => LucideIcons.signpost,
   };
 }
 
@@ -4926,9 +4943,9 @@ String _anitabiImageSourceDescription(AppSettings settings) {
 
 IconData _anitabiImageSourceIcon(AnitabiImageSource source) {
   return switch (source) {
-    AnitabiImageSource.auto => Icons.auto_awesome_outlined,
-    AnitabiImageSource.official => Icons.image_outlined,
-    AnitabiImageSource.mirror => Icons.swap_horiz_outlined,
+    AnitabiImageSource.auto => LucideIcons.sparkles,
+    AnitabiImageSource.official => LucideIcons.image,
+    AnitabiImageSource.mirror => LucideIcons.arrowLeftRight,
   };
 }
 
@@ -5073,7 +5090,7 @@ class _ThemeSwatch extends StatelessWidget {
       child: DecoratedBox(
         decoration: BoxDecoration(color: color, shape: BoxShape.circle),
         child: selected
-            ? Icon(Icons.check, color: AppColors.onAccent, size: 18)
+            ? Icon(LucideIcons.check, color: AppColors.onAccent, size: 18)
             : null,
       ),
     );

--- a/lib/widgets/app_back_button.dart
+++ b/lib/widgets/app_back_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 class AppBackButton extends StatelessWidget {
   const AppBackButton({this.onPressed, super.key});
@@ -17,7 +18,7 @@ class AppBackButton extends StatelessWidget {
           style: IconButton.styleFrom(
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
           ),
-          icon: const Icon(Icons.arrow_back, semanticLabel: '返回'),
+          icon: const Icon(LucideIcons.arrowLeft, semanticLabel: '返回'),
         ),
       ),
     );

--- a/lib/widgets/app_status_banner.dart
+++ b/lib/widgets/app_status_banner.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 
@@ -24,42 +25,42 @@ IconData statusBannerIcon({
     return icon;
   }
   return switch (kind) {
-    AppStatusBannerKind.success => Icons.check_rounded,
-    AppStatusBannerKind.warning => Icons.warning_rounded,
-    AppStatusBannerKind.error => Icons.error_rounded,
+    AppStatusBannerKind.success => LucideIcons.check,
+    AppStatusBannerKind.warning => LucideIcons.triangleAlert,
+    AppStatusBannerKind.error => LucideIcons.circleAlert,
     AppStatusBannerKind.running => statusBannerRunningIcon(title),
   };
 }
 
 IconData statusBannerRunningIcon(String title) {
   if (title.contains('取消')) {
-    return Icons.cancel_outlined;
+    return LucideIcons.circleX;
   }
   if (title.contains('导出')) {
-    return Icons.ios_share_outlined;
+    return LucideIcons.share2;
   }
   if (title.contains('导入')) {
-    return Icons.add_location_alt_outlined;
+    return LucideIcons.mapPinPlus;
   }
   if (title.contains('替换')) {
-    return Icons.swap_horiz_outlined;
+    return LucideIcons.arrowLeftRight;
   }
   if (title.contains('比例') || title.contains('读取')) {
-    return Icons.aspect_ratio_outlined;
+    return LucideIcons.ratio;
   }
   if (title.contains('清除') || title.contains('重新加载')) {
-    return Icons.cleaning_services_outlined;
+    return LucideIcons.brushCleaning;
   }
   if (title.contains('缩略图')) {
-    return Icons.photo_library_outlined;
+    return LucideIcons.images;
   }
   if (title.contains('缓存')) {
-    return Icons.cached_outlined;
+    return LucideIcons.refreshCw;
   }
   if (title.contains('保存')) {
-    return Icons.save_outlined;
+    return LucideIcons.save;
   }
-  return Icons.hourglass_top_outlined;
+  return LucideIcons.hourglass;
 }
 
 SnackBar appStatusSnackBar({
@@ -353,10 +354,10 @@ class _StatusIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (kind == AppStatusBannerKind.warning) {
-      return Icon(Icons.warning_rounded, size: 32, color: palette.iconFill);
+      return Icon(LucideIcons.triangleAlert, size: 32, color: palette.iconFill);
     }
     if (kind == AppStatusBannerKind.error) {
-      return Icon(Icons.error_rounded, size: 32, color: palette.iconFill);
+      return Icon(LucideIcons.circleAlert, size: 32, color: palette.iconFill);
     }
     final resolved = statusBannerIcon(kind: kind, title: title, icon: icon);
     return Container(

--- a/lib/widgets/clear_anchor_selection_button.dart
+++ b/lib/widgets/clear_anchor_selection_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 class ClearAnchorSelectionButton extends StatelessWidget {
   const ClearAnchorSelectionButton({required this.onPressed, super.key});
@@ -10,7 +11,7 @@ class ClearAnchorSelectionButton extends StatelessWidget {
     return IconButton(
       tooltip: '清除选点',
       onPressed: onPressed,
-      icon: const Icon(Icons.clear),
+      icon: const Icon(LucideIcons.x),
     );
   }
 }

--- a/lib/widgets/confirm_action_dialog.dart
+++ b/lib/widgets/confirm_action_dialog.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
+import 'responsive_button.dart';
 
 Future<bool> showConfirmActionDialog(
   BuildContext context, {
@@ -122,7 +124,11 @@ class ConfirmActionDialog extends StatelessWidget {
                   ),
                   child: const Row(
                     children: [
-                      Icon(Icons.warning_rounded, color: dangerColor, size: 17),
+                      Icon(
+                        LucideIcons.triangleAlert,
+                        color: dangerColor,
+                        size: 17,
+                      ),
                       SizedBox(width: 8),
                       Text(
                         '此操作无法撤销',
@@ -277,7 +283,7 @@ class _StandardConfirmDialog extends StatelessWidget {
                     child: Row(
                       children: [
                         Icon(
-                          Icons.info_rounded,
+                          LucideIcons.info,
                           color: AppColors.accent,
                           size: 17,
                         ),
@@ -331,40 +337,35 @@ class AppDialogActionRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Expanded(
-          child: FilledButton(
-            onPressed: onCancel,
-            style: FilledButton.styleFrom(
-              foregroundColor: AppColors.textPrimary,
-              backgroundColor: AppColors.surfaceMuted,
-              minimumSize: const Size.fromHeight(48),
-              padding: const EdgeInsets.symmetric(horizontal: 10),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-            ),
-            child: _DialogActionLabel(cancelLabel),
+    return ResponsiveTwoButtonRow(
+      spacing: 10,
+      stackBelowWidth: 240,
+      first: FilledButton(
+        onPressed: onCancel,
+        style: FilledButton.styleFrom(
+          foregroundColor: AppColors.textPrimary,
+          backgroundColor: AppColors.surfaceMuted,
+          minimumSize: const Size.fromHeight(48),
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
           ),
         ),
-        const SizedBox(width: 10),
-        Expanded(
-          child: FilledButton(
-            onPressed: onConfirm,
-            style: FilledButton.styleFrom(
-              foregroundColor: Colors.white,
-              backgroundColor: confirmColor ?? AppColors.accent,
-              minimumSize: const Size.fromHeight(48),
-              padding: const EdgeInsets.symmetric(horizontal: 10),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-            ),
-            child: _DialogActionLabel(confirmLabel),
+        child: _DialogActionLabel(cancelLabel),
+      ),
+      second: FilledButton(
+        onPressed: onConfirm,
+        style: FilledButton.styleFrom(
+          foregroundColor: Colors.white,
+          backgroundColor: confirmColor ?? AppColors.accent,
+          minimumSize: const Size.fromHeight(48),
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
           ),
         ),
-      ],
+        child: _DialogActionLabel(confirmLabel),
+      ),
     );
   }
 }
@@ -376,10 +377,7 @@ class _DialogActionLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FittedBox(
-      fit: BoxFit.scaleDown,
-      child: Text(label, maxLines: 1, softWrap: false),
-    );
+    return Text(label, textAlign: TextAlign.center, maxLines: 2);
   }
 }
 

--- a/lib/widgets/copyable_text.dart
+++ b/lib/widgets/copyable_text.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter/services.dart';
 
 OverlayEntry? _activeCopyOverlay;
@@ -150,7 +151,7 @@ class _CopyOverlay extends StatelessWidget {
               color: Colors.transparent,
               child: FilledButton.tonalIcon(
                 onPressed: onCopy,
-                icon: const Icon(Icons.copy_outlined, size: 16),
+                icon: const Icon(LucideIcons.copy, size: 16),
                 label: const Text('复制'),
                 style: FilledButton.styleFrom(
                   fixedSize: const Size(82, 42),

--- a/lib/widgets/image_viewer_screen.dart
+++ b/lib/widgets/image_viewer_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
@@ -85,7 +86,7 @@ class ImageViewerScreen extends StatelessWidget {
                 onTap: () => Navigator.of(context).pop(),
                 child: const Padding(
                   padding: EdgeInsets.all(10),
-                  child: Icon(Icons.close, color: Colors.white, size: 24),
+                  child: Icon(LucideIcons.x, color: Colors.white, size: 24),
                 ),
               ),
             ),
@@ -166,7 +167,7 @@ class ImageViewerScreen extends StatelessWidget {
           messenger,
           '已取消保存',
           kind: AppStatusBannerKind.running,
-          icon: Icons.cancel_outlined,
+          icon: LucideIcons.circleX,
         );
         return;
       }
@@ -497,9 +498,9 @@ class _ImageViewerPlaceholder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final icon = switch (state) {
-      _ImageViewerPlaceholderState.loading => Icons.hourglass_empty_rounded,
-      _ImageViewerPlaceholderState.empty => Icons.image_outlined,
-      _ImageViewerPlaceholderState.unavailable => Icons.broken_image_outlined,
+      _ImageViewerPlaceholderState.loading => LucideIcons.hourglass,
+      _ImageViewerPlaceholderState.empty => LucideIcons.image,
+      _ImageViewerPlaceholderState.unavailable => LucideIcons.imageOff,
     };
     final label = switch (state) {
       _ImageViewerPlaceholderState.loading => '图片加载中',
@@ -551,7 +552,7 @@ class _WebSaveSheet extends StatelessWidget {
         children: [
           const SizedBox(height: 12),
           ListTile(
-            leading: const Icon(Icons.save_alt_outlined, color: Colors.white),
+            leading: const Icon(LucideIcons.download, color: Colors.white),
             title: const Text('保存图片', style: TextStyle(color: Colors.white)),
             onTap: onSave,
           ),
@@ -579,12 +580,12 @@ class _MobileSaveSheet extends StatelessWidget {
         children: [
           const SizedBox(height: 12),
           ListTile(
-            leading: const Icon(Icons.share_outlined, color: Colors.white),
+            leading: const Icon(LucideIcons.share, color: Colors.white),
             title: const Text('分享', style: TextStyle(color: Colors.white)),
             onTap: onShare,
           ),
           ListTile(
-            leading: const Icon(Icons.save_alt_outlined, color: Colors.white),
+            leading: const Icon(LucideIcons.download, color: Colors.white),
             title: const Text('保存到相册', style: TextStyle(color: Colors.white)),
             onTap: onSaveToGallery,
           ),

--- a/lib/widgets/input_dialog.dart
+++ b/lib/widgets/input_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import 'confirm_action_dialog.dart';
@@ -103,7 +104,7 @@ class AppDialogPasteButton extends StatelessWidget {
     return OutlinedButton.icon(
       key: const ValueKey('dialog-paste-button'),
       onPressed: onPressed,
-      icon: const Icon(Icons.content_paste_outlined, size: 16),
+      icon: const Icon(LucideIcons.clipboardPaste, size: 16),
       label: const Text('粘贴'),
       style: OutlinedButton.styleFrom(
         visualDensity: VisualDensity.compact,

--- a/lib/widgets/map_thumbnail_marker.dart
+++ b/lib/widgets/map_thumbnail_marker.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 import '../plan/pilgrimage_models.dart';
@@ -70,7 +71,7 @@ class MapThumbnailMarker extends StatelessWidget {
                     width: bubbleWidth,
                     height: bubbleHeight,
                     placeholder: Icon(
-                      imported ? Icons.check : Icons.image_outlined,
+                      imported ? LucideIcons.check : LucideIcons.image,
                       color: imported ? AppColors.textSecondary : pinColor,
                       size: selected ? 24 : 22,
                     ),

--- a/lib/widgets/reference_image_placeholder.dart
+++ b/lib/widgets/reference_image_placeholder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import '../app_theme.dart';
 
@@ -31,7 +32,7 @@ class ReferenceImagePlaceholder extends StatelessWidget {
           padding: EdgeInsets.all(compact ? 6 : 14),
           child: compact
               ? Icon(
-                  Icons.image_outlined,
+                  LucideIcons.image,
                   color: iconColor ?? AppColors.accentDark,
                   size: 28,
                 )
@@ -46,7 +47,7 @@ class ReferenceImagePlaceholder extends StatelessWidget {
                       )
                     else
                       Icon(
-                        Icons.image_outlined,
+                        LucideIcons.image,
                         color: iconColor ?? AppColors.accentDark,
                         size: 32,
                       ),

--- a/lib/widgets/responsive_button.dart
+++ b/lib/widgets/responsive_button.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+
+/// Content for buttons whose label can degrade without reducing text size.
+///
+/// The surrounding button supplies its own visual style, key, callback, and
+/// state. This widget only selects the content that fits its finite width.
+class ResponsiveButtonContent extends StatelessWidget {
+  const ResponsiveButtonContent({
+    required this.icon,
+    required this.label,
+    this.shortLabel,
+    this.semanticLabel,
+    this.iconSize = 18,
+    this.iconOnlyBelowWidth,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final String? shortLabel;
+  final String? semanticLabel;
+  final double iconSize;
+  final double? iconOnlyBelowWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final display = _displayFor(context, constraints.maxWidth);
+        final fullSemantics = semanticLabel ?? label;
+        switch (display) {
+          case _ResponsiveButtonDisplay.full:
+            return _LabelAndIcon(icon: icon, label: label, iconSize: iconSize);
+          case _ResponsiveButtonDisplay.short:
+            return _LabelAndIcon(
+              icon: icon,
+              label: shortLabel!,
+              iconSize: iconSize,
+            );
+          case _ResponsiveButtonDisplay.iconOnly:
+            return Tooltip(
+              message: fullSemantics,
+              child: Semantics(
+                label: fullSemantics,
+                child: Icon(icon, size: iconSize),
+              ),
+            );
+        }
+      },
+    );
+  }
+
+  _ResponsiveButtonDisplay _displayFor(BuildContext context, double maxWidth) {
+    if (!maxWidth.isFinite) return _ResponsiveButtonDisplay.full;
+    if (iconOnlyBelowWidth != null && maxWidth < iconOnlyBelowWidth!) {
+      return _ResponsiveButtonDisplay.iconOnly;
+    }
+
+    final fullWidth = _contentWidth(context, label);
+    if (fullWidth <= maxWidth) return _ResponsiveButtonDisplay.full;
+
+    final compactLabel = shortLabel;
+    if (compactLabel != null &&
+        _contentWidth(context, compactLabel) <= maxWidth) {
+      return _ResponsiveButtonDisplay.short;
+    }
+    return _ResponsiveButtonDisplay.iconOnly;
+  }
+
+  double _contentWidth(BuildContext context, String text) {
+    final textStyle = DefaultTextStyle.of(context).style;
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: textStyle),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout();
+    return iconSize + 8 + painter.width;
+  }
+}
+
+class _LabelAndIcon extends StatelessWidget {
+  const _LabelAndIcon({
+    required this.icon,
+    required this.label,
+    required this.iconSize,
+  });
+
+  final IconData icon;
+  final String label;
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: iconSize),
+        const SizedBox(width: 8),
+        Text(label, maxLines: 1, softWrap: false),
+      ],
+    );
+  }
+}
+
+enum _ResponsiveButtonDisplay { full, short, iconOnly }
+
+/// A two-button action area that becomes a vertical stack before it overflows.
+class ResponsiveTwoButtonRow extends StatelessWidget {
+  const ResponsiveTwoButtonRow({
+    required this.first,
+    required this.second,
+    this.spacing = 8,
+    this.minimumButtonWidth = 44,
+    this.stackBelowWidth,
+    super.key,
+  });
+
+  final Widget first;
+  final Widget second;
+  final double spacing;
+  final double minimumButtonWidth;
+  final double? stackBelowWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final textScale = MediaQuery.textScalerOf(context).scale(1);
+        final threshold =
+            (stackBelowWidth ?? minimumButtonWidth * 2 + spacing) *
+            (stackBelowWidth == null ? 1 : textScale.clamp(1, 2));
+        final stack =
+            constraints.maxWidth.isFinite && constraints.maxWidth < threshold;
+        if (stack) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              first,
+              SizedBox(height: spacing),
+              second,
+            ],
+          );
+        }
+        return Row(
+          children: [
+            Expanded(child: first),
+            SizedBox(width: spacing),
+            Expanded(child: second),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -720,6 +720,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  lucide_icons_flutter:
+    dependency: "direct main"
+    description:
+      name: lucide_icons_flutter
+      sha256: "9a2e1708ade2ab587bee5034d939686fb89820426c41b4ffb9d97a698b526ceb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.18"
   maplibre:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   flutter_map_maplibre: ^0.0.5
   maplibre: ^0.3.5
   flutter_markdown_plus: ^1.0.7
+  lucide_icons_flutter: ^3.1.18
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/app_status_banner_test.dart
+++ b/test/app_status_banner_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:miriago/app_theme.dart';
 import 'package:miriago/widgets/app_status_banner.dart';
@@ -52,7 +53,7 @@ void main() {
     expect(find.text('数据包已导出'), findsOneWidget);
     expect(find.text('已保存到本地'), findsOneWidget);
     expect(find.byType(AppStatusBanner), findsOneWidget);
-    expect(find.byIcon(Icons.check_rounded), findsOneWidget);
+    expect(find.byIcon(LucideIcons.check), findsOneWidget);
   });
 
   test('single-sentence status titles drop the trailing period', () {
@@ -83,29 +84,20 @@ void main() {
   });
 
   test('running titles infer distinct action icons', () {
-    expect(statusBannerRunningIcon('正在导出...'), Icons.ios_share_outlined);
-    expect(statusBannerRunningIcon('已取消导出'), Icons.cancel_outlined);
-    expect(statusBannerRunningIcon('正在缓存参考图...'), Icons.cached_outlined);
-    expect(statusBannerRunningIcon('正在保存记录，请稍候。'), Icons.save_outlined);
-    expect(statusBannerRunningIcon('正在替换参考图...'), Icons.swap_horiz_outlined);
-    expect(
-      statusBannerRunningIcon('正在读取参考图比例，请稍后拍摄。'),
-      Icons.aspect_ratio_outlined,
-    );
+    expect(statusBannerRunningIcon('正在导出...'), LucideIcons.share2);
+    expect(statusBannerRunningIcon('已取消导出'), LucideIcons.circleX);
+    expect(statusBannerRunningIcon('正在缓存参考图...'), LucideIcons.refreshCw);
+    expect(statusBannerRunningIcon('正在保存记录，请稍候。'), LucideIcons.save);
+    expect(statusBannerRunningIcon('正在替换参考图...'), LucideIcons.arrowLeftRight);
+    expect(statusBannerRunningIcon('正在读取参考图比例，请稍后拍摄。'), LucideIcons.ratio);
     expect(
       statusBannerRunningIcon('正在清除缓存并重新加载 Anitabi 点位...'),
-      Icons.cleaning_services_outlined,
+      LucideIcons.brushCleaning,
     );
-    expect(
-      statusBannerRunningIcon('正在导入 12 个点位...'),
-      Icons.add_location_alt_outlined,
-    );
-    expect(
-      statusBannerRunningIcon('正在缓存缩略图 8/12，成功 7'),
-      Icons.photo_library_outlined,
-    );
-    expect(statusBannerRunningIcon('已取消保存'), Icons.cancel_outlined);
-    expect(statusBannerRunningIcon('正在处理...'), Icons.hourglass_top_outlined);
+    expect(statusBannerRunningIcon('正在导入 12 个点位...'), LucideIcons.mapPinPlus);
+    expect(statusBannerRunningIcon('正在缓存缩略图 8/12，成功 7'), LucideIcons.images);
+    expect(statusBannerRunningIcon('已取消保存'), LucideIcons.circleX);
+    expect(statusBannerRunningIcon('正在处理...'), LucideIcons.hourglass);
   });
 
   testWidgets('unknown running banner uses an hourglass instead of download', (
@@ -123,8 +115,8 @@ void main() {
       ),
     );
 
-    expect(find.byIcon(Icons.hourglass_top_outlined), findsOneWidget);
-    expect(find.byIcon(Icons.download_rounded), findsNothing);
+    expect(find.byIcon(LucideIcons.hourglass), findsOneWidget);
+    expect(find.byIcon(LucideIcons.download), findsNothing);
   });
 
   testWidgets('running banner renders a custom icon when provided', (
@@ -137,13 +129,13 @@ void main() {
           body: AppStatusBanner(
             kind: AppStatusBannerKind.running,
             title: '正在导出...',
-            icon: Icons.ios_share_outlined,
+            icon: LucideIcons.share2,
           ),
         ),
       ),
     );
 
-    expect(find.byIcon(Icons.ios_share_outlined), findsOneWidget);
-    expect(find.byIcon(Icons.download_rounded), findsNothing);
+    expect(find.byIcon(LucideIcons.share2), findsOneWidget);
+    expect(find.byIcon(LucideIcons.download), findsNothing);
   });
 }

--- a/test/comparison_export_config_test.dart
+++ b/test/comparison_export_config_test.dart
@@ -139,7 +139,7 @@ void main() {
       ),
     );
 
-    expect(find.text('自动宽度'), findsOneWidget);
+    expect(find.text('自动宽度'), findsNothing);
     expect(find.text('1080px'), findsNothing);
     expect(
       tester

--- a/test/pilgrimage_plan_controller_test.dart
+++ b/test/pilgrimage_plan_controller_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:miriago/data/sample_pilgrimage_repository.dart';
+import 'package:miriago/plan/pilgrimage_models.dart';
+import 'package:miriago/plan/pilgrimage_plan_controller.dart';
+
+void main() {
+  test(
+    'deletePoint clears the removed point state and related records',
+    () async {
+      const work = PilgrimageWork(
+        id: 'work',
+        title: '测试作品',
+        subtitle: '',
+        city: '',
+        source: WorkSource.manual,
+      );
+      const point = PilgrimagePoint(
+        id: 'point',
+        work: work,
+        name: '测试点位',
+        subtitle: '',
+        position: LatLng(35, 135),
+        episodeLabel: 'EP 1',
+        referenceLabel: '手动',
+      );
+      final now = DateTime.utc(2026);
+      final plan = PilgrimagePlan(
+        id: 'plan',
+        name: '测试计划',
+        area: '',
+        works: const [work],
+        points: const [point],
+        createdAt: now,
+        updatedAt: now,
+        currentPointId: point.id,
+        completedPointIds: {point.id},
+      );
+      final repository = SamplePilgrimageRepository(plans: [plan]);
+      final controller = PilgrimagePlanController(
+        plan: plan,
+        visitRepository: repository,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.createVisitRecord(
+        point: point,
+        photoPath: 'photo.jpg',
+        referenceMode: 'manual',
+      );
+      controller.selectPoint(point);
+      expect(controller.recordsForPoint(point.id), hasLength(1));
+      expect(controller.selectedPoint?.id, point.id);
+
+      await controller.deletePoint(point);
+
+      expect(controller.pointById(point.id), isNull);
+      expect(controller.currentPoint, isNull);
+      expect(controller.selectedPoint, isNull);
+      expect(controller.completedPointIds, isEmpty);
+      expect(controller.recordsForPoint(point.id), isEmpty);
+      expect(controller.visitRecords, isEmpty);
+    },
+  );
+}

--- a/test/pilgrimage_work_dropdown_test.dart
+++ b/test/pilgrimage_work_dropdown_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:miriago/plan/pilgrimage_models.dart';
 import 'package:miriago/plan/pilgrimage_work_dropdown.dart';
@@ -154,7 +155,9 @@ void main() {
 
     expect(find.byType(Scrollbar), findsOneWidget);
     final scrollbarRect = tester.getRect(find.byType(Scrollbar));
-    final selectedIconRect = tester.getRect(find.byIcon(Icons.check_circle));
+    final selectedIconRect = tester.getRect(
+      find.byIcon(LucideIcons.checkCircle),
+    );
     expect(selectedIconRect.right, lessThanOrEqualTo(scrollbarRect.right - 10));
 
     final backgrounds = find.byType(AnimatedContainer);

--- a/test/reference_cache_progress_dialog_test.dart
+++ b/test/reference_cache_progress_dialog_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:miriago/plan/reference_cache_progress_dialog.dart';
 import 'package:miriago/plan/reference_full_cache_runner.dart';
@@ -40,7 +41,7 @@ void main() {
     );
     expect(find.text('提示：缓存过程中请保持网络连接，避免切换页面或锁屏。'), findsOneWidget);
     expect(find.text('重试失败'), findsNothing);
-    expect(find.byIcon(Icons.close), findsNothing);
+    expect(find.byIcon(LucideIcons.x), findsNothing);
   });
 
   testWidgets('shows all-success cache state', (tester) async {
@@ -67,7 +68,7 @@ void main() {
 
     expect(find.text('参考图缓存完成'), findsOneWidget);
     expect(find.text('18 / 18 张成功，已保存到本地'), findsOneWidget);
-    expect(find.byIcon(Icons.close), findsNothing);
+    expect(find.byIcon(LucideIcons.x), findsNothing);
     expect(find.text('重试失败'), findsNothing);
     expect(find.text('重试全部'), findsNothing);
   });
@@ -98,7 +99,7 @@ void main() {
     expect(find.text('参考图缓存完成'), findsOneWidget);
     expect(find.text('14 / 18 张成功 · 4 张失败'), findsOneWidget);
     expect(find.text('重试失败'), findsOneWidget);
-    expect(find.byIcon(Icons.close), findsNothing);
+    expect(find.byIcon(LucideIcons.x), findsNothing);
   });
 
   testWidgets('shows all-failed cache state with retry all', (tester) async {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
 
 import 'package:miriago/app_theme.dart';
 import 'package:miriago/main.dart';
@@ -28,6 +29,7 @@ import 'package:miriago/widgets/constrained_menu_anchor.dart';
 import 'package:miriago/widgets/confirm_action_dialog.dart';
 import 'package:miriago/widgets/input_dialog.dart';
 import 'package:miriago/widgets/reference_image_placeholder.dart';
+import 'package:miriago/widgets/responsive_button.dart';
 
 Future<void> _pumpApp(WidgetTester tester) async {
   await tester.pumpWidget(MiriaGoApp(repository: SamplePilgrimageRepository()));
@@ -215,14 +217,14 @@ void main() {
     expect(
       find.descendant(
         of: switchButton,
-        matching: find.byIcon(Icons.swap_horiz),
+        matching: find.byIcon(LucideIcons.arrowLeftRight),
       ),
       findsOneWidget,
     );
     expect(
       find.descendant(
         of: toggleButton,
-        matching: find.byIcon(Icons.expand_more),
+        matching: find.byIcon(LucideIcons.chevronDown),
       ),
       findsOneWidget,
     );
@@ -243,7 +245,7 @@ void main() {
     expect(
       find.descendant(
         of: toggleButton,
-        matching: find.byIcon(Icons.expand_less),
+        matching: find.byIcon(LucideIcons.chevronUp),
       ),
       findsOneWidget,
     );
@@ -265,7 +267,7 @@ void main() {
     expect(
       find.descendant(
         of: find.byKey(const ValueKey('plan-action-cache-references')),
-        matching: find.byIcon(Icons.download_for_offline_outlined),
+        matching: find.byIcon(LucideIcons.cloudDownload),
       ),
       findsOneWidget,
     );
@@ -281,8 +283,9 @@ void main() {
     );
     expect(addPointsRect.top, closeTo(managePointsRect.top, 0.1));
     expect(addPointsRect.bottom, closeTo(managePointsRect.bottom, 0.1));
-    expect(cacheReferencesRect.top, greaterThan(addPointsRect.bottom));
-    expect(cacheReferencesRect.left, closeTo(addPointsRect.left, 0.1));
+    expect(cacheReferencesRect.top, closeTo(addPointsRect.top, 0.1));
+    expect(cacheReferencesRect.bottom, closeTo(addPointsRect.bottom, 0.1));
+    expect(cacheReferencesRect.left, greaterThan(managePointsRect.right));
 
     await tester.tap(find.byKey(const ValueKey('plan-action-add-points')));
     await tester.pumpAndSettle();
@@ -316,7 +319,7 @@ void main() {
     expect(
       find.descendant(
         of: toggleButton,
-        matching: find.byIcon(Icons.expand_more),
+        matching: find.byIcon(LucideIcons.chevronDown),
       ),
       findsOneWidget,
     );
@@ -329,7 +332,7 @@ void main() {
     expect(
       find.descendant(
         of: toggleButton,
-        matching: find.byIcon(Icons.expand_more),
+        matching: find.byIcon(LucideIcons.chevronDown),
       ),
       findsOneWidget,
     );
@@ -371,6 +374,166 @@ void main() {
     expect(find.text('加入巡礼场景'), findsOneWidget);
     expect(find.text('计划备忘录'), findsOneWidget);
     expect(find.text('记录行程要点'), findsOneWidget);
+    final addPointsRect = tester.getRect(
+      find.byKey(const ValueKey('plan-action-add-points')),
+    );
+    final cacheReferencesRect = tester.getRect(
+      find.byKey(const ValueKey('plan-action-cache-references')),
+    );
+    expect(cacheReferencesRect.top, greaterThan(addPointsRect.bottom));
+    expect(cacheReferencesRect.left, closeTo(addPointsRect.left, 0.1));
+  });
+
+  testWidgets(
+    'responsive button content degrades accessibly without shrinking',
+    (tester) async {
+      var presses = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(),
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 220,
+                child: FilledButton(
+                  onPressed: () => presses += 1,
+                  child: const ResponsiveButtonContent(
+                    icon: LucideIcons.mapPinPlus,
+                    label: '加入计划',
+                    shortLabel: '加入',
+                    semanticLabel: '加入计划',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('加入计划'), findsOneWidget);
+      await tester.tap(find.byType(FilledButton));
+      expect(presses, 1);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(),
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 112,
+                child: FilledButton(
+                  onPressed: () {},
+                  child: const ResponsiveButtonContent(
+                    icon: LucideIcons.mapPinPlus,
+                    label: '加入计划',
+                    shortLabel: '加入',
+                    semanticLabel: '加入计划',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('加入'), findsOneWidget);
+
+      final semantics = tester.ensureSemantics();
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(),
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 44,
+                child: FilledButton(
+                  onPressed: null,
+                  child: const ResponsiveButtonContent(
+                    icon: LucideIcons.mapPinPlus,
+                    label: '加入计划',
+                    shortLabel: '加入',
+                    semanticLabel: '加入计划',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byTooltip('加入计划'), findsOneWidget);
+      expect(
+        tester.getSemantics(find.byIcon(LucideIcons.mapPinPlus)).label,
+        '加入计划',
+      );
+      expect(
+        tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+        isNull,
+      );
+      semantics.dispose();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.light(),
+          home: MediaQuery(
+            data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 100,
+                  child: FilledButton(
+                    onPressed: () {},
+                    child: const ResponsiveButtonContent(
+                      icon: LucideIcons.mapPinPlus,
+                      label: '加入计划',
+                      shortLabel: '加入',
+                      semanticLabel: '加入计划',
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byTooltip('加入计划'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('confirmation actions stack at narrow widths with large text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: MediaQuery(
+          data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+          child: Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 220,
+                child: AppDialogActionRow(
+                  cancelLabel: '暂不删除',
+                  confirmLabel: '删除所有记录',
+                  onCancel: () {},
+                  onConfirm: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final buttons = find.byType(FilledButton);
+    expect(
+      tester.getRect(buttons.first).bottom,
+      lessThan(tester.getRect(buttons.last).top),
+    );
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('plan actions can ignore taps outside the panel', (tester) async {
@@ -509,11 +672,24 @@ void main() {
     );
     expect(completedIcon, findsOneWidget);
     expect(
-      find.descendant(of: completedIcon, matching: find.byIcon(Icons.folder)),
+      find.descendant(
+        of: completedIcon,
+        matching: find.byIcon(LucideIcons.folder),
+      ),
       findsOneWidget,
     );
+    final completedFill = tester.widget<DecoratedBox>(
+      find.byKey(ValueKey('plan-group-picker-completed-fill-${group.id}')),
+    );
+    expect(
+      (completedFill.decoration as BoxDecoration).color,
+      AppTheme.light().colorScheme.primary,
+    );
     final checkIcon = tester.widget<Icon>(
-      find.descendant(of: completedIcon, matching: find.byIcon(Icons.check)),
+      find.descendant(
+        of: completedIcon,
+        matching: find.byIcon(LucideIcons.check),
+      ),
     );
     expect(checkIcon.color, Colors.white);
     expect(
@@ -664,6 +840,33 @@ void main() {
     expect(tester.getSize(find.text('结束框选')).height, lessThanOrEqualTo(20));
   });
 
+  testWidgets('app shell uses the Lucide bottom navigation icons', (
+    tester,
+  ) async {
+    await _pumpApp(tester);
+
+    final destinations = tester
+        .widgetList<NavigationDestination>(find.byType(NavigationDestination))
+        .toList(growable: false);
+    const expectedIcons = [
+      LucideIcons.listTodo,
+      LucideIcons.map,
+      LucideIcons.images,
+      LucideIcons.settings,
+    ];
+    const expectedLabels = ['计划', '地图', '记录', '设置'];
+
+    expect(destinations, hasLength(4));
+    for (var index = 0; index < destinations.length; index += 1) {
+      expect(destinations[index].label, expectedLabels[index]);
+      expect((destinations[index].icon as Icon).icon, expectedIcons[index]);
+      expect(
+        (destinations[index].selectedIcon as Icon).icon,
+        expectedIcons[index],
+      );
+    }
+  });
+
   testWidgets('shows records dashboard header and summary', (tester) async {
     await _pumpApp(tester);
 
@@ -730,7 +933,7 @@ void main() {
           .height,
       4,
     );
-    expect(find.byIcon(Icons.collections_bookmark_outlined), findsNothing);
+    expect(find.byIcon(LucideIcons.folders), findsNothing);
     expect(
       find.byKey(const ValueKey('records-group-sample-group-uji-station')),
       findsOneWidget,
@@ -747,7 +950,7 @@ void main() {
     final expandedGroupIcon = tester.widget<Icon>(
       find.byKey(const ValueKey('records-group-icon-sample-group-uji-station')),
     );
-    expect(expandedGroupIcon.icon, Icons.location_on);
+    expect(expandedGroupIcon.icon, LucideIcons.mapPin);
     final recordTitle = tester.widget<Text>(
       find.descendant(
         of: find.byKey(const ValueKey('record-card-sample-record-jr-uji-01')),
@@ -804,6 +1007,12 @@ void main() {
       find.byKey(const ValueKey('record-card-sample-record-jr-uji-01')),
     );
     expect(find.byKey(const ValueKey('records-group-divider')), findsNothing);
+    expect(
+      find.byKey(
+        const ValueKey('records-group-divider-sample-group-uji-station'),
+      ),
+      findsNothing,
+    );
     expect(firstRecordRect.top - groupSurfaceRect.bottom, closeTo(4, 0.1));
     expect(
       find.ancestor(
@@ -829,7 +1038,7 @@ void main() {
             ),
           )
           .icon,
-      Icons.location_on_outlined,
+      LucideIcons.mapPin,
     );
     await tester.tap(firstGroupHeader);
     await tester.pumpAndSettle();
@@ -918,7 +1127,7 @@ void main() {
       find.byKey(const ValueKey('records-status-option-all')),
     );
     expect(selectedStatusOption.leadingIcon, isA<Icon>());
-    expect((selectedStatusOption.leadingIcon! as Icon).icon, Icons.check);
+    expect((selectedStatusOption.leadingIcon! as Icon).icon, LucideIcons.check);
     expect(
       selectedStatusOption.style?.overlayColor?.resolve({WidgetState.hovered}),
       Colors.transparent,
@@ -989,7 +1198,7 @@ void main() {
 
       expect(find.byKey(const ValueKey('records-empty-state')), findsOneWidget);
       expect(find.text('没有找到相关记录'), findsOneWidget);
-      expect(find.byIcon(Icons.search_off_rounded), findsOneWidget);
+      expect(find.byIcon(LucideIcons.searchX), findsOneWidget);
       expect(find.textContaining('点位、作品或场景'), findsOneWidget);
       expect(
         find.byKey(const ValueKey('records-empty-clear-search')),
@@ -1200,6 +1409,12 @@ void main() {
       findsNothing,
     );
     expect(
+      find.byKey(
+        const ValueKey('records-group-divider-sample-group-uji-station'),
+      ),
+      findsOneWidget,
+    );
+    expect(
       tester
           .widget<Icon>(
             find.byKey(
@@ -1207,7 +1422,7 @@ void main() {
             ),
           )
           .icon,
-      Icons.location_on_outlined,
+      LucideIcons.mapPin,
     );
 
     await tester.tap(find.byKey(const ValueKey('records-toggle-all-sections')));
@@ -1361,13 +1576,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('备用路线'), findsOneWidget);
-    expect(find.byIcon(Icons.check_box_outline_blank), findsOneWidget);
-    expect(find.byIcon(Icons.check_box), findsOneWidget);
+    expect(find.byIcon(LucideIcons.square), findsOneWidget);
+    expect(find.byIcon(LucideIcons.squareCheckBig), findsOneWidget);
 
-    await tester.tap(find.byIcon(Icons.check_box_outline_blank));
+    await tester.tap(find.byIcon(LucideIcons.square));
     await tester.pumpAndSettle();
 
-    expect(find.byIcon(Icons.check_box), findsNWidgets(2));
+    expect(find.byIcon(LucideIcons.squareCheckBig), findsNWidgets(2));
 
     await tester.tap(find.byTooltip('编辑'));
     await tester.pumpAndSettle();
@@ -1377,9 +1592,9 @@ void main() {
   testWidgets('opens camera reference from current target', (tester) async {
     await _pumpApp(tester);
 
-    await tester.tap(find.byIcon(Icons.photo_camera_outlined).first);
+    await tester.tap(find.byIcon(LucideIcons.camera).first);
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump(const Duration(milliseconds: 500));
 
     expect(find.text('叠影'), findsWidgets);
     expect(find.text('上下'), findsWidgets);
@@ -1421,7 +1636,7 @@ void main() {
     );
     expect(selectedTile, findsOneWidget);
     expect(tester.getSize(selectedTile).height, 44);
-    expect(selectedIcon.icon, Icons.check_circle);
+    expect(selectedIcon.icon, LucideIcons.checkCircle);
     expect(
       find.byKey(const ValueKey('plan-group-picker-selected-accent')),
       findsNothing,
@@ -1542,6 +1757,112 @@ void main() {
     expect(middleTop, lessThan(lateTop));
   });
 
+  testWidgets('point detail confirms deletion and keeps the sheet on failure', (
+    tester,
+  ) async {
+    const work = PilgrimageWork(
+      id: 'delete-work',
+      title: '删除测试作品',
+      subtitle: '',
+      city: '',
+      source: WorkSource.manual,
+    );
+    const point = PilgrimagePoint(
+      id: 'delete-point',
+      work: work,
+      name: '删除测试点位',
+      subtitle: '',
+      position: LatLng(35, 135),
+      episodeLabel: 'EP 1',
+      referenceLabel: '手动',
+    );
+    var deleteCalls = 0;
+    var shouldFail = true;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => FilledButton(
+              onPressed: () => PointDetailSheet.show(
+                context,
+                point: point,
+                status: VisitStatus.pending,
+                onReplaceReference: (_, _) async {},
+                onDelete: (_) async {
+                  deleteCalls += 1;
+                  if (shouldFail) {
+                    throw StateError('delete failed');
+                  }
+                },
+              ),
+              child: const Text('打开删除测试'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开删除测试'));
+    await tester.pumpAndSettle();
+
+    final deleteButton = find.byKey(const ValueKey('point-detail-delete'));
+    expect(deleteButton, findsOneWidget);
+    expect(tester.getSize(deleteButton), const Size(36, 36));
+    expect(
+      tester
+          .widget<Icon>(
+            find.descendant(of: deleteButton, matching: find.byType(Icon)),
+          )
+          .size,
+      18,
+    );
+    expect(
+      tester.getCenter(find.text('待访问')).dy,
+      closeTo(tester.getCenter(deleteButton).dy, 0.1),
+    );
+    expect(find.byTooltip('删除点位'), findsOneWidget);
+
+    await tester.tap(deleteButton);
+    await tester.pumpAndSettle();
+    var dialogButtons = find.descendant(
+      of: find.byType(ConfirmActionDialog),
+      matching: find.byType(FilledButton),
+    );
+    await tester.tap(dialogButtons.first);
+    await tester.pumpAndSettle();
+    expect(deleteCalls, 0);
+    expect(deleteButton, findsOneWidget);
+
+    await tester.tap(deleteButton);
+    await tester.pumpAndSettle();
+    dialogButtons = find.descendant(
+      of: find.byType(ConfirmActionDialog),
+      matching: find.byType(FilledButton),
+    );
+    await tester.tap(dialogButtons.last);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
+    expect(deleteCalls, 1);
+    expect(deleteButton, findsOneWidget);
+    expect(find.text('删除点位失败，请稍后重试'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+    shouldFail = false;
+    await tester.tap(deleteButton);
+    await tester.pumpAndSettle();
+    dialogButtons = find.descendant(
+      of: find.byType(ConfirmActionDialog),
+      matching: find.byType(FilledButton),
+    );
+    await tester.tap(dialogButtons.last);
+    await tester.pumpAndSettle();
+    expect(deleteCalls, 2);
+    expect(deleteButton, findsNothing);
+  });
+
   testWidgets('edits point details from the shared detail sheet', (
     tester,
   ) async {
@@ -1580,7 +1901,7 @@ void main() {
   testWidgets('shows group filters on the map', (tester) async {
     await _pumpApp(tester);
 
-    await tester.tap(find.byIcon(Icons.map_outlined).last);
+    await tester.tap(find.byIcon(LucideIcons.map).last);
     await tester.pumpAndSettle();
 
     expect(find.textContaining('宇治站附近'), findsWidgets);
@@ -1624,11 +1945,16 @@ void main() {
     (tester) async {
       await _pumpApp(tester);
 
-      await tester.tap(find.byIcon(Icons.map_outlined).last);
+      await tester.tap(find.byIcon(LucideIcons.map).last);
       await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.info_outline), findsNothing);
-      expect(find.byIcon(Icons.near_me_outlined), findsNWidgets(2));
+      expect(find.byIcon(LucideIcons.info), findsNothing);
+      expect(find.byIcon(Icons.directions_walk), findsOneWidget);
+      expect(find.byIcon(LucideIcons.navigation), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('map-navigation-button-divider')),
+        findsOneWidget,
+      );
 
       await tester.tap(
         find.byKey(
@@ -1648,14 +1974,54 @@ void main() {
     addTearDown(() => tester.binding.setSurfaceSize(null));
     await _pumpApp(tester);
 
-    await tester.tap(find.byIcon(Icons.map_outlined).last);
+    await tester.tap(find.byIcon(LucideIcons.map).last);
     await tester.pumpAndSettle();
 
-    final navigationButton = tester.widget<FilledButton>(
+    final navigationButton = tester.widget<InkWell>(
       find.byKey(const ValueKey('map-in-app-navigation-button')),
     );
-    expect(navigationButton.onPressed, isNotNull);
+    final externalNavigationButton = tester.widget<InkWell>(
+      find.byKey(const ValueKey('map-external-navigation-button')),
+    );
+    expect(navigationButton.onTap, isNotNull);
+    expect(externalNavigationButton.onTap, isNotNull);
   });
+
+  testWidgets(
+    'map point card keeps 44px actions without overflow when narrow',
+    (tester) async {
+      for (final width in [320.0, 300.0, 280.0]) {
+        await tester.binding.setSurfaceSize(Size(width, 844));
+        await _pumpApp(tester);
+        await tester.tap(find.byIcon(LucideIcons.map).last);
+        await tester.pumpAndSettle();
+
+        final navigation = tester.getRect(
+          find.byKey(const ValueKey('map-in-app-navigation-button')),
+        );
+        final camera = tester.getRect(find.byTooltip('拍摄参考'));
+        final complete = tester.getRect(find.byTooltip('标记完成'));
+        expect(navigation.height, closeTo(44, 0.1));
+        expect(camera.height, closeTo(navigation.height, 0.1));
+        expect(complete.height, closeTo(navigation.height, 0.1));
+        expect(camera.width, closeTo(52, 0.1));
+        expect(complete.width, closeTo(52, 0.1));
+        if (width == 280) {
+          expect(
+            find.descendant(
+              of: find.byKey(const ValueKey('map-in-app-navigation-button')),
+              matching: find.text('导航'),
+            ),
+            findsNothing,
+          );
+        }
+        expect(tester.takeException(), isNull);
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+      }
+      await tester.binding.setSurfaceSize(null);
+    },
+  );
 
   testWidgets('plan point detail exposes in-app navigation action', (
     tester,
@@ -1947,7 +2313,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('plan-group-summary')), findsOneWidget);
-    expect(find.byIcon(Icons.account_tree_outlined), findsNothing);
+    expect(find.byIcon(LucideIcons.network), findsNothing);
     expect(find.text('未分配点位'), findsOneWidget);
     expect(find.textContaining('个点位等待整理'), findsOneWidget);
 
@@ -2543,7 +2909,7 @@ void main() {
       find
           .descendant(
             of: find.byTooltip('编辑计划信息').first,
-            matching: find.byIcon(Icons.edit_outlined),
+            matching: find.byIcon(LucideIcons.edit),
           )
           .first,
     );
@@ -2769,7 +3135,10 @@ void main() {
     final moreButton = find.byKey(ValueKey('work-manage-more-${work.id}'));
     expect(moreButton, findsOneWidget);
     expect(
-      find.descendant(of: moreButton, matching: find.byIcon(Icons.more_horiz)),
+      find.descendant(
+        of: moreButton,
+        matching: find.byIcon(LucideIcons.ellipsis),
+      ),
       findsOneWidget,
     );
     expect(tester.getSize(moreButton), const Size.square(34));
@@ -3006,7 +3375,7 @@ void main() {
       tester.widget<TextFormField>(fields.at(2)).controller!.text,
       isEmpty,
     );
-    await tester.tap(find.byIcon(Icons.arrow_back));
+    await tester.tap(find.byIcon(LucideIcons.arrowLeft));
     await tester.pumpAndSettle();
 
     expect(find.text('原创短片'), findsOneWidget);
@@ -3232,6 +3601,67 @@ void main() {
       hasLength(1),
     );
     expect(updatedPlan.points, hasLength(1));
+  });
+
+  testWidgets('Anitabi point card shortens import action when narrow', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(280, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final repository = SamplePilgrimageRepository(plans: const []);
+    final plan = await repository.createPlan(name: '窄屏导入测试', area: '京都');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: AnitabiMapImportScreen(
+          plan: plan,
+          repository: repository,
+          initialBangumiId: 12345,
+          initialPointId: 'point-1',
+          anitabiClient: _FakeAnitabiClient(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final card = find.byKey(const ValueKey('anitabi-point-card-point-1'));
+    expect(card, findsOneWidget);
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('anitabi-point-thumbnail-point-1')),
+      ),
+      const Size(80, 80),
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('anitabi-point-text-point-1')))
+          .height,
+      80,
+    );
+    expect(
+      tester
+          .getSize(
+            find.byKey(const ValueKey('anitabi-point-navigation-point-1')),
+          )
+          .height,
+      40,
+    );
+    expect(
+      tester
+          .getSize(find.byKey(const ValueKey('anitabi-point-import-point-1')))
+          .height,
+      40,
+    );
+    expect(
+      find.descendant(of: card, matching: find.text('加入')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: card, matching: find.text('加入计划')),
+      findsNothing,
+    );
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('Anitabi link import uses global pid owner work', (tester) async {


### PR DESCRIPTION
## 变更内容

- 为 Anitabi 导入、路线确认、点位详情、设置页双按钮、对比图导出、添加点位、最近分配、导入导出及确认对话框补充统一的空间降级处理。
- 将 Anitabi 点位卡操作区移动到信息区下方，窄屏时将“加入计划”缩短为“加入”。
- 统一应用内图标为 Lucide，并补充对应的 MIT 许可证声明。
- 优化对比图设置、地图操作区布局及片区全部完成时的文件夹状态。

## 验证

- `dart analyze lib test` 通过。
- 对比图配置测试通过。
- 片区完成状态与窄屏地图操作区组件测试通过。
- 受影响的组件测试中 101 项通过；另有 1 项既有紧凑按钮高度断言仍预期 36px，而主题控件实际渲染为 44px。
- Flutter Web 构建成功，预览首页及 Anitabi JSON 代理端点验证通过。