### PR TITLE
polish: align navigation actions and refine assign and settings UI

### DIFF
--- a/lib/camera_reference/photo_location_choice_sheet.dart
+++ b/lib/camera_reference/photo_location_choice_sheet.dart
@@ -63,7 +63,6 @@ class PhotoLocationChoiceSheet extends StatelessWidget {
               title: '确认记录时获取定位',
               subtitle: '拍摄后在确认页面等待新定位，适合需要更准确位置时。',
               recommended: true,
-              highlighted: true,
               onTap: () => Navigator.of(
                 context,
               ).pop(PhotoLocationStrategy.waitOnConfirmation),
@@ -90,7 +89,6 @@ class _PhotoLocationChoiceTile extends StatelessWidget {
     required this.onTap,
     this.subtitle,
     this.recommended = false,
-    this.highlighted = false,
     super.key,
   });
 
@@ -98,22 +96,15 @@ class _PhotoLocationChoiceTile extends StatelessWidget {
   final String title;
   final String? subtitle;
   final bool recommended;
-  final bool highlighted;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    final borderColor = highlighted
-        ? AppColors.accent
-        : AppColors.border.withValues(alpha: 0.9);
-    final fillColor = highlighted
-        ? AppColors.accent.withValues(alpha: 0.08)
-        : AppColors.surface;
     return Material(
-      color: fillColor,
+      color: AppColors.surface,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(12),
-        side: BorderSide(color: borderColor, width: highlighted ? 1.5 : 1),
+        side: BorderSide(color: AppColors.border.withValues(alpha: 0.9)),
       ),
       child: InkWell(
         onTap: onTap,
@@ -123,10 +114,7 @@ class _PhotoLocationChoiceTile extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Icon(
-                icon,
-                color: highlighted ? AppColors.accent : AppColors.textPrimary,
-              ),
+              Icon(icon, color: AppColors.textPrimary),
               const SizedBox(width: 12),
               Expanded(
                 child: Column(

--- a/lib/map/in_app_navigation_screen.dart
+++ b/lib/map/in_app_navigation_screen.dart
@@ -433,6 +433,9 @@ class _InAppNavigationScreenState extends State<InAppNavigationScreen>
     BuildContext context,
     _NavigationChrome chrome,
   ) async {
+    if (_arrivalSheetOpen) {
+      return;
+    }
     final arrived = _currentTarget;
     final next = _nextStop;
     final remainingCount = _activeStops.isEmpty ? 1 : _activeStops.length;
@@ -655,6 +658,7 @@ class _InAppNavigationScreenState extends State<InAppNavigationScreen>
                       setState(() => _sheetExpanded = !_sheetExpanded);
                     },
                     onShowAllStops: () => _showAllStops(context, chrome),
+                    onArrive: () => _showArrival(context, chrome),
                     onEndRoute: () => Navigator.of(context).maybePop(),
                   ),
                 ],
@@ -927,6 +931,7 @@ class _BottomPanel extends StatelessWidget {
     required this.bottomInset,
     required this.onToggleExpanded,
     required this.onShowAllStops,
+    required this.onArrive,
     required this.onEndRoute,
   });
 
@@ -939,6 +944,7 @@ class _BottomPanel extends StatelessWidget {
   final double bottomInset;
   final VoidCallback onToggleExpanded;
   final VoidCallback onShowAllStops;
+  final VoidCallback onArrive;
   final VoidCallback onEndRoute;
 
   @override
@@ -997,6 +1003,28 @@ class _BottomPanel extends StatelessWidget {
                       onTap: onShowAllStops,
                     ),
                     const SizedBox(height: 16),
+                    SizedBox(
+                      width: double.infinity,
+                      height: 52,
+                      child: OutlinedButton(
+                        key: const ValueKey('in-app-navigation-arrive'),
+                        onPressed: onArrive,
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: chrome.primaryText,
+                          side: BorderSide(color: chrome.iconButton),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          textStyle: const TextStyle(
+                            fontSize: 17,
+                            fontWeight: FontWeight.w700,
+                            letterSpacing: 0,
+                          ),
+                        ),
+                        child: const Text('已到达'),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
                     SizedBox(
                       width: double.infinity,
                       height: 52,

--- a/lib/map/pilgrimage_map_screen.dart
+++ b/lib/map/pilgrimage_map_screen.dart
@@ -20,6 +20,7 @@ import '../records/point_visit_records_screen.dart';
 import '../records/visit_record_detail_screen.dart';
 import '../utils/selected_item_order.dart';
 import '../widgets/copyable_text.dart';
+import '../widgets/split_navigation_button.dart';
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/auto_caching_reference_thumbnail.dart';
 import '../widgets/image_load_limiter.dart';
@@ -1058,6 +1059,16 @@ class _CurrentLocationMarker extends StatelessWidget {
 const _mapPointActionExtent = 44.0;
 const _mapPointPrimaryActionWidth = 52.0;
 
+ButtonStyle _mapPointIconButtonStyle(double width) {
+  return IconButton.styleFrom(
+    minimumSize: Size(width, _mapPointActionExtent),
+    maximumSize: Size(width, _mapPointActionExtent),
+    padding: EdgeInsets.zero,
+    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    visualDensity: VisualDensity.compact,
+  );
+}
+
 class _PointCard extends StatelessWidget {
   const _PointCard({
     required this.controller,
@@ -1182,10 +1193,11 @@ class _PointCard extends StatelessWidget {
           const SizedBox(height: 12),
           LayoutBuilder(
             builder: (context, constraints) {
-              final navigation = _SplitNavigationButton(
+              final navigation = SplitNavigationButton(
                 inAppLabel: point.hasCoordinate ? '导航' : '坐标待补充',
                 onOpenInAppNavigation: onOpenInAppNavigation,
                 onOpenExternalNavigation: onOpenExternalNavigation,
+                height: _mapPointActionExtent,
               );
               final showCurrent =
                   point.hasCoordinate &&
@@ -1198,6 +1210,9 @@ class _PointCard extends StatelessWidget {
                   child: IconButton.outlined(
                     tooltip: '拍摄参考',
                     onPressed: onOpenCamera,
+                    style: _mapPointIconButtonStyle(
+                      _mapPointPrimaryActionWidth,
+                    ),
                     icon: SizedBox(
                       width: 24,
                       height: 24,
@@ -1206,10 +1221,10 @@ class _PointCard extends StatelessWidget {
                         children: [
                           const Center(child: Icon(LucideIcons.camera)),
                           if (recordCount > 0)
-                            const Positioned(
+                            Positioned(
                               top: -5,
                               right: -5,
-                              child: _MapRecordBadge(),
+                              child: _MapRecordBadge(stacked: recordCount > 1),
                             ),
                         ],
                       ),
@@ -1223,6 +1238,9 @@ class _PointCard extends StatelessWidget {
                   child: IconButton.outlined(
                     tooltip: status == VisitStatus.completed ? '撤回打卡' : '标记完成',
                     onPressed: onComplete,
+                    style: _mapPointIconButtonStyle(
+                      _mapPointPrimaryActionWidth,
+                    ),
                     icon: Icon(
                       status == VisitStatus.completed
                           ? LucideIcons.undo2
@@ -1238,6 +1256,7 @@ class _PointCard extends StatelessWidget {
                     child: IconButton.outlined(
                       tooltip: '设为当前目标',
                       onPressed: onSetCurrent,
+                      style: _mapPointIconButtonStyle(_mapPointActionExtent),
                       icon: const Icon(LucideIcons.flag),
                     ),
                   ),
@@ -1263,6 +1282,7 @@ class _PointCard extends StatelessWidget {
                 );
               }
               return Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   Expanded(child: navigation),
                   const SizedBox(width: 4),
@@ -1294,94 +1314,6 @@ class _PointCard extends StatelessWidget {
           ? '${point.position.latitude.toStringAsFixed(5)},${point.position.longitude.toStringAsFixed(5)}'
           : '坐标待补充',
     ].where((value) => value.trim().isNotEmpty).join('\n');
-  }
-}
-
-class _SplitNavigationButton extends StatelessWidget {
-  const _SplitNavigationButton({
-    required this.inAppLabel,
-    required this.onOpenInAppNavigation,
-    required this.onOpenExternalNavigation,
-  });
-
-  final String inAppLabel;
-  final VoidCallback? onOpenInAppNavigation;
-  final VoidCallback? onOpenExternalNavigation;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final enabled =
-        onOpenInAppNavigation != null || onOpenExternalNavigation != null;
-    final foregroundColor = enabled
-        ? colorScheme.onPrimary
-        : colorScheme.onSurface.withValues(alpha: 0.38);
-    final backgroundColor = enabled
-        ? colorScheme.primary
-        : colorScheme.onSurface.withValues(alpha: 0.12);
-
-    return Material(
-      color: backgroundColor,
-      borderRadius: BorderRadius.circular(8),
-      clipBehavior: Clip.antiAlias,
-      child: SizedBox(
-        height: _mapPointActionExtent,
-        child: Row(
-          children: [
-            Expanded(
-              child: Semantics(
-                button: true,
-                enabled: onOpenInAppNavigation != null,
-                label: '应用内导航：$inAppLabel',
-                child: InkWell(
-                  key: const ValueKey('map-in-app-navigation-button'),
-                  onTap: onOpenInAppNavigation,
-                  child: Center(
-                    child: IconTheme(
-                      data: IconThemeData(color: foregroundColor),
-                      child: Tooltip(
-                        message: '应用内导航：$inAppLabel',
-                        excludeFromSemantics: true,
-                        child: const Icon(LucideIcons.footprints, size: 20),
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            Container(
-              key: const ValueKey('map-navigation-button-divider'),
-              width: 1,
-              height: 28,
-              color: foregroundColor.withValues(alpha: 0.38),
-            ),
-            Expanded(
-              child: Semantics(
-                button: true,
-                enabled: onOpenExternalNavigation != null,
-                label: '打开外部地图',
-                child: Tooltip(
-                  message: '打开外部地图',
-                  excludeFromSemantics: true,
-                  child: InkWell(
-                    key: const ValueKey('map-external-navigation-button'),
-                    onTap: onOpenExternalNavigation,
-                    child: SizedBox(
-                      height: _mapPointActionExtent,
-                      child: Icon(
-                        LucideIcons.navigation,
-                        size: 21,
-                        color: foregroundColor,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 }
 
@@ -1435,7 +1367,9 @@ class _PointThumbnail extends StatelessWidget {
 }
 
 class _MapRecordBadge extends StatelessWidget {
-  const _MapRecordBadge();
+  const _MapRecordBadge({required this.stacked});
+
+  final bool stacked;
 
   @override
   Widget build(BuildContext context) {
@@ -1456,7 +1390,11 @@ class _MapRecordBadge extends StatelessWidget {
           ),
         ],
       ),
-      child: Icon(LucideIcons.images, size: 10, color: AppColors.accentDark),
+      child: Icon(
+        stacked ? LucideIcons.images : LucideIcons.image,
+        size: 10,
+        color: AppColors.accentDark,
+      ),
     );
   }
 }

--- a/lib/plan/anitabi_map_import_screen.dart
+++ b/lib/plan/anitabi_map_import_screen.dart
@@ -2097,7 +2097,7 @@ class _ImportSummary extends StatelessWidget {
     final expected = expectedCount;
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(8),
@@ -2134,12 +2134,12 @@ class _ImportSummary extends StatelessWidget {
             ],
           ),
           if (!isLoading) ...[
-            const SizedBox(height: 10),
+            const SizedBox(height: 8),
             Row(
               children: [
                 SizedBox(
                   width: 44,
-                  height: 44,
+                  height: 36,
                   child: IconButton.outlined(
                     tooltip: '添加所有点位',
                     onPressed: isImporting || availableCount == 0
@@ -2152,7 +2152,7 @@ class _ImportSummary extends StatelessWidget {
                 const SizedBox(width: 8),
                 SizedBox(
                   width: 44,
-                  height: 44,
+                  height: 36,
                   child: IconButton.outlined(
                     tooltip: boxSelectionEnabled ? '退出框选' : '框选点位',
                     isSelected: boxSelectionEnabled,
@@ -2165,7 +2165,7 @@ class _ImportSummary extends StatelessWidget {
                 const SizedBox(width: 8),
                 Expanded(
                   child: SizedBox(
-                    height: 44,
+                    height: 36,
                     child: FilledButton(
                       onPressed:
                           isImporting ||

--- a/lib/plan/nearest_group_assign_screen.dart
+++ b/lib/plan/nearest_group_assign_screen.dart
@@ -7,12 +7,15 @@ import 'package:latlong2/latlong.dart';
 
 import '../app_theme.dart';
 import '../widgets/responsive_button.dart';
+import '../widgets/reference_thumbnail_stub.dart'
+    if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
 import '../data/pilgrimage_repository.dart';
 import '../map/map_marker_scale.dart';
 import '../map/map_tile_config.dart';
 import '../data/user_reference_image_stub.dart'
     if (dart.library.io) '../data/user_reference_image_io.dart';
 import '../point_detail/point_detail_sheet.dart';
+import 'reference_image_status.dart';
 import '../utils/selected_item_order.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/input_dialog.dart';
@@ -664,6 +667,8 @@ class _BoxGroupAssignScreenState extends State<BoxGroupAssignScreen> {
                       assignable: selectedBoxPoints.any(
                         (point) => point.id == _selectedPoint!.id,
                       ),
+                      assignableLabel: '已框选',
+                      unassignableLabel: '未框选',
                       onOpenDetail: () => _showPointDetail(_selectedPoint!),
                     ),
             ),
@@ -974,7 +979,7 @@ class _BoxAssignGroupPickerState extends State<_BoxAssignGroupPicker> {
                       }
                     : null,
                 child: SizedBox(
-                  height: 44,
+                  height: AppButtonStyles.compactHeight,
                   child: Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 14),
                     child: Row(
@@ -1269,7 +1274,7 @@ class _BoxAssignPanel extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Padding(
-        padding: const EdgeInsets.all(12),
+        padding: const EdgeInsets.all(10),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -1288,7 +1293,7 @@ class _BoxAssignPanel extends StatelessWidget {
                 SizedBox(
                   key: const ValueKey('box-assign-toggle-button'),
                   width: actionButtonWidth,
-                  height: 44,
+                  height: 36,
                   child: OutlinedButton(
                     onPressed: isSaving ? null : onToggleBoxSelection,
                     style: AppButtonStyles.compactOutlinedButton(),
@@ -1323,7 +1328,7 @@ class _BoxAssignPanel extends StatelessWidget {
                 SizedBox(
                   key: const ValueKey('box-assign-submit-button'),
                   width: actionButtonWidth,
-                  height: 44,
+                  height: 36,
                   child: FilledButton(
                     onPressed:
                         isSaving || targetGroup == null || selectedCount == 0
@@ -1409,7 +1414,7 @@ class _NearestAssignPanel extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+        padding: const EdgeInsets.fromLTRB(12, 10, 12, 10),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -1419,7 +1424,7 @@ class _NearestAssignPanel extends StatelessWidget {
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
-                    '最大距离 ${_formatDistance(distanceMeters)} · 可分配 $assignableCount/$ungroupedCount',
+                    '最大距离 ${_formatDistance(distanceMeters)}',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: const TextStyle(
@@ -1428,17 +1433,18 @@ class _NearestAssignPanel extends StatelessWidget {
                     ),
                   ),
                 ),
-                const SizedBox(width: 8),
-                SizedBox(
-                  height: 36,
-                  child: FilledButton(
-                    onPressed: isSaving || groupCount == 0 ? null : onAssign,
-                    child: Text(isSaving ? '分配中' : '分配'),
+                Text(
+                  '可分配 $assignableCount/$ungroupedCount',
+                  style: TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0,
                   ),
                 ),
               ],
             ),
-            const SizedBox(height: 4),
+            const SizedBox(height: 3),
             Text(
               '未分组点位会分配到距离最近、且在最大距离范围内的片区关键点。',
               style: TextStyle(
@@ -1448,14 +1454,50 @@ class _NearestAssignPanel extends StatelessWidget {
                 letterSpacing: 0,
               ),
             ),
-            const SizedBox(height: 8),
-            Slider(
-              value: distanceMeters.clamp(50.0, 5000.0),
-              min: 50,
-              max: 5000,
-              divisions: 99,
-              label: _formatDistance(distanceMeters),
-              onChanged: isSaving ? null : onDistanceChanged,
+            const SizedBox(height: 4),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '当前 ${_formatDistance(distanceMeters)}',
+                  style: TextStyle(
+                    color: AppColors.accentDark,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0,
+                  ),
+                ),
+                Text(
+                  '50 m - 5 km',
+                  style: TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 12,
+                    letterSpacing: 0,
+                  ),
+                ),
+              ],
+            ),
+            Row(
+              children: [
+                Expanded(
+                  child: Slider(
+                    value: distanceMeters.clamp(50.0, 5000.0),
+                    min: 50,
+                    max: 5000,
+                    divisions: 99,
+                    label: _formatDistance(distanceMeters),
+                    onChanged: isSaving ? null : onDistanceChanged,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                SizedBox(
+                  height: 38,
+                  child: FilledButton(
+                    onPressed: isSaving || groupCount == 0 ? null : onAssign,
+                    child: Text(isSaving ? '分配中' : '分配'),
+                  ),
+                ),
+              ],
             ),
           ],
         ),
@@ -1471,12 +1513,16 @@ class _NearestAssignPointCard extends StatelessWidget {
     required this.distanceMeters,
     required this.assignable,
     required this.onOpenDetail,
+    this.assignableLabel = '在最大距离范围内',
+    this.unassignableLabel = '超出最大距离',
   });
 
   final PilgrimagePoint point;
   final PilgrimagePlanGroup? nearestGroup;
   final double? distanceMeters;
   final bool assignable;
+  final String assignableLabel;
+  final String unassignableLabel;
   final VoidCallback onOpenDetail;
 
   @override
@@ -1484,54 +1530,84 @@ class _NearestAssignPointCard extends StatelessWidget {
     final bottomInset = MediaQuery.paddingOf(context).bottom;
     return Padding(
       padding: EdgeInsets.fromLTRB(12, 0, 12, 12 + bottomInset),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: AppColors.surface,
-          border: Border.all(color: AppColors.border),
+      child: Material(
+        color: AppColors.surface,
+        shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8),
+          side: BorderSide(color: AppColors.border),
         ),
-        child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Row(
-            children: [
-              Icon(
-                assignable ? LucideIcons.circleCheckBig : LucideIcons.info,
-                color: assignable ? AppColors.accentDark : AppColors.warning,
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      point.name,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onOpenDetail,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: SizedBox(
+                    width: 56,
+                    height: 56,
+                    child: ReferenceThumbnail(
+                      localPath: point.referenceThumbnailPath,
+                      imageUrl: hasRemoteReferenceImage(point)
+                          ? point.referenceImageUrl
+                          : null,
+                      placeholder: const Icon(LucideIcons.image),
                     ),
-                    const SizedBox(height: 3),
-                    Text(
-                      nearestGroup == null
-                          ? '没有可用片区关键点'
-                          : '${nearestGroup!.name} · ${_formatDistance(distanceMeters ?? 0)}',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        color: AppColors.textSecondary,
-                        fontSize: 13,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              OutlinedButton(onPressed: onOpenDetail, child: const Text('详情')),
-            ],
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        point.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        nearestGroup == null
+                            ? '没有可用片区关键点'
+                            : '${nearestGroup!.name} · ${_formatDistance(distanceMeters ?? 0)}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 13,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        assignable ? assignableLabel : unassignableLabel,
+                        style: TextStyle(
+                          color: assignable
+                              ? AppColors.accentDark
+                              : AppColors.warning,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Icon(
+                  assignable ? LucideIcons.circleCheckBig : LucideIcons.info,
+                  color: assignable ? AppColors.accentDark : AppColors.warning,
+                  size: 20,
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/plan/plan_manager_screen.dart
+++ b/lib/plan/plan_manager_screen.dart
@@ -504,7 +504,13 @@ class _PlanCardState extends State<_PlanCard> {
     if (_menuOpen == open) {
       return;
     }
-    setState(() => _menuOpen = open);
+    setState(() {
+      _menuOpen = open;
+      _cardHovered = false;
+      if (!open) {
+        _actionHovered = false;
+      }
+    });
   }
 
   @override
@@ -537,6 +543,9 @@ class _PlanCardState extends State<_PlanCard> {
         child: InkWell(
           onTap: selected ? null : widget.onSwitch,
           hoverColor: Colors.transparent,
+          highlightColor: Colors.transparent,
+          splashColor: Colors.transparent,
+          overlayColor: const WidgetStatePropertyAll(Colors.transparent),
           child: Stack(
             children: [
               Padding(
@@ -720,6 +729,7 @@ class _PlanCardState extends State<_PlanCard> {
                           onDuplicate: widget.onDuplicate!,
                           onDelete: widget.onDelete!,
                           onMenuOpenChanged: _setMenuOpen,
+                          onMenuHoverChanged: _setActionHovered,
                         ),
                     ],
                   ),
@@ -769,6 +779,7 @@ class _PlanMoreButton extends StatefulWidget {
     required this.onDuplicate,
     required this.onDelete,
     required this.onMenuOpenChanged,
+    required this.onMenuHoverChanged,
   });
 
   final PilgrimagePlan plan;
@@ -777,6 +788,7 @@ class _PlanMoreButton extends StatefulWidget {
   final VoidCallback onDuplicate;
   final VoidCallback onDelete;
   final ValueChanged<bool> onMenuOpenChanged;
+  final ValueChanged<bool> onMenuHoverChanged;
 
   @override
   State<_PlanMoreButton> createState() => _PlanMoreButtonState();
@@ -800,11 +812,15 @@ class _PlanMoreButtonState extends State<_PlanMoreButton> {
         alignment: AlignmentDirectional.bottomStart,
         backgroundColor: WidgetStatePropertyAll(Colors.transparent),
         surfaceTintColor: WidgetStatePropertyAll(Colors.transparent),
+        shadowColor: WidgetStatePropertyAll(Colors.transparent),
         padding: WidgetStatePropertyAll(EdgeInsets.zero),
         minimumSize: WidgetStatePropertyAll(Size(_menuWidth, 0)),
         maximumSize: WidgetStatePropertyAll(Size(_menuWidth, 520)),
         elevation: WidgetStatePropertyAll(0),
-        shadowColor: WidgetStatePropertyAll(Colors.transparent),
+        side: WidgetStatePropertyAll(BorderSide.none),
+        shape: WidgetStatePropertyAll(
+          RoundedRectangleBorder(side: BorderSide.none),
+        ),
       ),
       menuChildren: [
         _PlanActionsMenuPanel(
@@ -812,6 +828,7 @@ class _PlanMoreButtonState extends State<_PlanMoreButton> {
           onExport: widget.onExport,
           onDuplicate: widget.onDuplicate,
           onDelete: widget.onDelete,
+          onHoverChanged: widget.onMenuHoverChanged,
         ),
       ],
       child: _PlanActionButton(
@@ -837,64 +854,70 @@ class _PlanActionsMenuPanel extends StatelessWidget {
     required this.onExport,
     required this.onDuplicate,
     required this.onDelete,
+    required this.onHoverChanged,
   });
 
   final bool canDelete;
   final VoidCallback onExport;
   final VoidCallback onDuplicate;
   final VoidCallback onDelete;
+  final ValueChanged<bool> onHoverChanged;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      key: const ValueKey('plan-actions-menu'),
-      width: _PlanMoreButtonState._menuWidth,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          CustomPaint(
-            key: const ValueKey('plan-actions-menu-panel'),
-            painter: const _PlanMenuSurfacePainter(),
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(10, 23, 10, 10),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  _PlanMenuActionItem(
-                    actionKey: const ValueKey('plan-menu-action-transfer'),
-                    label: '导入导出',
-                    icon: LucideIcons.import,
-                    onPressed: onExport,
-                  ),
-                  const SizedBox(height: 6),
-                  _PlanMenuActionItem(
-                    actionKey: const ValueKey('plan-menu-action-copy'),
-                    label: '复制计划',
-                    icon: LucideIcons.copy,
-                    onPressed: onDuplicate,
-                  ),
-                  Divider(height: 17, color: AppColors.border),
-                  _PlanMenuActionItem(
-                    actionKey: const ValueKey('plan-menu-action-delete'),
-                    label: '删除计划',
-                    icon: LucideIcons.trash2,
-                    onPressed: canDelete ? onDelete : null,
-                    isDangerous: true,
-                  ),
-                ],
+    return MouseRegion(
+      onEnter: (_) => onHoverChanged(true),
+      onExit: (_) => onHoverChanged(false),
+      child: SizedBox(
+        key: const ValueKey('plan-actions-menu'),
+        width: _PlanMoreButtonState._menuWidth,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            CustomPaint(
+              key: const ValueKey('plan-actions-menu-panel'),
+              painter: const _PlanMenuSurfacePainter(),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(10, 23, 10, 10),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _PlanMenuActionItem(
+                      actionKey: const ValueKey('plan-menu-action-transfer'),
+                      label: '导入导出',
+                      icon: LucideIcons.import,
+                      onPressed: onExport,
+                    ),
+                    const SizedBox(height: 6),
+                    _PlanMenuActionItem(
+                      actionKey: const ValueKey('plan-menu-action-copy'),
+                      label: '复制计划',
+                      icon: LucideIcons.copy,
+                      onPressed: onDuplicate,
+                    ),
+                    Divider(height: 17, color: AppColors.border),
+                    _PlanMenuActionItem(
+                      actionKey: const ValueKey('plan-menu-action-delete'),
+                      label: '删除计划',
+                      icon: LucideIcons.trash2,
+                      onPressed: canDelete ? onDelete : null,
+                      isDangerous: true,
+                    ),
+                  ],
+                ),
               ),
             ),
-          ),
-          const Positioned(
-            top: 0,
-            right: 8,
-            child: SizedBox(
-              key: ValueKey('plan-actions-menu-pointer'),
-              width: 22,
-              height: 13,
+            const Positioned(
+              top: 0,
+              right: 8,
+              child: SizedBox(
+                key: ValueKey('plan-actions-menu-pointer'),
+                width: 22,
+                height: 13,
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -1044,9 +1067,18 @@ class _PlanActionButton extends StatelessWidget {
             clipBehavior: Clip.antiAlias,
             child: InkWell(
               onTap: onPressed,
+              borderRadius: BorderRadius.circular(8),
               hoverColor: AppColors.surfaceMuted,
               highlightColor: AppColors.surfaceMuted,
               splashColor: AppColors.accent.withValues(alpha: 0.08),
+              focusColor: Colors.transparent,
+              overlayColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.hovered) ||
+                    states.contains(WidgetState.pressed)) {
+                  return AppColors.surfaceMuted;
+                }
+                return Colors.transparent;
+              }),
               child: Center(
                 child: Icon(
                   icon,

--- a/lib/plan/plan_screen.dart
+++ b/lib/plan/plan_screen.dart
@@ -2037,10 +2037,10 @@ class _PlanPointTile extends StatelessWidget {
                     children: [
                       const Center(child: Icon(LucideIcons.camera)),
                       if (recordCount > 0)
-                        const Positioned(
+                        Positioned(
                           top: -5,
                           right: -5,
-                          child: _PointRecordBadge(),
+                          child: _PointRecordBadge(stacked: recordCount > 1),
                         ),
                     ],
                   ),
@@ -2112,7 +2112,9 @@ class _PlanPointThumbnail extends StatelessWidget {
 }
 
 class _PointRecordBadge extends StatelessWidget {
-  const _PointRecordBadge();
+  const _PointRecordBadge({required this.stacked});
+
+  final bool stacked;
 
   @override
   Widget build(BuildContext context) {
@@ -2133,7 +2135,11 @@ class _PointRecordBadge extends StatelessWidget {
           ),
         ],
       ),
-      child: Icon(LucideIcons.images, size: 10, color: AppColors.accentDark),
+      child: Icon(
+        stacked ? LucideIcons.images : LucideIcons.image,
+        size: 10,
+        color: AppColors.accentDark,
+      ),
     );
   }
 }

--- a/lib/point_detail/point_detail_sheet.dart
+++ b/lib/point_detail/point_detail_sheet.dart
@@ -18,6 +18,7 @@ import '../widgets/copyable_text.dart';
 import '../widgets/confirm_action_dialog.dart';
 import '../widgets/image_viewer_screen.dart';
 import '../widgets/responsive_button.dart';
+import '../widgets/split_navigation_button.dart';
 import '../plan/reference_image_status.dart';
 import '../widgets/reference_thumbnail_stub.dart'
     if (dart.library.io) '../widgets/reference_thumbnail_io.dart';
@@ -170,6 +171,19 @@ class PointDetailSheet extends StatelessWidget {
     navigator.pop();
   }
 
+  Future<void> _openExternalNavigation(BuildContext context) async {
+    if (!point.hasCoordinate) {
+      return;
+    }
+    final opened = await navigationLauncher.openWalking(point, navigationApp);
+    if (!opened && context.mounted) {
+      ScaffoldMessenger.of(context).showStatusSnack(
+        kind: AppStatusBannerKind.error,
+        title: '无法打开${navigationApp.label}。',
+      );
+    }
+  }
+
   Future<void> _openInAppNavigation(BuildContext context) async {
     if (!point.hasCoordinate) {
       return;
@@ -265,17 +279,28 @@ class PointDetailSheet extends StatelessWidget {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Row(
-                            children: [
-                              _StatusBadge(status: status),
-                              const Spacer(),
-                              if (onDelete != null)
-                                _DeletePointButton(
-                                  key: ValueKey(point.id),
-                                  point: point,
-                                  onDelete: onDelete!,
+                          IntrinsicHeight(
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                _StatusBadge(
+                                  key: const ValueKey(
+                                    'point-detail-status-badge',
+                                  ),
+                                  status: status,
                                 ),
-                            ],
+                                const Expanded(child: SizedBox.shrink()),
+                                if (onDelete != null)
+                                  AspectRatio(
+                                    aspectRatio: 1,
+                                    child: _DeletePointButton(
+                                      key: ValueKey(point.id),
+                                      point: point,
+                                      onDelete: onDelete!,
+                                    ),
+                                  ),
+                              ],
+                            ),
                           ),
                           const SizedBox(height: 8),
                           CopyableText(
@@ -391,8 +416,11 @@ class PointDetailSheet extends StatelessWidget {
                 _PointDetailActions(
                   scope: actionScope,
                   status: status,
-                  onOpenNavigation: point.hasCoordinate
+                  onOpenInAppNavigation: point.hasCoordinate
                       ? () => _openInAppNavigation(context)
+                      : null,
+                  onOpenExternalNavigation: point.hasCoordinate
+                      ? () => _openExternalNavigation(context)
                       : null,
                   onOpenCamera: onOpenCamera == null
                       ? null
@@ -563,17 +591,15 @@ class _DeletePointButtonState extends State<_DeletePointButton> {
           key: const ValueKey('point-detail-delete'),
           onPressed: _busy || _deleted ? null : _deletePoint,
           style: IconButton.styleFrom(
-            fixedSize: const Size(44, 44),
-            minimumSize: const Size(44, 44),
-            maximumSize: const Size(44, 44),
             padding: EdgeInsets.zero,
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
             visualDensity: VisualDensity.compact,
             foregroundColor: AppColors.error,
+            minimumSize: Size.zero,
           ),
-          constraints: const BoxConstraints.tightFor(width: 44, height: 44),
+          constraints: const BoxConstraints.expand(),
           padding: EdgeInsets.zero,
-          icon: const Icon(LucideIcons.trash2, size: 18),
+          icon: const Icon(LucideIcons.trash2, size: 16),
         ),
       ),
     );
@@ -584,7 +610,8 @@ class _PointDetailActions extends StatelessWidget {
   const _PointDetailActions({
     required this.scope,
     required this.status,
-    required this.onOpenNavigation,
+    required this.onOpenInAppNavigation,
+    required this.onOpenExternalNavigation,
     required this.onOpenCamera,
     required this.onSetCurrent,
     required this.statusAction,
@@ -593,7 +620,8 @@ class _PointDetailActions extends StatelessWidget {
 
   final PointDetailActionScope scope;
   final VisitStatus status;
-  final VoidCallback? onOpenNavigation;
+  final VoidCallback? onOpenInAppNavigation;
+  final VoidCallback? onOpenExternalNavigation;
   final VoidCallback? onOpenCamera;
   final VoidCallback? onSetCurrent;
   final _PointStatusAction? statusAction;
@@ -601,19 +629,27 @@ class _PointDetailActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final canNavigate =
+        onOpenInAppNavigation != null || onOpenExternalNavigation != null;
+    final actionHeight =
+        44 + Theme.of(context).visualDensity.baseSizeAdjustment.dy;
+    final actionStyle = OutlinedButton.styleFrom(
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
     final primaryActions = <Widget>[
-      FilledButton(
-        key: const ValueKey('point-detail-in-app-navigation-button'),
-        onPressed: onOpenNavigation,
-        child: ResponsiveButtonContent(
-          icon: LucideIcons.navigation,
-          label: onOpenNavigation == null ? '坐标待补充' : '导航',
-          semanticLabel: '应用内导航',
-        ),
+      SplitNavigationButton(
+        inAppLabel: canNavigate ? '导航' : '坐标待补充',
+        onOpenInAppNavigation: onOpenInAppNavigation,
+        onOpenExternalNavigation: onOpenExternalNavigation,
+        height: actionHeight,
+        inAppKey: const ValueKey('point-detail-in-app-navigation-button'),
+        externalKey: const ValueKey('point-detail-external-navigation-button'),
+        dividerKey: const ValueKey('point-detail-navigation-button-divider'),
       ),
       if (scope == PointDetailActionScope.visit && onOpenCamera != null) ...[
         OutlinedButton(
           onPressed: onOpenCamera,
+          style: actionStyle,
           child: const ResponsiveButtonContent(
             icon: LucideIcons.camera,
             label: '拍摄参考',
@@ -628,6 +664,7 @@ class _PointDetailActions extends StatelessWidget {
       if (scope != PointDetailActionScope.assign && onSetCurrent != null)
         OutlinedButton(
           onPressed: status == VisitStatus.current ? null : onSetCurrent,
+          style: actionStyle,
           child: const ResponsiveButtonContent(
             icon: LucideIcons.flag,
             label: '设为当前',
@@ -641,6 +678,7 @@ class _PointDetailActions extends StatelessWidget {
             Navigator.of(context).pop();
             statusAction!.onTap();
           },
+          style: actionStyle,
           child: ResponsiveButtonContent(
             icon: statusAction!.icon,
             label: statusAction!.label,
@@ -664,6 +702,7 @@ class _PointDetailActions extends StatelessWidget {
             child: OutlinedButton.icon(
               key: const ValueKey('point-detail-edit'),
               onPressed: onEditPoint,
+              style: actionStyle,
               icon: const Icon(LucideIcons.edit, size: 18),
               label: const Text('编辑点位'),
             ),
@@ -847,7 +886,7 @@ class _GroupInfoRow extends StatelessWidget {
 }
 
 class _StatusBadge extends StatelessWidget {
-  const _StatusBadge({required this.status});
+  const _StatusBadge({required this.status, super.key});
 
   final VisitStatus status;
 
@@ -991,7 +1030,13 @@ class _PointRecordsPreview extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        Expanded(child: VisitRecordPhoto(path: photoPath)),
+                        Expanded(
+                          child: ClipRRect(
+                            key: const ValueKey('point-record-preview-photo'),
+                            borderRadius: BorderRadius.circular(8),
+                            child: VisitRecordPhoto(path: photoPath),
+                          ),
+                        ),
                         const SizedBox(height: 4),
                         Text(
                           _formatRecordTime(record.capturedAt),

--- a/lib/settings/settings_screen.dart
+++ b/lib/settings/settings_screen.dart
@@ -733,52 +733,58 @@ class _AppearanceSettingsPageState extends State<_AppearanceSettingsPage> {
           ),
           const SizedBox(height: 14),
           _AppearancePanel(
-            child: Material(
-              color: Colors.transparent,
-              child: SwitchListTile(
-                key: const ValueKey('plan-group-progress-toggle'),
-                contentPadding: EdgeInsets.zero,
-                secondary: Icon(
-                  LucideIcons.moveHorizontal,
-                  color: AppColors.textSecondary,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('个性化功能配置', style: _cardTitleTextStyle),
+                const SizedBox(height: 4),
+                Material(
+                  color: Colors.transparent,
+                  child: SwitchListTile(
+                    key: const ValueKey('plan-group-progress-toggle'),
+                    contentPadding: EdgeInsets.zero,
+                    secondary: Icon(
+                      LucideIcons.moveHorizontal,
+                      color: AppColors.textSecondary,
+                    ),
+                    title: Text('显示片区进度条', style: _titleTextStyle),
+                    subtitle: Text(
+                      '在片区选择弹窗中显示未完成片区的进度背景；完成后仅显示对勾。',
+                      style: _secondaryTextStyle,
+                    ),
+                    value: settings.showPlanGroupProgress,
+                    onChanged: (value) {
+                      _update(settings.copyWith(showPlanGroupProgress: value));
+                    },
+                  ),
                 ),
-                title: Text('显示片区进度条', style: _titleTextStyle),
-                subtitle: Text(
-                  '在片区选择弹窗中显示未完成片区的进度背景；完成后仅显示对勾。',
-                  style: _secondaryTextStyle,
+                Material(
+                  color: Colors.transparent,
+                  child: SwitchListTile(
+                    key: const ValueKey(
+                      'dismiss-plan-actions-on-outside-tap-toggle',
+                    ),
+                    contentPadding: EdgeInsets.zero,
+                    secondary: Icon(
+                      LucideIcons.pointer,
+                      color: AppColors.textSecondary,
+                    ),
+                    title: Text('点击空白收回计划操作', style: _titleTextStyle),
+                    subtitle: Text(
+                      '展开计划操作后，点击面板外的空白区域自动收回',
+                      style: _secondaryTextStyle,
+                    ),
+                    value: settings.dismissPlanActionsOnOutsideTap,
+                    onChanged: (value) {
+                      _update(
+                        settings.copyWith(
+                          dismissPlanActionsOnOutsideTap: value,
+                        ),
+                      );
+                    },
+                  ),
                 ),
-                value: settings.showPlanGroupProgress,
-                onChanged: (value) {
-                  _update(settings.copyWith(showPlanGroupProgress: value));
-                },
-              ),
-            ),
-          ),
-          const SizedBox(height: 14),
-          _AppearancePanel(
-            child: Material(
-              color: Colors.transparent,
-              child: SwitchListTile(
-                key: const ValueKey(
-                  'dismiss-plan-actions-on-outside-tap-toggle',
-                ),
-                contentPadding: EdgeInsets.zero,
-                secondary: Icon(
-                  LucideIcons.pointer,
-                  color: AppColors.textSecondary,
-                ),
-                title: Text('点击空白收回计划操作', style: _titleTextStyle),
-                subtitle: Text(
-                  '展开计划操作后，点击面板外的空白区域自动收回',
-                  style: _secondaryTextStyle,
-                ),
-                value: settings.dismissPlanActionsOnOutsideTap,
-                onChanged: (value) {
-                  _update(
-                    settings.copyWith(dismissPlanActionsOnOutsideTap: value),
-                  );
-                },
-              ),
+              ],
             ),
           ),
         ],
@@ -1828,8 +1834,11 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
         ),
         const SizedBox(height: 12),
         _SettingsSection(
-          title: 'Anitabi 服务地址',
+          title: '',
+          showTitle: false,
           children: [
+            const _SettingsSubheading(title: 'Anitabi 服务地址'),
+            const SizedBox(height: 8),
             _AnitabiServiceEntryRow(
               key: const ValueKey('anitabi-service-settings-entry'),
               siteUrl: settings.anitabiSiteBaseUrl,
@@ -1846,13 +1855,19 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
             ),
             const SizedBox(height: 10),
             Text('服务域名变化时可单独调整，不会改写计划中的标准图片链接。', style: _secondaryTextStyle),
-          ],
-        ),
-        const SizedBox(height: 12),
-        _SettingsSection(
-          title:
+            const SizedBox(height: 20),
+            Divider(height: 1, thickness: 1, color: AppColors.surfaceMuted),
+            const SizedBox(height: 18),
+            Text(
               'Anitabi 图片源 ${_anitabiImageSourceLabel(settings.anitabiImageSource)}',
-          children: [
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurface,
+                fontSize: 15,
+                fontWeight: FontWeight.w900,
+                letterSpacing: 0,
+              ),
+            ),
+            const SizedBox(height: 12),
             _AnitabiImageSourceGrid(
               selectedSource: settings.anitabiImageSource,
               onSelected: (source) {
@@ -1863,6 +1878,22 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
             Text(
               _anitabiImageSourceDescription(settings),
               style: _secondaryTextStyle,
+            ),
+            const SizedBox(height: 20),
+            Divider(height: 1, thickness: 1, color: AppColors.surfaceMuted),
+            const SizedBox(height: 18),
+            _NumberStepperSetting(
+              icon: LucideIcons.cloudDownload,
+              title: '图片同时请求数',
+              subtitle: '用于地图缩略图显示、导入点位时缓存缩略图，以及批量缓存参考图。数值越大速度可能越快，但网络压力也更高。',
+              value: settings.mapThumbnailConcurrentLoads,
+              min: 1,
+              max: 30,
+              step: 1,
+              valueLabel: '${settings.mapThumbnailConcurrentLoads} 个',
+              onChanged: (value) {
+                _update(settings.copyWith(mapThumbnailConcurrentLoads: value));
+              },
             ),
           ],
         ),
@@ -1940,25 +1971,6 @@ class _DataSourceSettingsPageState extends State<_DataSourceSettingsPage> {
             Text('仅发送路线坐标，不会上传计划、作品或照片信息。', style: _secondaryTextStyle),
           ],
         ),
-        const SizedBox(height: 12),
-        _SettingsSection(
-          title: '图片加载',
-          children: [
-            _NumberStepperSetting(
-              icon: LucideIcons.cloudDownload,
-              title: '图片同时请求数',
-              subtitle: '用于地图缩略图显示、导入点位时缓存缩略图，以及批量缓存参考图。数值越大速度可能越快，但网络压力也更高。',
-              value: settings.mapThumbnailConcurrentLoads,
-              min: 1,
-              max: 30,
-              step: 1,
-              valueLabel: '${settings.mapThumbnailConcurrentLoads} 个',
-              onChanged: (value) {
-                _update(settings.copyWith(mapThumbnailConcurrentLoads: value));
-              },
-            ),
-          ],
-        ),
       ],
     );
   }
@@ -2020,6 +2032,7 @@ class _MapDisplaySettingsPageState extends State<_MapDisplaySettingsPage> {
             ),
           ],
         ),
+        const SizedBox(height: 12),
         _SettingsSection(
           title: '地图缩放',
           children: [
@@ -3036,28 +3049,30 @@ class _SettingsSection extends StatelessWidget {
 }
 
 class _SettingsSubheading extends StatelessWidget {
-  const _SettingsSubheading({required this.icon, required this.title});
+  const _SettingsSubheading({this.icon, required this.title});
 
-  final IconData icon;
+  final IconData? icon;
   final String title;
 
   @override
   Widget build(BuildContext context) {
+    final titleText = Text(
+      title,
+      style: TextStyle(
+        color: AppColors.textPrimary,
+        fontSize: 14,
+        fontWeight: FontWeight.w900,
+        letterSpacing: 0,
+      ),
+    );
+    if (icon == null) {
+      return titleText;
+    }
     return Row(
       children: [
         Icon(icon, size: 18, color: AppColors.textSecondary),
         const SizedBox(width: 8),
-        Expanded(
-          child: Text(
-            title,
-            style: TextStyle(
-              color: AppColors.textPrimary,
-              fontSize: 14,
-              fontWeight: FontWeight.w900,
-              letterSpacing: 0,
-            ),
-          ),
-        ),
+        Expanded(child: titleText),
       ],
     );
   }

--- a/lib/widgets/split_navigation_button.dart
+++ b/lib/widgets/split_navigation_button.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:lucide_icons_flutter/lucide_icons.dart';
+
+class SplitNavigationButton extends StatelessWidget {
+  const SplitNavigationButton({
+    required this.inAppLabel,
+    required this.onOpenInAppNavigation,
+    required this.onOpenExternalNavigation,
+    this.height = 44,
+    this.walkIconSize = 24,
+    this.inAppKey = const ValueKey('map-in-app-navigation-button'),
+    this.externalKey = const ValueKey('map-external-navigation-button'),
+    this.dividerKey = const ValueKey('map-navigation-button-divider'),
+    super.key,
+  });
+
+  final String inAppLabel;
+  final VoidCallback? onOpenInAppNavigation;
+  final VoidCallback? onOpenExternalNavigation;
+  final double height;
+  final double walkIconSize;
+  final Key inAppKey;
+  final Key externalKey;
+  final Key dividerKey;
+
+  static final _overlayColor = WidgetStateProperty.resolveWith<Color?>((
+    states,
+  ) {
+    if (states.contains(WidgetState.pressed)) {
+      return Colors.white.withValues(alpha: 0.18);
+    }
+    if (states.contains(WidgetState.hovered)) {
+      return Colors.white.withValues(alpha: 0.1);
+    }
+    return Colors.transparent;
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final enabled =
+        onOpenInAppNavigation != null || onOpenExternalNavigation != null;
+    final foregroundColor = enabled
+        ? colorScheme.onPrimary
+        : colorScheme.onSurface.withValues(alpha: 0.38);
+    final backgroundColor = enabled
+        ? colorScheme.primary
+        : colorScheme.onSurface.withValues(alpha: 0.12);
+
+    return Material(
+      color: backgroundColor,
+      elevation: 0,
+      shadowColor: Colors.transparent,
+      surfaceTintColor: Colors.transparent,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      clipBehavior: Clip.antiAlias,
+      child: SizedBox(
+        height: height,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: _SplitNavHalf(
+                buttonKey: inAppKey,
+                enabled: onOpenInAppNavigation != null,
+                label: '应用内导航：$inAppLabel',
+                onTap: onOpenInAppNavigation,
+                iconColor: foregroundColor,
+                child: Icon(Icons.directions_walk, size: walkIconSize),
+              ),
+            ),
+            Center(
+              child: Container(
+                key: dividerKey,
+                width: 1,
+                height: (height - 16).clamp(12, 28),
+                color: foregroundColor.withValues(alpha: 0.38),
+              ),
+            ),
+            Expanded(
+              child: _SplitNavHalf(
+                buttonKey: externalKey,
+                enabled: onOpenExternalNavigation != null,
+                label: '打开外部地图',
+                onTap: onOpenExternalNavigation,
+                iconColor: foregroundColor,
+                child: Icon(LucideIcons.navigation, size: 21),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SplitNavHalf extends StatelessWidget {
+  const _SplitNavHalf({
+    required this.buttonKey,
+    required this.enabled,
+    required this.label,
+    required this.onTap,
+    required this.iconColor,
+    required this.child,
+  });
+
+  final Key buttonKey;
+  final bool enabled;
+  final String label;
+  final VoidCallback? onTap;
+  final Color iconColor;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      enabled: enabled,
+      label: label,
+      child: Tooltip(
+        message: label,
+        excludeFromSemantics: true,
+        child: Material(
+          type: MaterialType.transparency,
+          child: InkWell(
+            key: buttonKey,
+            onTap: onTap,
+            overlayColor: SplitNavigationButton._overlayColor,
+            focusColor: Colors.transparent,
+            hoverColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            splashColor: Colors.transparent,
+            child: Center(
+              child: IconTheme(
+                data: IconThemeData(color: iconColor),
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/in_app_navigation_screen_test.dart
+++ b/test/in_app_navigation_screen_test.dart
@@ -257,7 +257,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('结束路线'), findsOneWidget);
-    expect(find.text('已到达'), findsNothing);
+    expect(find.text('已到达'), findsOneWidget);
     expect(find.text('全部点位'), findsOneWidget);
     expect(find.text('到达'), findsOneWidget);
     expect(find.text('小时'), findsOneWidget);
@@ -293,6 +293,31 @@ void main() {
       find.byKey(const ValueKey('in-app-navigation-screen')),
       findsNothing,
     );
+  });
+
+  testWidgets('expanded sheet can mark arrival manually', (tester) async {
+    const lastPoint = PilgrimagePoint(
+      id: 'point-2',
+      work: work,
+      name: '京阪宇治站前',
+      subtitle: '京阪宇治駅前',
+      position: LatLng(34.8942, 135.8069),
+      episodeLabel: 'EP 5',
+      referenceLabel: '手动',
+    );
+    await pumpScreen(tester, stops: const [point, lastPoint]);
+
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-expand')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('in-app-navigation-arrive')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('in-app-navigation-arrival-sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('打开相机'), findsOneWidget);
+    expect(find.text('前往下一点'), findsOneWidget);
   });
 
   testWidgets('trip summary stays visible after collapsing the panel', (

--- a/test/photo_location_choice_sheet_test.dart
+++ b/test/photo_location_choice_sheet_test.dart
@@ -6,7 +6,7 @@ import 'package:miriago/plan/pilgrimage_models.dart';
 
 void main() {
   testWidgets(
-    'photo location sheet strengthens copy and highlights recommend',
+    'photo location sheet keeps recommend badge without preselecting',
     (tester) async {
       PhotoLocationStrategy? selected;
       await tester.pumpWidget(
@@ -51,7 +51,7 @@ void main() {
             )
             .first,
       );
-      expect(confirmTile.color, AppColors.accent.withValues(alpha: 0.08));
+      expect(confirmTile.color, AppColors.surface);
 
       await tester.tap(
         find.byKey(const ValueKey('photo-location-choice-recent')),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter/services.dart';
@@ -184,6 +185,20 @@ void main() {
         matching: find.text('2'),
       ),
       findsNothing,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-point-shot-badge')),
+        matching: find.byIcon(LucideIcons.images),
+      ),
+      findsWidgets,
+    );
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('plan-point-shot-badge')),
+        matching: find.byIcon(LucideIcons.image),
+      ),
+      findsWidgets,
     );
     final planTitle = tester.widget<Text>(
       find.descendant(of: find.byType(AppBar), matching: find.text('示例计划')),
@@ -756,11 +771,13 @@ void main() {
       tester
           .getSize(find.byKey(const ValueKey('box-assign-group-picker-button')))
           .height,
-      44,
+      tester
+          .getSize(find.byKey(const ValueKey('box-assign-toggle-button')))
+          .height,
     );
     expect(
       tester.getSize(find.byKey(const ValueKey('box-assign-toggle-button'))),
-      const Size(112, 44),
+      const Size(112, AppButtonStyles.compactHeight),
     );
     expect(
       tester.getSize(find.byKey(const ValueKey('box-assign-submit-button'))),
@@ -852,6 +869,72 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('box-assign-toggle-button')));
     await tester.pumpAndSettle();
     expect(tester.getSize(find.text('结束框选')).height, lessThanOrEqualTo(20));
+  });
+
+  testWidgets('box assign point card uses selection status labels', (
+    tester,
+  ) async {
+    final repository = SamplePilgrimageRepository();
+    final plan = await repository.loadActivePlan();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: BoxGroupAssignScreen(
+          plan: plan,
+          repository: repository,
+          settings: const AppSettings(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    tester
+        .widget<IconButton>(
+          find.widgetWithIcon(IconButton, LucideIcons.mapPin),
+        )
+        .onPressed!();
+    await tester.pumpAndSettle();
+    expect(find.text('宇治上神社参道'), findsWidgets);
+    expect(find.text('未框选'), findsOneWidget);
+    expect(find.text('超出最大距离'), findsNothing);
+    expect(find.text('在最大距离范围内'), findsNothing);
+  });
+
+  testWidgets('nearest assign keeps distance status and puts assign beside slider', (
+    tester,
+  ) async {
+    final repository = SamplePilgrimageRepository();
+    final plan = await repository.loadActivePlan();
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.light(),
+        home: NearestGroupAssignScreen(
+          plan: plan,
+          repository: repository,
+          settings: const AppSettings(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final sliderRect = tester.getRect(find.byType(Slider));
+    final assignRect = tester.getRect(find.widgetWithText(FilledButton, '分配'));
+    expect(assignRect.left, greaterThan(sliderRect.center.dx));
+    expect(assignRect.top, closeTo(sliderRect.center.dy - assignRect.height / 2, 8));
+
+    tester
+        .widget<IconButton>(
+          find.widgetWithIcon(IconButton, LucideIcons.mapPin),
+        )
+        .onPressed!();
+    await tester.pumpAndSettle();
+    expect(find.text('未框选'), findsNothing);
+    expect(find.text('已框选'), findsNothing);
+    expect(
+      find.text('超出最大距离').evaluate().isNotEmpty ||
+          find.text('在最大距离范围内').evaluate().isNotEmpty,
+      isTrue,
+    );
   });
 
   testWidgets('app shell uses the Lucide bottom navigation icons', (
@@ -1624,10 +1707,24 @@ void main() {
     expect(find.text('当前目标'), findsWidgets);
     expect(find.text('坐标'), findsOneWidget);
     expect(find.text('来源'), findsOneWidget);
-    expect(find.text('导航'), findsOneWidget);
+    expect(find.byIcon(Icons.directions_walk), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('point-detail-external-navigation-button')),
+      findsOneWidget,
+    );
     expect(find.text('拍摄参考'), findsWidgets);
     expect(find.text('标记完成'), findsWidgets);
     expect(find.text('编辑点位'), findsOneWidget);
+    expect(find.text('本点记录 2'), findsOneWidget);
+    expect(find.text('06/01 09:26'), findsOneWidget);
+    expect(
+      tester
+          .widget<ClipRRect>(
+            find.byKey(const ValueKey('point-record-preview-photo')).first,
+          )
+          .borderRadius,
+      BorderRadius.circular(8),
+    );
   });
 
   testWidgets('plan point detail uses the region picker with create action', (
@@ -1822,16 +1919,21 @@ void main() {
     await tester.pumpAndSettle();
 
     final deleteButton = find.byKey(const ValueKey('point-detail-delete'));
+    final statusBadge = find.byKey(const ValueKey('point-detail-status-badge'));
     expect(deleteButton, findsOneWidget);
-    expect(tester.getSize(deleteButton), const Size(44, 44));
+    expect(statusBadge, findsOneWidget);
     expect(
-      tester
-          .widget<Icon>(
-            find.descendant(of: deleteButton, matching: find.byType(Icon)),
-          )
-          .size,
-      18,
+      tester.getSize(deleteButton).height,
+      tester.getSize(statusBadge).height,
     );
+    expect(
+      tester.getSize(deleteButton).width,
+      tester.getSize(deleteButton).height,
+    );
+    final deleteIcon = tester.widget<Icon>(
+      find.descendant(of: deleteButton, matching: find.byType(Icon)),
+    );
+    expect(deleteIcon.size, lessThanOrEqualTo(tester.getSize(deleteButton).height));
     expect(
       tester.getCenter(find.text('待访问')).dy,
       closeTo(tester.getCenter(deleteButton).dy, 0.1),
@@ -1933,6 +2035,13 @@ void main() {
       findsOneWidget,
     );
     expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('map-point-shot-badge')),
+        matching: find.byIcon(LucideIcons.images),
+      ),
+      findsOneWidget,
+    );
+    expect(
       tester
           .widgetList<PolygonLayer>(find.byType(PolygonLayer))
           .any((layer) => layer.simplificationTolerance == 0),
@@ -1963,7 +2072,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(LucideIcons.info), findsNothing);
-      expect(find.byIcon(LucideIcons.footprints), findsOneWidget);
+      expect(find.byIcon(Icons.directions_walk), findsOneWidget);
+      expect(tester.widget<Icon>(find.byIcon(Icons.directions_walk)).size, 24);
       expect(find.byIcon(LucideIcons.navigation), findsOneWidget);
       expect(
         find.byKey(const ValueKey('map-navigation-button-divider')),
@@ -2018,6 +2128,8 @@ void main() {
         expect(navigation.height, closeTo(44, 0.1));
         expect(camera.height, closeTo(navigation.height, 0.1));
         expect(complete.height, closeTo(navigation.height, 0.1));
+        expect(camera.top, closeTo(navigation.top, 0.1));
+        expect(complete.top, closeTo(navigation.top, 0.1));
         expect(camera.width, closeTo(52, 0.1));
         expect(complete.width, closeTo(52, 0.1));
         expect(navigation.width, greaterThanOrEqualTo(44));
@@ -2074,10 +2186,31 @@ void main() {
 
     await tester.tap(find.text('井用机前步行道').first);
     await tester.pumpAndSettle();
-    final navigationButton = tester.widget<FilledButton>(
+    final navigationButton = tester.widget<InkWell>(
       find.byKey(const ValueKey('point-detail-in-app-navigation-button')),
     );
-    expect(navigationButton.onPressed, isNotNull);
+    final externalNavigationButton = tester.widget<InkWell>(
+      find.byKey(const ValueKey('point-detail-external-navigation-button')),
+    );
+    expect(navigationButton.onTap, isNotNull);
+    expect(externalNavigationButton.onTap, isNotNull);
+    final sheet = find.byType(PointDetailSheet);
+    final navigationRect = tester.getRect(
+      find.descendant(
+        of: sheet,
+        matching: find.byKey(
+          const ValueKey('point-detail-in-app-navigation-button'),
+        ),
+      ),
+    );
+    final cameraRect = tester.getRect(
+      find.descendant(
+        of: sheet,
+        matching: find.widgetWithText(OutlinedButton, '拍摄参考'),
+      ),
+    );
+    expect(navigationRect.height, closeTo(cameraRect.height, 0.1));
+    expect(cameraRect.top, closeTo(navigationRect.top, 0.1));
     expect(find.byType(PointDetailSheet), findsOneWidget);
   });
 
@@ -2100,7 +2233,7 @@ void main() {
 
     expect(find.text('坐标'), findsOneWidget);
     expect(find.text('来源'), findsOneWidget);
-    expect(find.text('导航'), findsOneWidget);
+    expect(find.byIcon(Icons.directions_walk), findsOneWidget);
   });
 
   testWidgets('shows plan manager', (tester) async {
@@ -2525,6 +2658,7 @@ void main() {
       scrollable: find.byType(Scrollable).last,
     );
     expect(find.text('显示片区进度条'), findsOneWidget);
+    expect(find.text('个性化功能配置'), findsOneWidget);
     final progressToggle = tester.widget<SwitchListTile>(
       find.byKey(const ValueKey('plan-group-progress-toggle')),
     );
@@ -2643,6 +2777,13 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.scrollUntilVisible(
+      find.text('图片同时请求数'),
+      280,
+      scrollable: find.byType(Scrollable).last,
+    );
+    expect(find.text('图片同时请求数'), findsOneWidget);
+
+    await tester.scrollUntilVisible(
       find.text('步行路径规划'),
       280,
       scrollable: find.byType(Scrollable).last,
@@ -2650,13 +2791,6 @@ void main() {
     expect(find.text('步行路径规划'), findsOneWidget);
     expect(find.text('https://valhalla1.openstreetmap.de'), findsOneWidget);
     expect(find.text('测试连接'), findsOneWidget);
-
-    await tester.scrollUntilVisible(
-      find.text('图片同时请求数'),
-      280,
-      scrollable: find.byType(Scrollable).last,
-    );
-    expect(find.text('图片同时请求数'), findsOneWidget);
     expect(find.text('地图标记大小'), findsNothing);
     expect(find.text('片区范围半径'), findsNothing);
     expect(find.text('自动聚合密集点位'), findsNothing);
@@ -3162,6 +3296,45 @@ void main() {
     await tester.tap(find.text('可切换').first);
     await tester.pumpAndSettle();
     expect(find.text('切换计划'), findsNothing);
+  });
+
+  testWidgets('plan more menu hover does not leave the card highlighted', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MiriaGoApp(repository: SamplePilgrimageRepository()),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('plan-switch-button')));
+    await tester.pumpAndSettle();
+
+    final planCard = find
+        .byWidgetPredicate(
+          (widget) =>
+              widget is Material &&
+              widget.key is ValueKey<String> &&
+              (widget.key! as ValueKey<String>).value.startsWith('plan-card-'),
+        )
+        .first;
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+
+    await gesture.moveTo(tester.getCenter(planCard));
+    await tester.pump();
+    await tester.tap(find.byTooltip('更多计划操作').first);
+    await tester.pumpAndSettle();
+    expect(find.text('导入导出'), findsOneWidget);
+    await gesture.moveTo(tester.getCenter(find.text('导入导出')));
+    await tester.pump();
+    await gesture.moveTo(const Offset(8, 8));
+    await tester.pump();
+
+    expect(tester.widget<Material>(planCard).color, AppColors.surface);
+    await tester.tap(find.byTooltip('更多计划操作').first);
+    await tester.pumpAndSettle();
+    expect(tester.widget<Material>(planCard).color, AppColors.surface);
   });
 
   testWidgets('work manager opens a compact delete menu', (tester) async {

--- a/web/index.html
+++ b/web/index.html
@@ -30,6 +30,12 @@
   <link rel="icon" type="image/png" href="favicon.png"/>
 
   <title>MiriaGo</title>
+  <style>
+    flt-semantics:focus,
+    .flt-semantics:focus {
+      outline: none;
+    }
+  </style>
   <script src="desktop_startup_monitor.js"></script>
   <script src="vendor/maplibre-gl/maplibre-gl.js"></script>
   <link href="vendor/maplibre-gl/maplibre-gl.css" rel="stylesheet"/>


### PR DESCRIPTION
## 主要修改
- 抽出共用的左右分栏导航按钮，地图点位卡和点位详情共用同一套交互；操作按钮强制齐高，去掉多余描边和焦点环。地图页脚印改为 `Icons.directions_walk`。
- 计划卡片打开菜单后不再残留灰底 hover；设置里把 Anitabi 服务/图片源/并发数收进同一面板，外观项归到「个性化功能配置」。
- 框选分配顶部带边框控件降低高度；点位卡片提示改为「未框选 / 已框选」，片区下拉与框选按钮齐高。最近分配的「分配」放到进度条右侧。
- 框选分配、最近分配选中点位后，底部信息卡左侧改为参考图，去掉「详情」按钮，点击整张卡片打开点位弹窗。
- 相机角标：1 条记录用单图图标，多条才叠图。点位详情记录缩略图四角圆角；删除按钮与前方状态 badge 等高，并收成正方形。

## 验证
- [ ] 地图点位卡：应用内步行图标是 `Icons.directions_walk`，高度与拍摄、完成、设为当前一致
- [ ] 点位详情：导航及相关按钮同一行高；删除按钮与「当前目标」badge 等高
- [ ] 计划列表：打开/关闭三点菜单后，卡片灰底会消失
- [ ] 设置 → 数据源：Anitabi 服务地址、图片源、图片同时请求数在同一块
- [ ] 设置 → 外观：「个性化功能配置」含片区进度条和「点击空白收回计划操作」
- [ ] 框选分配：顶部带边框控件比原来更矮；未选显示「未框选」，框进范围后显示「已框选」
- [ ] 框选分配 / 最近分配：选中点位后底部卡片左侧是参考图，没有「详情」按钮，点卡片会打开点位弹窗
- [ ] 最近分配：「分配」在进度条右侧，距离提示文案不变
- [ ] 本点仅 1 条记录时相机角标是单图，2 条及以上是叠图